### PR TITLE
Fix serialization issue by deleting cached covariance matrix

### DIFF
--- a/bayesianbandits/_estimators.py
+++ b/bayesianbandits/_estimators.py
@@ -534,6 +534,18 @@ class NormalRegressor(BaseEstimator, RegressorMixin):
         self.sparse = sparse
         self.random_state = random_state
 
+    def _delete_cached_properties(self):
+        try:
+            del self.cov_
+        except AttributeError:
+            pass
+
+    def __getstate__(self):
+        # Delete the cached covariance matrix, since it likely contains C
+        # objects that cannot be pickled
+        self._delete_cached_properties()
+        return super().__getstate__()
+
     def fit(self, X_fit: Union[NDArray[Any], csc_array], y: NDArray[Any]) -> Self:
         """
         Fit the model using X as training data and y as target values. y must be
@@ -549,9 +561,7 @@ class NormalRegressor(BaseEstimator, RegressorMixin):
         )
 
         self._initialize_prior(X_fit)
-
         self._fit_helper(X_fit, y)
-
         return self
 
     def _initialize_prior(self, X: Union[NDArray[Any], csc_array]) -> None:
@@ -643,8 +653,7 @@ class NormalRegressor(BaseEstimator, RegressorMixin):
 
         self.cov_inv_ = cov_inv
         # Delete the cached covariance matrix, since it is no longer valid
-        if hasattr(self, "cov_"):
-            del self.cov_
+        self._delete_cached_properties()
         self.coef_ = coef
 
     def partial_fit(self, X: Union[NDArray[Any], csc_array], y: NDArray[Any]):
@@ -742,8 +751,7 @@ class NormalRegressor(BaseEstimator, RegressorMixin):
 
         self.cov_inv_ = cov_inv
         # Delete the cached covariance matrix, since it is no longer valid
-        if hasattr(self, "cov_"):
-            del self.cov_
+        self._delete_cached_properties()
 
 
 class NormalInverseGammaRegressor(NormalRegressor):
@@ -867,6 +875,19 @@ class NormalInverseGammaRegressor(NormalRegressor):
         self.sparse = sparse
         self.random_state = random_state
 
+    def _delete_cached_properties(self):
+        try:
+            del self.shape_
+        except AttributeError:
+            pass
+        super()._delete_cached_properties()
+
+    def __getstate__(self):
+        # Delete the cached covariance matrix, since it likely contains C
+        # objects that cannot be pickled
+        self._delete_cached_properties()
+        return super().__getstate__()
+
     def _initialize_prior(self, X: Union[NDArray[Any], csc_array]) -> None:
         if isinstance(self.random_state, int) or self.random_state is None:
             self.random_state_ = np.random.default_rng(self.random_state)
@@ -980,10 +1001,7 @@ class NormalInverseGammaRegressor(NormalRegressor):
         # Posteriors become priors for the next batch
         self.cov_inv_ = V_n
         # Delete the cached shape_ property so it is recalculated
-        if hasattr(self, "shape_"):
-            del self.shape_
-        if hasattr(self, "cov_"):
-            del self.cov_
+        self._delete_cached_properties()
         self.coef_ = m_n
         self.a_ = a_n
         self.b_ = b_n
@@ -1074,10 +1092,7 @@ class NormalInverseGammaRegressor(NormalRegressor):
         b_n = prior_decay * self.b_
 
         self.cov_inv_ = V_n
-        if hasattr(self, "shape_"):
-            del self.shape_
-        if hasattr(self, "cov_"):
-            del self.cov_
+        self._delete_cached_properties()
         self.a_ = a_n
         self.b_ = b_n
 

--- a/bayesianbandits/_estimators.py
+++ b/bayesianbandits/_estimators.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from functools import cached_property, partial
-from typing import Any, Dict, Optional, Union, cast
+from functools import cached_property, partial, wraps
+from typing import Any, Callable, Dict, Optional, TypeVar, Union, cast
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -24,7 +24,7 @@ from sklearn.utils.validation import (
     check_is_fitted,
     check_X_y,  # type: ignore
 )
-from typing_extensions import Self
+from typing_extensions import ParamSpec, Self, Concatenate
 
 from ._np_utils import groupby_array
 from ._sparse_bayesian_linear_regression import (
@@ -36,6 +36,10 @@ from ._sparse_bayesian_linear_regression import (
 )
 
 use_solver(useUmfpack=False)
+
+Params = ParamSpec("Params")
+ReturnType = TypeVar("ReturnType")
+SelfType = TypeVar("SelfType", bound="NormalRegressor")
 
 
 class DirichletClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
@@ -434,6 +438,24 @@ class GammaRegressor(BaseEstimator, RegressorMixin):
             self.coef_[x.item()] *= decay_rate
 
 
+def _invalidate_cached_properties(
+    func: Callable[Concatenate[SelfType, Params], ReturnType]  # type: ignore
+) -> Callable[Concatenate[SelfType, Params], ReturnType]:
+    @wraps(func)
+    def wrapper(self, *args: Params.args, **kwargs: Params.kwargs) -> ReturnType:
+        try:
+            del self.shape_
+        except AttributeError:
+            pass
+        try:
+            del self.cov_
+        except AttributeError:
+            pass
+        return func(self, *args, **kwargs)
+
+    return wrapper
+
+
 class NormalRegressor(BaseEstimator, RegressorMixin):
     """
     A Bayesian linear regression model that assumes a Gaussian noise distribution.
@@ -534,16 +556,10 @@ class NormalRegressor(BaseEstimator, RegressorMixin):
         self.sparse = sparse
         self.random_state = random_state
 
-    def _delete_cached_properties(self):
-        try:
-            del self.cov_
-        except AttributeError:
-            pass
-
+    @_invalidate_cached_properties
     def __getstate__(self):
         # Delete the cached covariance matrix, since it likely contains C
         # objects that cannot be pickled
-        self._delete_cached_properties()
         return super().__getstate__()
 
     def fit(self, X_fit: Union[NDArray[Any], csc_array], y: NDArray[Any]) -> Self:
@@ -593,6 +609,7 @@ class NormalRegressor(BaseEstimator, RegressorMixin):
             )
         return Covariance.from_cholesky(cholesky(cov, lower=True))
 
+    @_invalidate_cached_properties
     def _fit_helper(self, X: Union[NDArray[Any], csc_array], y: NDArray[Any]):
         if self.sparse:
             X = csc_array(X)
@@ -652,8 +669,6 @@ class NormalRegressor(BaseEstimator, RegressorMixin):
             )
 
         self.cov_inv_ = cov_inv
-        # Delete the cached covariance matrix, since it is no longer valid
-        self._delete_cached_properties()
         self.coef_ = coef
 
     def partial_fit(self, X: Union[NDArray[Any], csc_array], y: NDArray[Any]):
@@ -726,6 +741,7 @@ class NormalRegressor(BaseEstimator, RegressorMixin):
 
         return np.atleast_2d(samples @ X_sample.T)  # type: ignore
 
+    @_invalidate_cached_properties
     def decay(
         self,
         X: Union[NDArray[Any], csc_array],
@@ -750,8 +766,6 @@ class NormalRegressor(BaseEstimator, RegressorMixin):
         cov_inv = prior_decay * self.cov_inv_
 
         self.cov_inv_ = cov_inv
-        # Delete the cached covariance matrix, since it is no longer valid
-        self._delete_cached_properties()
 
 
 class NormalInverseGammaRegressor(NormalRegressor):
@@ -875,17 +889,10 @@ class NormalInverseGammaRegressor(NormalRegressor):
         self.sparse = sparse
         self.random_state = random_state
 
-    def _delete_cached_properties(self):
-        try:
-            del self.shape_
-        except AttributeError:
-            pass
-        super()._delete_cached_properties()
-
+    @_invalidate_cached_properties
     def __getstate__(self):
         # Delete the cached covariance matrix, since it likely contains C
         # objects that cannot be pickled
-        self._delete_cached_properties()
         return super().__getstate__()
 
     def _initialize_prior(self, X: Union[NDArray[Any], csc_array]) -> None:
@@ -931,6 +938,7 @@ class NormalInverseGammaRegressor(NormalRegressor):
         self.a_ = self.a
         self.b_ = self.b
 
+    @_invalidate_cached_properties
     def _fit_helper(self, X: Union[NDArray[Any], csc_array], y: NDArray[Any]):
         if self.sparse:
             X = csc_array(X)
@@ -1000,8 +1008,6 @@ class NormalInverseGammaRegressor(NormalRegressor):
 
         # Posteriors become priors for the next batch
         self.cov_inv_ = V_n
-        # Delete the cached shape_ property so it is recalculated
-        self._delete_cached_properties()
         self.coef_ = m_n
         self.a_ = a_n
         self.b_ = b_n
@@ -1062,6 +1068,7 @@ class NormalInverseGammaRegressor(NormalRegressor):
 
         return np.atleast_2d(samples @ X_sample.T)  # type: ignore
 
+    @_invalidate_cached_properties
     def decay(
         self,
         X: Union[NDArray[Any], csc_array],
@@ -1086,13 +1093,10 @@ class NormalInverseGammaRegressor(NormalRegressor):
         # decay only increases the variance, so we only need to update the
         # inverse covariance matrix, a_, and b_
         V_n = prior_decay * self.cov_inv_
-
         a_n = prior_decay * self.a_
-
         b_n = prior_decay * self.b_
 
         self.cov_inv_ = V_n
-        self._delete_cached_properties()
         self.a_ = a_n
         self.b_ = b_n
 


### PR DESCRIPTION
These objects can't be pickled because they contain references to C objects, so we just have to delete them

Also unifies cache invalidation logic in general