### PR TITLE
[MAINT] Makes output dimensions of Dirichlet classifier's sample method more consistent

### DIFF
--- a/bayesianbandits/_estimators.py
+++ b/bayesianbandits/_estimators.py
@@ -111,7 +111,7 @@ class DirichletClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
     This classifier also implements `sample` to sample from the posterior,
     which can be useful for uncertainty estimation and Thompson sampling.
 
-    >>> clf.sample(X)
+    >>> clf.sample(X).squeeze()
     array([[0.52877785, 0.41235606, 0.05886609],
            [0.34152373, 0.28178422, 0.37669205],
            [0.70292861, 0.07890427, 0.21816712],
@@ -225,13 +225,11 @@ class DirichletClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
             self._initialize_prior()
 
         alphas = list(self.known_alphas_[x.item()] for x in X)
-        return np.squeeze(
-            np.stack(
-                list(
-                    dirichlet.rvs(alpha, size, self.random_state_)  # type: ignore
-                    for alpha in alphas
-                ),
-            )
+        return np.stack(
+            list(
+                dirichlet.rvs(alpha, size, self.random_state_)  # type: ignore
+                for alpha in alphas
+            ),
         )
 
     def decay(self, X: NDArray[Any], *, decay_rate: Optional[float] = None) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -80,7 +80,7 @@ def bandit_instance(
     if isinstance(learner_class, DirichletClassifier):
 
         def reward_func(x: NDArray[np.float_]) -> Union[NDArray[np.float_], np.float_]:
-            return np.take(x, 0, axis=-1)  # type: ignore
+            return x[..., 0].T
 
     else:
         reward_func = None  # type: ignore
@@ -109,6 +109,22 @@ class TestBandits:
             (token,) = bandit_instance.pull(np.array([[2.0]]))
 
         assert bandit_instance.arm_to_update.action_token == token
+
+    def test_batch_pull(
+        self,
+        bandit_instance: Union[
+            Agent[DecayingLearner, int], ContextualAgent[DecayingLearner, int]
+        ],
+    ) -> None:
+        if isinstance(bandit_instance, Agent):
+            pytest.skip("Batch pull is not supported for non-contextual bandits")
+
+        # if isinstance(bandit_instance.arm(0).learner, DirichletClassifier):
+        #     pytest.xfail("DirichletClassifier does not support batch pull")
+
+        (_, _, token3) = bandit_instance.pull(np.array([[2.0], [2.0], [2.0]]))
+
+        assert bandit_instance.arm_to_update.action_token == token3
 
     def test_update(
         self,

--- a/tests/test_basebandit.py
+++ b/tests/test_basebandit.py
@@ -76,7 +76,7 @@ def bandit_class(
     if isinstance(learner_class, DirichletClassifier):
 
         def reward_func(x: NDArray[np.float_]) -> Union[NDArray[np.float_], np.float_]:
-            return np.take(x, 0, axis=-1)  # type: ignore
+            return x[..., 0].T
 
     else:
         reward_func = None  # type: ignore

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -154,7 +154,7 @@ def test_dirichletclassifier_sample(
     clf.fit(X, y)
 
     assert_almost_equal(
-        clf.sample(X),
+        clf.sample(X).squeeze(),
         np.array(
             [
                 [0.47438369, 0.43488058, 0.09073572],
@@ -180,7 +180,7 @@ def test_dirichletclassifier_sample_no_fit(
     clf = DirichletClassifier(alphas={1: 1, 2: 1, 3: 1}, random_state=0)
 
     assert_almost_equal(
-        clf.sample(X),
+        clf.sample(X).squeeze(),
         np.array(
             [
                 [3.95461990e-01, 5.93018059e-01, 1.15199510e-02],


### PR DESCRIPTION
Remove np.squeeze call. Callers can squeeze as needed, but squeezing by default results in some unexpected behavior.