### PR TITLE
[FEAT] Speeds choice for sparse learners by caching the covariance matrix 

### DIFF
--- a/bayesianbandits/_np_utils.py
+++ b/bayesianbandits/_np_utils.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+
 from functools import partial
 from typing import Any, Generator, Tuple, TypeVar
+
 import numpy as np
 from numpy.typing import NDArray
 


### PR DESCRIPTION
This cached property speeds up sampling (and therefore choice). The first pull for a bandit will be slow, but subsequent pulls will be very fast until `fit` or `partial_fit` is called, invalidating the cached property.

This additionally includes a fix that makes the first pull about 3x faster than it used to be, due to `factorized -> solve` being faster than `spsolve_triangular` for csc matrices. 

Fixes #58