### PR TITLE
chore: update Documentation with python 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ While the API is still evolving, this library is already being used in productio
 
 ## Compatibility
 
-`bayesianbandits` is tested with Python 3.9, 3.10, 3.11, and 3.12 with `scikit-learn` 1.2.2, 1.3.2, 1.4.2, and 1.5.1.
+`bayesianbandits` is tested with Python 3.10, 3.11, 3.12 and 3.13 with `scikit-learn` 1.3.2, 1.4.2, and 1.5.2.
 
 ## Getting Started
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -2,7 +2,7 @@
 Installation
 ============
 
-Python 3.9+ is required.
+Python 3.10+ is required.
 
 Install with pip::
 


### PR DESCRIPTION
Update readme and documentation to include python version 3.10+ to 3.13 according to https://github.com/bayesianbandits/bayesianbandits/pull/114

I also dropped scikit-learn 1.2.2 because it is not in .github/workflows/matrix_test.yml anymore.