### PR TITLE
Add Pipeline class for better sklearn compatibility and allowing shared estimators across arms

### DIFF
--- a/.github/workflows/matrix_test.yml
+++ b/.github/workflows/matrix_test.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         sudo apt-get install -y swig libsuitesparse-dev
         python -m pip install --upgrade pip pytest
-        pip install scikit-learn==${{ matrix.sklearn-version }} scikit-sparse
+        pip install scikit-learn==${{ matrix.sklearn-version }} scikit-sparse pandas
 
     - name: Install bayesianbandits
       run: |

--- a/bayesianbandits/__init__.py
+++ b/bayesianbandits/__init__.py
@@ -40,6 +40,17 @@ policies of your bandit as your needs change.
     EXP3A
     Arm
 
+Pipeline
+========
+Pipeline enables the use of sklearn transformers with Bayesian learners,
+supporting the standard contextual bandit formulation where multiple arms
+share a single model.
+
+.. autosummary::
+    :toctree: _autosummary
+
+    Pipeline
+
 
 Estimators
 ==========
@@ -89,4 +100,5 @@ from .api import (
     ThompsonSampling,
     UpperConfidenceBound,
 )
+from .pipeline import Pipeline
 from .policies import EXP3A

--- a/bayesianbandits/_arm.py
+++ b/bayesianbandits/_arm.py
@@ -5,6 +5,7 @@ from typing import (
     Any,
     Callable,
     Generic,
+    Iterable,
     Optional,
     Protocol,
     TypeVar,
@@ -13,7 +14,6 @@ from typing import (
 
 import numpy as np
 from numpy.typing import NDArray
-from scipy.sparse import csc_array
 from typing_extensions import Concatenate, ParamSpec, Self
 
 P = ParamSpec("P")
@@ -26,13 +26,11 @@ RewardFunction = Union[
 TokenType = TypeVar("TokenType")
 X_contra = TypeVar("X_contra", contravariant=True)  # Contravariant for input types
 A = TypeVar("A", bound="Arm[Any, Any]")
-ContextType = TypeVar("ContextType", bound=csc_array | NDArray[np.float64])
+ContextType = TypeVar("ContextType", bound=Iterable[Any])
 
 
 class Learner(Protocol[X_contra]):
     """Protocol defining the learner interface with contravariant X type parameter."""
-
-    random_state: Union[np.random.Generator, int, None]
 
     def sample(self, X: X_contra, size: int = 1) -> NDArray[np.float64]: ...
     def partial_fit(
@@ -43,6 +41,10 @@ class Learner(Protocol[X_contra]):
     ) -> Self: ...
     def decay(self, X: X_contra, *, decay_rate: Optional[float] = None) -> None: ...
     def predict(self, X: X_contra) -> NDArray[np.float64]: ...
+    @property
+    def random_state(self) -> Union[np.random.Generator, int, None]: ...
+    @random_state.setter
+    def random_state(self, value: Union[np.random.Generator, int, None]) -> None: ...
 
 
 def requires_learner(

--- a/bayesianbandits/api.py
+++ b/bayesianbandits/api.py
@@ -313,11 +313,6 @@ class ContextualAgent(Generic[ContextType, TokenType]):
         y : NDArray[np.float64]
             Reward(s) to use for updating the arm.
         """
-        assert X.shape is not None, "X must be a 2D array."
-        if X.shape[0] != y.shape[0]:
-            raise ValueError(
-                "The number of rows in `X` must match the number of rows in `y`."
-            )
         self.policy.update(self.arm_to_update, X, y, self.arms, self.rng)
 
     def decay(

--- a/bayesianbandits/pipeline.py
+++ b/bayesianbandits/pipeline.py
@@ -1,0 +1,342 @@
+"""Pipeline implementation for Bayesian bandits.
+
+Enables sklearn transformers to work with Bayesian learners,
+supporting workflows with DataFrames, dicts, and other input types.
+"""
+
+from typing import Any, Generic, List, Optional, Tuple, Union
+
+import numpy as np
+from numpy.typing import NDArray
+from sklearn.pipeline import Pipeline as SklearnPipeline
+from typing_extensions import Self
+
+from ._arm import ContextType
+
+
+class Pipeline(Generic[ContextType]):
+    """Pipeline that bridges sklearn transformers with Bayesian learners.
+
+    Implements the Learner protocol, allowing arbitrary input types to be
+    transformed through sklearn transformers before reaching the final
+    Bayesian learner. This enables the standard contextual bandit formulation
+    where multiple arms share a single model with arm-specific features.
+
+    Parameters
+    ----------
+    steps : list of tuples
+        List of (name, transform/estimator) tuples. All steps except the
+        last must be sklearn transformers. The last step must be a
+        bayesianbandits learner (implementing partial_fit and sample).
+
+    Examples
+    --------
+    **Standard Contextual Bandit with Shared Model** (most common pattern):
+
+    >>> from functools import partial
+    >>> from sklearn.preprocessing import FunctionTransformer, StandardScaler
+    >>> from bayesianbandits import (
+    ...     Arm, ContextualAgent, ThompsonSampling, NormalRegressor, Pipeline
+    ... )
+    >>>
+    >>> # Single shared model for all arms (like LinUCB, Li et al. 2010)
+    >>> shared_model = NormalRegressor(alpha=1.0, beta=1.0)
+    >>>
+    >>> # Product catalog with features
+    >>> products = {
+    ...     'iPhone': {'price': 999, 'category': 'electronics', 'brand_tier': 3},
+    ...     'Shoes': {'price': 89, 'category': 'fashion', 'brand_tier': 2},
+    ...     'Book': {'price': 15, 'category': 'media', 'brand_tier': 1},
+    ... }
+    >>>
+    >>> # Create arms with product-specific features
+    >>> arms = []
+    >>> for product_id, features in products.items():
+    ...     # Each arm augments context with its specific features
+    ...     def add_product_features(X, prod_features):
+    ...         # X shape: (n_users, n_user_features)
+    ...         n_samples = len(X)
+    ...         product_array = np.array([
+    ...             prod_features['price'] / 1000,  # Normalize price
+    ...             prod_features['brand_tier'] / 3,  # Normalize tier
+    ...         ])
+    ...         # Concatenate: [user_features, product_features]
+    ...         return np.c_[X, np.tile(product_array, (n_samples, 1))]
+    ...
+    ...     pipeline = Pipeline([
+    ...         ('add_product', FunctionTransformer(
+    ...             partial(add_product_features, prod_features=features)
+    ...         )),
+    ...         ('scale', StandardScaler()),
+    ...         ('model', shared_model)  # Shared across all products!
+    ...     ])
+    ...     arms.append(Arm(product_id, learner=pipeline))
+    >>>
+    >>> # The agent learns user preferences across all products jointly
+    >>> agent = ContextualAgent(arms, ThompsonSampling())
+    >>>
+    >>> # User context: [age, income, days_since_last_purchase]
+    >>> users = np.array([
+    ...     [25, 50000, 7],
+    ...     [45, 120000, 30],
+    ... ])
+    >>> recommendations = agent.pull(users)  # Personalized for each user
+
+    **DataFrame Input with Feature Engineering**:
+
+    >>> import pandas as pd
+    >>> from sklearn.feature_extraction import FeatureHasher
+    >>>
+    >>> def enrich_user_context(df, item_features):
+    ...     \"\"\"Add item features and compute interactions.\"\"\"
+    ...     df = df.copy()
+    ...
+    ...     # Add item features
+    ...     for key, value in item_features.items():
+    ...         df[f'item_{key}'] = value
+    ...
+    ...     # Compute interactions
+    ...     df['price_to_income_ratio'] = item_features['price'] / df['income']
+    ...     df['is_premium_user_and_item'] = (
+    ...         (df['user_tier'] == 'premium') & item_features['is_premium']
+    ...     )
+    ...     df['category_match'] = df['preferred_category'] == item_features['category']
+    ...
+    ...     return df
+    >>>
+    >>> # Shared model learns what features matter across all items
+    >>> shared_model = NormalRegressor(alpha=0.1, beta=1.0)
+    >>>
+    >>> # Create item-specific pipelines
+    >>> item_features = {'price': 49.99, 'category': 'electronics', 'is_premium': True}
+    >>>
+    >>> pipeline = Pipeline([
+    ...     ('enrich', FunctionTransformer(
+    ...         partial(enrich_user_context, item_features=item_features)
+    ...     )),
+    ...     ('hash', FeatureHasher(n_features=128, input_type='dict')),
+    ...     ('model', shared_model)
+    ... ])
+
+    **Dict Input for A/B Testing Variants**:
+
+    >>> from sklearn.feature_extraction import DictVectorizer
+    >>>
+    >>> # Testing different website layouts with shared learning
+    >>> shared_model = NormalRegressor(alpha=1.0, beta=1.0)
+    >>>
+    >>> layouts = {
+    ...     'layout_A': {'button_color': 'blue', 'header_size': 'large'},
+    ...     'layout_B': {'button_color': 'green', 'header_size': 'medium'},
+    ...     'layout_C': {'button_color': 'blue', 'header_size': 'medium'},
+    ... }
+    >>>
+    >>> arms = []
+    >>> for layout_id, layout_features in layouts.items():
+    ...     def combine_context(user_dicts, layout):
+    ...         \"\"\"Combine user and layout features.\"\"\"
+    ...         combined = []
+    ...         for user in user_dicts:
+    ...             combined_dict = user.copy()
+    ...             combined_dict.update({f'layout_{k}': v for k, v in layout.items()})
+    ...             combined.append(combined_dict)
+    ...         return combined
+    ...
+    ...     pipeline = Pipeline([
+    ...         ('combine', FunctionTransformer(
+    ...             partial(combine_context, layout=layout_features)
+    ...         )),
+    ...         ('vectorize', DictVectorizer()),
+    ...         ('model', shared_model)  # Learn user preferences across layouts
+    ...     ])
+    ...     arms.append(Arm(layout_id, learner=pipeline))
+
+    **Non-stationary Environments with Sparse Features**:
+
+    >>> from scipy.sparse import csc_array, hstack
+    >>>
+    >>> # E-commerce with changing user preferences
+    >>> shared_model = NormalRegressor(
+    ...     alpha=1.0,
+    ...     beta=1.0,
+    ...     learning_rate=0.99,  # Gradual forgetting
+    ...     sparse=True  # Efficient for high-dimensional features
+    ... )
+    >>>
+    >>> def add_sparse_product_features(X, product_one_hot):
+    ...     \"\"\"Add sparse product indicators to user features.\"\"\"
+    ...     n_users = X.shape[0]
+    ...     product_features = csc_array(
+    ...         np.tile(product_one_hot.toarray(), (n_users, 1))
+    ...     )
+    ...     return hstack([X, product_features], format='csc')
+    >>>
+    >>> # Product one-hot encoding (e.g., 10000 products)
+    >>> product_idx = 42
+    >>> product_one_hot = csc_array(([1], ([0], [product_idx])), shape=(1, 10000))
+    >>>
+    >>> pipeline = Pipeline([
+    ...     ('add_product', FunctionTransformer(
+    ...         partial(add_sparse_product_features, product_one_hot=product_one_hot)
+    ...     )),
+    ...     ('model', shared_model)
+    ... ])
+
+    Notes
+    -----
+    The Pipeline class is essential for implementing standard contextual
+    bandit algorithms from the literature, where a single model learns
+    jointly across all arms. This provides several benefits:
+
+    1. **Better cold-start**: New arms benefit from patterns learned on others
+    2. **Parameter efficiency**: One model instead of K independent models
+    3. **Standard formulation**: Matches papers like LinUCB, LinTS, etc.
+    4. **Flexible features**: Easy to add arm-specific or interaction features
+
+    See Also
+    --------
+    sklearn.pipeline.Pipeline : The underlying sklearn Pipeline
+    sklearn.preprocessing.FunctionTransformer : For custom transformations
+    bayesianbandits.Arm : Arms that use these pipelines as learners
+    """
+
+    def __init__(self, steps: List[Tuple[str, Any]]) -> None:
+        if not steps:
+            raise ValueError("Pipeline cannot be empty")
+
+        *transformer_steps, (final_name, final_estimator) = steps
+
+        # Validate final step has required methods
+        if not (
+            hasattr(final_estimator, "partial_fit")
+            and hasattr(final_estimator, "sample")
+            and hasattr(final_estimator, "predict")
+            and hasattr(final_estimator, "decay")
+        ):
+            raise ValueError(
+                f"Final step '{final_name}' must be a bayesianbandits learner "
+                f"implementing partial_fit, sample, predict, and decay methods"
+            )
+
+        # Create sklearn pipeline for transformers
+        if transformer_steps:
+            self._transformers = SklearnPipeline(transformer_steps)
+        else:
+            self._transformers = None
+
+        self._final_estimator = final_estimator
+        self._final_name = final_name
+        self._is_fitted = False
+
+    @property
+    def random_state(self) -> Union[np.random.Generator, int, None]:
+        """Get random state from final estimator."""
+        return getattr(self._final_estimator, "random_state", None)
+
+    @random_state.setter
+    def random_state(self, value: Union[np.random.Generator, int, None]) -> None:
+        """Propagate random state to final estimator."""
+        if hasattr(self._final_estimator, "random_state"):
+            self._final_estimator.random_state = value
+
+    def _apply_transformers(self, X: ContextType, fit: bool = False) -> Any:
+        """Apply transformers to input data."""
+        if self._transformers is None:
+            return X
+
+        if not self._is_fitted or fit:
+            # First time or explicit fit request
+            result = self._transformers.fit_transform(X)
+            self._is_fitted = True
+            return result
+        else:
+            return self._transformers.transform(X)
+
+    def sample(self, X: ContextType, size: int = 1) -> NDArray[np.float64]:
+        """Sample from the posterior predictive distribution.
+
+        Parameters
+        ----------
+        X : ContextType
+            Input data (DataFrame, dict, array, etc.)
+        size : int, default=1
+            Number of samples to draw
+
+        Returns
+        -------
+        samples : NDArray[np.float64]
+            Samples from the posterior
+        """
+        X_transformed = self._apply_transformers(X, fit=False)
+        return self._final_estimator.sample(X_transformed, size)
+
+    def partial_fit(
+        self,
+        X: ContextType,
+        y: NDArray[np.float64],
+        sample_weight: Optional[NDArray[np.float64]] = None,
+    ) -> Self:
+        """Update the learner with new data.
+
+        Parameters
+        ----------
+        X : ContextType
+            Input data (DataFrame, dict, array, etc.)
+        y : NDArray[np.float64]
+            Target values
+        sample_weight : NDArray[np.float64], optional
+            Sample weights
+
+        Returns
+        -------
+        self : Pipeline
+            Returns self for method chaining
+        """
+        X_transformed = self._apply_transformers(X, fit=True)
+        self._final_estimator.partial_fit(X_transformed, y, sample_weight)
+        return self
+
+    def decay(self, X: ContextType, *, decay_rate: Optional[float] = None) -> None:
+        """Decay the learner's parameters.
+
+        Parameters
+        ----------
+        X : ContextType
+            Input data (DataFrame, dict, array, etc.)
+        decay_rate : float, optional
+            Rate of decay
+        """
+        X_transformed = self._apply_transformers(X, fit=False)
+        self._final_estimator.decay(X_transformed, decay_rate=decay_rate)
+
+    def predict(self, X: ContextType) -> NDArray[np.float64]:
+        """Predict expected values.
+
+        Parameters
+        ----------
+        X : ContextType
+            Input data (DataFrame, dict, array, etc.)
+
+        Returns
+        -------
+        predictions : NDArray[np.float64]
+            Expected values
+        """
+        X_transformed = self._apply_transformers(X, fit=False)
+        return self._final_estimator.predict(X_transformed)
+
+    def __repr__(self) -> str:
+        """String representation."""
+        steps_repr = [
+            f"('{name}', {estimator.__class__.__name__})"
+            for name, estimator in self.get_steps()
+        ]
+        return f"Pipeline({', '.join(steps_repr)})"
+
+    def get_steps(self) -> List[Tuple[str, Any]]:
+        """Get all steps including transformers and final estimator."""
+        steps = []
+        if self._transformers is not None:
+            steps.extend(self._transformers.steps)
+        steps.append((self._final_name, self._final_estimator))
+        return steps

--- a/bayesianbandits/policies/_exp3a.py
+++ b/bayesianbandits/policies/_exp3a.py
@@ -182,27 +182,13 @@ class EXP3A:
     ) -> List[Arm[ContextType, TokenType]]:
         """
         Select arms according to exponential weights with optional exploration.
-
-        Parameters
-        ----------
-        arms : List[Arm]
-            Available arms to choose from
-        X : array-like of shape (n_samples, n_features)
-            Context matrix
-        rng : np.random.Generator
-            Random number generator for sampling
-
-        Returns
-        -------
-        List[Arm]
-            Selected arms, one per context
         """
-        assert X.shape is not None, "Context matrix X must not be empty"
-
         # Get expected rewards via Monte Carlo estimation
         rewards = np.stack(
             [arm.sample(X, size=self.samples).mean(axis=0) for arm in arms]
         )
+
+        n_contexts = rewards.shape[1]  # rewards is (n_arms, n_contexts)
 
         # Exponential weights with numerical stability
         weights = np.exp(self.eta * (rewards - rewards.max(axis=0)))
@@ -213,7 +199,7 @@ class EXP3A:
         )
 
         # Sample arms according to probabilities
-        choices = [rng.choice(len(arms), p=probs[:, i]) for i in range(X.shape[0])]
+        choices = [rng.choice(len(arms), p=probs[:, i]) for i in range(n_contexts)]
 
         return [arms[i] for i in choices]
 

--- a/docs/generated/_autosummary/bayesianbandits.Pipeline.rst
+++ b/docs/generated/_autosummary/bayesianbandits.Pipeline.rst
@@ -1,0 +1,33 @@
+﻿bayesianbandits.Pipeline
+========================
+
+.. currentmodule:: bayesianbandits
+
+.. autoclass:: Pipeline
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~Pipeline.__init__
+      ~Pipeline.decay
+      ~Pipeline.get_steps
+      ~Pipeline.partial_fit
+      ~Pipeline.predict
+      ~Pipeline.sample
+   
+   
+
+   
+   
+   .. rubric:: Attributes
+
+   .. autosummary::
+   
+      ~Pipeline.random_state
+   
+   

--- a/docs/generated/bayesianbandits.pipeline.rst
+++ b/docs/generated/bayesianbandits.pipeline.rst
@@ -1,0 +1,29 @@
+﻿bayesianbandits.pipeline
+========================
+
+.. automodule:: bayesianbandits.pipeline
+
+   
+   
+   
+
+   
+   
+   
+
+   
+   
+   .. rubric:: Classes
+
+   .. autosummary::
+   
+      Pipeline
+   
+   
+
+   
+   
+   
+
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
     "pytest-cov>=5.0.0,<6",
     "optuna>=4.0.0,<5",
     "ipywidgets>=8.1.5,<9",
+    "pandas>=2.2.3",
 ]
 cholmod = ["scikit-sparse>=0.4.15,<0.5"]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -256,8 +256,7 @@ class TestBandits:
 
 def test_contextual_agent_update_mismatched_shapes() -> None:
     with pytest.raises(
-        ValueError,
-        match="The number of rows in `X` must match the number of rows in `y`.",
+        ValueError, match="Found input variables with inconsistent numbers of samples: "
     ):
         ContextualAgent(
             [

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -6,7 +6,6 @@ from functools import partial
 from typing import Dict, List
 
 import numpy as np
-import pandas as pd
 import pytest
 from numpy.typing import NDArray
 from scipy.sparse import csc_array
@@ -73,6 +72,9 @@ class TestPipeline:
 
     def test_dataframe_input(self):
         """Test pipeline with DataFrame input."""
+        pytest.importorskip("pandas")
+        import pandas as pd
+
         pipeline = Pipeline(
             [
                 ("select", FunctionTransformer(lambda df: df[["feature"]].values)),
@@ -349,6 +351,9 @@ class TestPipelineInputTypes:
 
     def test_dataframe_features(self) -> None:
         """Test adding features to DataFrames."""
+        pytest.importorskip("pandas")
+        import pandas as pd
+
         item_info = {
             "brand": "BrandA",
             "price": 29.99,
@@ -445,6 +450,8 @@ class TestPipelineInputTypes:
 
     def test_shared_model_different_inputs(self) -> None:
         """Test shared model with pipelines using different input types."""
+        pytest.importorskip("pandas")
+        import pandas as pd
 
         shared_model = NormalRegressor(alpha=1.0, beta=1.0)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,5 +1,7 @@
 """Tests for Pipeline implementation."""
 
+from __future__ import annotations
+
 from functools import partial
 from typing import Dict, List
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,484 @@
+"""Tests for Pipeline implementation."""
+
+from functools import partial
+from typing import Dict, List
+
+import numpy as np
+import pandas as pd
+import pytest
+from numpy.typing import NDArray
+from scipy.sparse import csc_array
+from sklearn.feature_extraction import DictVectorizer
+from sklearn.preprocessing import FunctionTransformer, StandardScaler
+
+from bayesianbandits import (
+    Arm,
+    ContextualAgent,
+    NormalInverseGammaRegressor,
+    NormalRegressor,
+    ThompsonSampling,
+)
+from bayesianbandits.pipeline import Pipeline
+
+
+class TestPipeline:
+    """Test Pipeline functionality."""
+
+    def test_basic_pipeline(self):
+        """Test basic pipeline with array input."""
+        pipeline = Pipeline(
+            [
+                ("scaler", StandardScaler()),
+                ("model", NormalRegressor(alpha=1.0, beta=1.0)),
+            ]
+        )
+
+        X = np.array([[1.0], [2.0], [3.0]])
+        y = np.array([1.0, 2.0, 3.0])
+
+        # Test partial_fit
+        pipeline.partial_fit(X, y)
+
+        # Test predict
+        predictions = pipeline.predict(X)
+        assert predictions.shape == (3,)
+
+        # Test sample
+        samples = pipeline.sample(X, size=10)
+        assert samples.shape == (10, 3)
+
+    def test_get_steps(self):
+        """Test getting steps from the pipeline."""
+        pipeline = Pipeline(
+            [
+                ("scaler", StandardScaler()),
+                ("model", NormalRegressor(alpha=1.0, beta=1.0)),
+            ]
+        )
+
+        steps = pipeline.get_steps()
+        assert len(steps) == 2
+        assert steps[0][0] == "scaler"
+        assert steps[1][0] == "model"
+
+    def test_get_steps_no_transformers(self):
+        """Test getting steps when no transformers are present."""
+        pipeline = Pipeline([("model", NormalRegressor(alpha=1.0, beta=1.0))])
+
+        steps = pipeline.get_steps()
+        assert len(steps) == 1
+        assert steps[0][0] == "model"
+
+    def test_dataframe_input(self):
+        """Test pipeline with DataFrame input."""
+        pipeline = Pipeline(
+            [
+                ("select", FunctionTransformer(lambda df: df[["feature"]].values)),
+                ("model", NormalRegressor(alpha=1.0, beta=1.0)),
+            ]
+        )
+
+        df = pd.DataFrame({"feature": [1.0, 2.0, 3.0], "other": ["a", "b", "c"]})
+        y = np.array([1.0, 2.0, 3.0])
+
+        pipeline.partial_fit(df, y)
+        predictions = pipeline.predict(df)
+        assert predictions.shape == (3,)
+
+    def test_dict_input(self):
+        """Test pipeline with dict input."""
+        pipeline = Pipeline(
+            [
+                ("vectorizer", DictVectorizer()),
+                ("model", NormalRegressor(alpha=1.0, beta=1.0, sparse=True)),
+            ]
+        )
+
+        X = [
+            {"user": "A", "item": "X"},
+            {"user": "B", "item": "Y"},
+            {"user": "A", "item": "Y"},
+        ]
+        y = np.array([1.0, 2.0, 1.5])
+
+        pipeline.partial_fit(X, y)
+        predictions = pipeline.predict(X)
+        assert predictions.shape == (3,)
+
+    def test_shared_model(self):
+        """Test multiple pipelines sharing the same model."""
+        shared_model = NormalRegressor(alpha=1.0, beta=1.0)
+
+        # Create two pipelines with different preprocessing but same model
+        pipeline1 = Pipeline([("scale", StandardScaler()), ("model", shared_model)])
+
+        pipeline2 = Pipeline(
+            [("scale", StandardScaler(with_mean=False)), ("model", shared_model)]
+        )
+
+        X = np.array([[1.0], [2.0], [3.0]])
+        y = np.array([1.0, 2.0, 3.0])
+
+        # Train through first pipeline
+        pipeline1.partial_fit(X, y)
+
+        # Model should be updated
+        assert hasattr(shared_model, "coef_")
+        initial_coef = shared_model.coef_.copy()
+
+        # Train through second pipeline
+        pipeline2.partial_fit(X * 2, y * 2)  # type: ignore
+
+        # Shared model should be updated
+        assert not np.allclose(shared_model.coef_, initial_coef)
+
+    def test_random_state_propagation(self):
+        """Test that random_state is properly propagated."""
+        model = NormalRegressor(alpha=1.0, beta=1.0, random_state=42)
+        pipeline = Pipeline([("scaler", StandardScaler()), ("model", model)])
+
+        # Check getter
+        assert pipeline.random_state == 42
+
+        # Check setter
+        pipeline.random_state = 123
+        assert model.random_state == 123
+        assert pipeline.random_state == 123
+
+    def test_validation_errors(self):
+        """Test validation of pipeline steps."""
+        # Empty pipeline
+        with pytest.raises(ValueError, match="Pipeline cannot be empty"):
+            Pipeline([])
+
+        # Invalid final step
+        with pytest.raises(ValueError, match="must be a bayesianbandits learner"):
+            Pipeline(
+                [
+                    ("scaler", StandardScaler()),
+                    ("invalid", StandardScaler()),  # Not a learner
+                ]
+            )
+
+    def test_integration_with_bandit(self):
+        """Test pipeline integration with ContextualAgent."""
+        shared_model = NormalInverseGammaRegressor()
+
+        # Create arms with different preprocessing
+        arms: List[Arm[NDArray[np.float64], str]] = []
+        for i in range(3):
+            pipeline: Pipeline[NDArray[np.float64]] = Pipeline(
+                [
+                    (
+                        "add_bias",
+                        FunctionTransformer(
+                            lambda x, bias=i: np.column_stack(
+                                [x, np.full(len(x), bias)]
+                            )
+                        ),
+                    ),
+                    ("model", shared_model),
+                ]
+            )
+            arms.append(Arm(f"arm_{i}", learner=pipeline))
+
+        # Create agent
+        agent = ContextualAgent(arms, ThompsonSampling())
+
+        # Pull and update
+        X = np.array([[1.0], [2.0]])
+        actions = agent.pull(X)
+        assert len(actions) == 2
+
+        y = np.array([1.0, 2.0])
+        agent.update(X, y)
+
+    def test_decay(self):
+        """Test decay propagation."""
+        model = NormalRegressor(alpha=1.0, beta=1.0, learning_rate=0.9)
+        pipeline = Pipeline([("scaler", StandardScaler()), ("model", model)])
+
+        X = np.array([[1.0], [2.0]])
+        y = np.array([1.0, 2.0])
+
+        # Fit first
+        pipeline.partial_fit(X, y)
+        initial_cov_inv = model.cov_inv_.copy()
+
+        # Decay
+        pipeline.decay(X, decay_rate=0.5)
+
+        # Precision should decrease (variance increase)
+        assert np.all(model.cov_inv_ < initial_cov_inv)
+
+    def test_no_transformer_pipeline(self):
+        """Test pipeline with only a final estimator."""
+        pipeline = Pipeline([("model", NormalRegressor(alpha=1.0, beta=1.0))])
+
+        X = np.array([[1.0], [2.0]])
+        y = np.array([1.0, 2.0])
+
+        pipeline.partial_fit(X, y)
+        predictions = pipeline.predict(X)
+        assert predictions.shape == (2,)
+
+    def test_sample_weight_propagation(self):
+        """Test that sample weights are properly propagated."""
+        model = NormalRegressor(alpha=1.0, beta=1.0)
+        pipeline = Pipeline([("scaler", StandardScaler()), ("model", model)])
+
+        X = np.array([[1.0], [2.0], [3.0]])
+        y = np.array([1.0, 2.0, 10.0])
+        weights = np.array([1.0, 1.0, 0.1])  # Downweight outlier
+
+        pipeline.partial_fit(X, y, sample_weight=weights)
+
+        # With low weight on outlier, prediction should be closer to 1-2 range
+        pred = pipeline.predict(np.array([[2.5]]))
+        assert pred[0] < 5.0  # Would be ~5.5 without weights
+
+
+class TestPipelineInputTypes:
+    """Test Pipeline with different input types and FunctionTransformer."""
+
+    def test_array_with_static_features(self) -> None:
+        """Test adding static features to numpy arrays."""
+        # Define item features
+        item_price: float = 9.99
+        item_category: int = 2
+
+        def add_item_features(X: NDArray[np.float64]) -> NDArray[np.float64]:
+            """Add item price and category to each row."""
+            n_samples = len(X)
+            price_col = np.full((n_samples, 1), item_price)
+            category_col = np.full((n_samples, 1), item_category)
+            return np.column_stack([X, price_col, category_col])
+
+        pipeline: Pipeline[NDArray[np.float64]] = Pipeline(
+            [
+                ("add_features", FunctionTransformer(add_item_features)),
+                ("model", NormalRegressor(alpha=1.0, beta=1.0)),
+            ]
+        )
+
+        X: NDArray[np.float64] = np.array([[0.5], [1.0], [1.5]])
+        y: NDArray[np.float64] = np.array([10.0, 15.0, 20.0])
+
+        pipeline.partial_fit(X, y)
+        predictions: NDArray[np.float64] = pipeline.predict(X)
+
+        assert predictions.shape == (3,)
+        assert isinstance(predictions, np.ndarray)
+
+    def test_array_with_interactions(self) -> None:
+        """Test computing interaction features."""
+        item_features = {"price": 10.0, "discount": 0.2}
+
+        def add_interactions(
+            X: NDArray[np.float64], features: Dict[str, float]
+        ) -> NDArray[np.float64]:
+            """Add features and compute price-sensitive interaction."""
+            # X has columns: [user_income, days_since_purchase]
+            user_income = X[:, 0]
+            days_since = X[:, 1]
+
+            # Compute interactions
+            price_sensitivity = user_income / features["price"]
+            urgency_discount = np.where(days_since > 30, features["discount"], 0)
+
+            return np.column_stack(  # type:ignore[return]
+                [
+                    X,
+                    price_sensitivity,
+                    urgency_discount,
+                    np.full(len(X), features["price"]),
+                    np.full(len(X), features["discount"]),
+                ]
+            )
+
+        pipeline: Pipeline[NDArray[np.float64]] = Pipeline(
+            [
+                (
+                    "add_features",
+                    FunctionTransformer(
+                        partial(add_interactions, features=item_features)
+                    ),
+                ),
+                ("model", NormalRegressor(alpha=1.0, beta=1.0)),
+            ]
+        )
+
+        X: NDArray[np.float64] = np.array(
+            [
+                [50000, 45],  # Low income, long time
+                [150000, 5],  # High income, recent
+            ]
+        )
+        y: NDArray[np.float64] = np.array([1.0, 0.0])  # First bought, second didn't
+
+        pipeline.partial_fit(X, y)
+        assert pipeline.predict(X).shape == (2,)
+
+    def test_sparse_array_features(self) -> None:
+        """Test adding features to sparse arrays."""
+        from scipy.sparse import hstack
+
+        item_one_hot = csc_array([[0, 0, 1, 0, 0]])  # Item category 3
+
+        def add_sparse_features(X: csc_array) -> csc_array:
+            """Add sparse item features to each row."""
+            n_samples = X.shape[0]  # type: ignore
+            item_features = csc_array(np.tile(item_one_hot.toarray(), (n_samples, 1)))
+            return hstack([X, item_features], format="csc")
+
+        pipeline: Pipeline[csc_array] = Pipeline(
+            [
+                ("add_features", FunctionTransformer(add_sparse_features)),
+                ("model", NormalRegressor(alpha=1.0, beta=1.0, sparse=True)),
+            ]
+        )
+
+        X = csc_array([[1, 0], [0, 1], [1, 1]])
+        y = np.array([1.0, 2.0, 3.0])
+
+        pipeline.partial_fit(X, y)
+        predictions = pipeline.predict(X)
+        assert predictions.shape == (3,)
+
+    def test_dataframe_features(self) -> None:
+        """Test adding features to DataFrames."""
+        item_info = {
+            "brand": "BrandA",
+            "price": 29.99,
+            "in_stock": True,
+            "avg_rating": 4.5,
+        }
+
+        def add_item_to_df(df: pd.DataFrame) -> pd.DataFrame:
+            """Add item features and compute interactions."""
+            df = df.copy()
+
+            # Add static features
+            for key, value in item_info.items():
+                df[f"item_{key}"] = value
+
+            # Add interactions
+            df["can_afford"] = df["user_balance"] >= item_info["price"]
+            df["brand_loyalty"] = df["preferred_brand"] == item_info["brand"]
+
+            return df
+
+        pipeline: Pipeline[pd.DataFrame] = Pipeline(
+            [
+                ("add_features", FunctionTransformer(add_item_to_df)),
+                (
+                    "vectorize",
+                    FunctionTransformer(
+                        lambda df: df.select_dtypes(include=[np.number]).values
+                    ),
+                ),
+                ("model", NormalRegressor(alpha=1.0, beta=1.0)),
+            ]
+        )
+
+        users = pd.DataFrame(
+            {
+                "user_balance": [100.0, 20.0, 50.0],
+                "preferred_brand": ["BrandA", "BrandB", "BrandA"],
+            }
+        )
+        y = np.array([1.0, 0.0, 1.0])  # Who bought
+
+        pipeline.partial_fit(users, y)
+        predictions = pipeline.predict(users)
+
+        assert predictions.shape == (3,)
+
+    def test_dict_list_features(self) -> None:
+        """Test adding features to list of dicts."""
+        from sklearn.feature_extraction import DictVectorizer
+
+        product = {"sku": "ABC123", "category": "electronics", "price_tier": "premium"}
+
+        def enrich_user_dict(
+            users: List[Dict[str, str]], product_info: Dict[str, str]
+        ) -> List[Dict[str, str]]:
+            """Add product info to each user dict."""
+            enriched = []
+            for user in users:
+                user_copy = user.copy()
+                # Add product features
+                for key, value in product_info.items():
+                    user_copy[f"product_{key}"] = value
+                # Add interaction
+                user_copy["matches_interest"] = (  # type: ignore
+                    user.get("interest") == product_info["category"]
+                )
+                enriched.append(user_copy)
+            return enriched
+
+        pipeline: Pipeline[List[Dict[str, str]]] = Pipeline(
+            [
+                (
+                    "add_features",
+                    FunctionTransformer(
+                        partial(enrich_user_dict, product_info=product)
+                    ),
+                ),
+                ("vectorize", DictVectorizer()),
+                ("model", NormalRegressor(alpha=1.0, beta=1.0, sparse=True)),
+            ]
+        )
+
+        users: List[Dict[str, str]] = [
+            {"user_id": "U1", "interest": "electronics"},
+            {"user_id": "U2", "interest": "sports"},
+            {"user_id": "U3", "interest": "electronics"},
+        ]
+        y = np.array([1.0, 0.0, 1.0])
+
+        pipeline.partial_fit(users, y)
+        predictions = pipeline.predict(users)
+        assert predictions.shape == (3,)
+
+    def test_shared_model_different_inputs(self) -> None:
+        """Test shared model with pipelines using different input types."""
+
+        shared_model = NormalRegressor(alpha=1.0, beta=1.0)
+
+        # Pipeline 1: DataFrame input for product A
+        def add_product_a(df: pd.DataFrame) -> NDArray[np.float64]:
+            df = df.copy()
+            df["product_price"] = 19.99
+            df["product_type"] = 1
+            return df[["user_age", "product_price", "product_type"]].values
+
+        pipeline_a: Pipeline[pd.DataFrame] = Pipeline(
+            [("transform", FunctionTransformer(add_product_a)), ("model", shared_model)]
+        )
+
+        # Pipeline 2: Dict input for product B
+        def add_product_b(users: List[Dict[str, float]]) -> NDArray[np.float64]:
+            result = []
+            for user in users:
+                result.append([user["age"], 29.99, 2])  # price=29.99, type=2
+            return np.array(result)
+
+        pipeline_b: Pipeline[List[Dict[str, float]]] = Pipeline(
+            [("transform", FunctionTransformer(add_product_b)), ("model", shared_model)]
+        )
+
+        # Train through pipeline A
+        df_users = pd.DataFrame({"user_age": [25.0, 35.0]})
+        pipeline_a.partial_fit(df_users, np.array([1.0, 0.0]))
+
+        # Train through pipeline B (updates shared model)
+        dict_users: List[Dict[str, float]] = [{"age": 45.0}, {"age": 55.0}]
+        pipeline_b.partial_fit(dict_users, np.array([1.0, 1.0]))
+
+        # Both pipelines should work for prediction
+        pred_a = pipeline_a.predict(df_users)
+        pred_b = pipeline_b.predict(dict_users)
+
+        assert pred_a.shape == (2,)
+        assert pred_b.shape == (2,)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,10 @@
 version = 1
 requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
 
 [[package]]
 name = "alabaster"
@@ -88,6 +93,7 @@ dev = [
     { name = "nbsphinx" },
     { name = "numpydoc" },
     { name = "optuna" },
+    { name = "pandas" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "sphinx" },
@@ -117,6 +123,7 @@ dev = [
     { name = "nbsphinx", specifier = ">=0.9.3,<0.10" },
     { name = "numpydoc", specifier = ">=1.7.0,<2" },
     { name = "optuna", specifier = ">=4.0.0,<5" },
+    { name = "pandas", specifier = ">=2.2.3" },
     { name = "pytest", specifier = ">=8.1.1,<9" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6" },
     { name = "sphinx", specifier = ">=7.2.6,<8" },
@@ -318,7 +325,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -712,7 +719,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "platform_system == 'Darwin'" },
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -1352,6 +1359,54 @@ wheels = [
 ]
 
 [[package]]
+name = "pandas"
+version = "2.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/d6/9f8431bacc2e19dca897724cd097b1bb224a6ad5433784a44b587c7c13af/pandas-2.2.3.tar.gz", hash = "sha256:4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667", size = 4399213 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/70/c853aec59839bceed032d52010ff5f1b8d87dc3114b762e4ba2727661a3b/pandas-2.2.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1948ddde24197a0f7add2bdc4ca83bf2b1ef84a1bc8ccffd95eda17fd836ecb5", size = 12580827 },
+    { url = "https://files.pythonhosted.org/packages/99/f2/c4527768739ffa4469b2b4fff05aa3768a478aed89a2f271a79a40eee984/pandas-2.2.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:381175499d3802cde0eabbaf6324cce0c4f5d52ca6f8c377c29ad442f50f6348", size = 11303897 },
+    { url = "https://files.pythonhosted.org/packages/ed/12/86c1747ea27989d7a4064f806ce2bae2c6d575b950be087837bdfcabacc9/pandas-2.2.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d9c45366def9a3dd85a6454c0e7908f2b3b8e9c138f5dc38fed7ce720d8453ed", size = 66480908 },
+    { url = "https://files.pythonhosted.org/packages/44/50/7db2cd5e6373ae796f0ddad3675268c8d59fb6076e66f0c339d61cea886b/pandas-2.2.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86976a1c5b25ae3f8ccae3a5306e443569ee3c3faf444dfd0f41cda24667ad57", size = 13064210 },
+    { url = "https://files.pythonhosted.org/packages/61/61/a89015a6d5536cb0d6c3ba02cebed51a95538cf83472975275e28ebf7d0c/pandas-2.2.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b8661b0238a69d7aafe156b7fa86c44b881387509653fdf857bebc5e4008ad42", size = 16754292 },
+    { url = "https://files.pythonhosted.org/packages/ce/0d/4cc7b69ce37fac07645a94e1d4b0880b15999494372c1523508511b09e40/pandas-2.2.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:37e0aced3e8f539eccf2e099f65cdb9c8aa85109b0be6e93e2baff94264bdc6f", size = 14416379 },
+    { url = "https://files.pythonhosted.org/packages/31/9e/6ebb433de864a6cd45716af52a4d7a8c3c9aaf3a98368e61db9e69e69a9c/pandas-2.2.3-cp310-cp310-win_amd64.whl", hash = "sha256:56534ce0746a58afaf7942ba4863e0ef81c9c50d3f0ae93e9497d6a41a057645", size = 11598471 },
+    { url = "https://files.pythonhosted.org/packages/a8/44/d9502bf0ed197ba9bf1103c9867d5904ddcaf869e52329787fc54ed70cc8/pandas-2.2.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:66108071e1b935240e74525006034333f98bcdb87ea116de573a6a0dccb6c039", size = 12602222 },
+    { url = "https://files.pythonhosted.org/packages/52/11/9eac327a38834f162b8250aab32a6781339c69afe7574368fffe46387edf/pandas-2.2.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7c2875855b0ff77b2a64a0365e24455d9990730d6431b9e0ee18ad8acee13dbd", size = 11321274 },
+    { url = "https://files.pythonhosted.org/packages/45/fb/c4beeb084718598ba19aa9f5abbc8aed8b42f90930da861fcb1acdb54c3a/pandas-2.2.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd8d0c3be0515c12fed0bdbae072551c8b54b7192c7b1fda0ba56059a0179698", size = 15579836 },
+    { url = "https://files.pythonhosted.org/packages/cd/5f/4dba1d39bb9c38d574a9a22548c540177f78ea47b32f99c0ff2ec499fac5/pandas-2.2.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c124333816c3a9b03fbeef3a9f230ba9a737e9e5bb4060aa2107a86cc0a497fc", size = 13058505 },
+    { url = "https://files.pythonhosted.org/packages/b9/57/708135b90391995361636634df1f1130d03ba456e95bcf576fada459115a/pandas-2.2.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:63cc132e40a2e084cf01adf0775b15ac515ba905d7dcca47e9a251819c575ef3", size = 16744420 },
+    { url = "https://files.pythonhosted.org/packages/86/4a/03ed6b7ee323cf30404265c284cee9c65c56a212e0a08d9ee06984ba2240/pandas-2.2.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:29401dbfa9ad77319367d36940cd8a0b3a11aba16063e39632d98b0e931ddf32", size = 14440457 },
+    { url = "https://files.pythonhosted.org/packages/ed/8c/87ddf1fcb55d11f9f847e3c69bb1c6f8e46e2f40ab1a2d2abadb2401b007/pandas-2.2.3-cp311-cp311-win_amd64.whl", hash = "sha256:3fc6873a41186404dad67245896a6e440baacc92f5b716ccd1bc9ed2995ab2c5", size = 11617166 },
+    { url = "https://files.pythonhosted.org/packages/17/a3/fb2734118db0af37ea7433f57f722c0a56687e14b14690edff0cdb4b7e58/pandas-2.2.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b1d432e8d08679a40e2a6d8b2f9770a5c21793a6f9f47fdd52c5ce1948a5a8a9", size = 12529893 },
+    { url = "https://files.pythonhosted.org/packages/e1/0c/ad295fd74bfac85358fd579e271cded3ac969de81f62dd0142c426b9da91/pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a5a1595fe639f5988ba6a8e5bc9649af3baf26df3998a0abe56c02609392e0a4", size = 11363475 },
+    { url = "https://files.pythonhosted.org/packages/c6/2a/4bba3f03f7d07207481fed47f5b35f556c7441acddc368ec43d6643c5777/pandas-2.2.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5de54125a92bb4d1c051c0659e6fcb75256bf799a732a87184e5ea503965bce3", size = 15188645 },
+    { url = "https://files.pythonhosted.org/packages/38/f8/d8fddee9ed0d0c0f4a2132c1dfcf0e3e53265055da8df952a53e7eaf178c/pandas-2.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fffb8ae78d8af97f849404f21411c95062db1496aeb3e56f146f0355c9989319", size = 12739445 },
+    { url = "https://files.pythonhosted.org/packages/20/e8/45a05d9c39d2cea61ab175dbe6a2de1d05b679e8de2011da4ee190d7e748/pandas-2.2.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6dfcb5ee8d4d50c06a51c2fffa6cff6272098ad6540aed1a76d15fb9318194d8", size = 16359235 },
+    { url = "https://files.pythonhosted.org/packages/1d/99/617d07a6a5e429ff90c90da64d428516605a1ec7d7bea494235e1c3882de/pandas-2.2.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:062309c1b9ea12a50e8ce661145c6aab431b1e99530d3cd60640e255778bd43a", size = 14056756 },
+    { url = "https://files.pythonhosted.org/packages/29/d4/1244ab8edf173a10fd601f7e13b9566c1b525c4f365d6bee918e68381889/pandas-2.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:59ef3764d0fe818125a5097d2ae867ca3fa64df032331b7e0917cf5d7bf66b13", size = 11504248 },
+    { url = "https://files.pythonhosted.org/packages/64/22/3b8f4e0ed70644e85cfdcd57454686b9057c6c38d2f74fe4b8bc2527214a/pandas-2.2.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f00d1345d84d8c86a63e476bb4955e46458b304b9575dcf71102b5c705320015", size = 12477643 },
+    { url = "https://files.pythonhosted.org/packages/e4/93/b3f5d1838500e22c8d793625da672f3eec046b1a99257666c94446969282/pandas-2.2.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3508d914817e153ad359d7e069d752cdd736a247c322d932eb89e6bc84217f28", size = 11281573 },
+    { url = "https://files.pythonhosted.org/packages/f5/94/6c79b07f0e5aab1dcfa35a75f4817f5c4f677931d4234afcd75f0e6a66ca/pandas-2.2.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22a9d949bfc9a502d320aa04e5d02feab689d61da4e7764b62c30b991c42c5f0", size = 15196085 },
+    { url = "https://files.pythonhosted.org/packages/e8/31/aa8da88ca0eadbabd0a639788a6da13bb2ff6edbbb9f29aa786450a30a91/pandas-2.2.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3a255b2c19987fbbe62a9dfd6cff7ff2aa9ccab3fc75218fd4b7530f01efa24", size = 12711809 },
+    { url = "https://files.pythonhosted.org/packages/ee/7c/c6dbdb0cb2a4344cacfb8de1c5808ca885b2e4dcfde8008266608f9372af/pandas-2.2.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:800250ecdadb6d9c78eae4990da62743b857b470883fa27f652db8bdde7f6659", size = 16356316 },
+    { url = "https://files.pythonhosted.org/packages/57/b7/8b757e7d92023b832869fa8881a992696a0bfe2e26f72c9ae9f255988d42/pandas-2.2.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6374c452ff3ec675a8f46fd9ab25c4ad0ba590b71cf0656f8b6daa5202bca3fb", size = 14022055 },
+    { url = "https://files.pythonhosted.org/packages/3b/bc/4b18e2b8c002572c5a441a64826252ce5da2aa738855747247a971988043/pandas-2.2.3-cp313-cp313-win_amd64.whl", hash = "sha256:61c5ad4043f791b61dd4752191d9f07f0ae412515d59ba8f005832a532f8736d", size = 11481175 },
+    { url = "https://files.pythonhosted.org/packages/76/a3/a5d88146815e972d40d19247b2c162e88213ef51c7c25993942c39dbf41d/pandas-2.2.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:3b71f27954685ee685317063bf13c7709a7ba74fc996b84fc6821c59b0f06468", size = 12615650 },
+    { url = "https://files.pythonhosted.org/packages/9c/8c/f0fd18f6140ddafc0c24122c8a964e48294acc579d47def376fef12bcb4a/pandas-2.2.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:38cf8125c40dae9d5acc10fa66af8ea6fdf760b2714ee482ca691fc66e6fcb18", size = 11290177 },
+    { url = "https://files.pythonhosted.org/packages/ed/f9/e995754eab9c0f14c6777401f7eece0943840b7a9fc932221c19d1abee9f/pandas-2.2.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba96630bc17c875161df3818780af30e43be9b166ce51c9a18c1feae342906c2", size = 14651526 },
+    { url = "https://files.pythonhosted.org/packages/25/b0/98d6ae2e1abac4f35230aa756005e8654649d305df9a28b16b9ae4353bff/pandas-2.2.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db71525a1538b30142094edb9adc10be3f3e176748cd7acc2240c2f2e5aa3a4", size = 11871013 },
+    { url = "https://files.pythonhosted.org/packages/cc/57/0f72a10f9db6a4628744c8e8f0df4e6e21de01212c7c981d31e50ffc8328/pandas-2.2.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:15c0e1e02e93116177d29ff83e8b1619c93ddc9c49083f237d4312337a61165d", size = 15711620 },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/b38085618b950b79d2d9164a711c52b10aefc0ae6833b96f626b7021b2ed/pandas-2.2.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ad5b65698ab28ed8d7f18790a0dc58005c7629f227be9ecc1072aa74c0c1d43a", size = 13098436 },
+]
+
+[[package]]
 name = "pandocfilters"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1605,6 +1660,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[package]]
+name = "pytz"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225 },
 ]
 
 [[package]]
@@ -2240,7 +2304,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [
@@ -2263,6 +2327,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839 },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR provides an clean API to implement the standard contextual bandit formulation from the literature, where multiple arms share a single model with arm-specific features, as described in foundational papers like LinUCB (Li et al., 2010). Fixes #147

## Background

The library's original design - each `Arm` having an independent learner - works well for many scenarios. This PR adds `Pipeline` to enable shared-model approaches (also called hybrid bandits), giving users the flexibility to choose the right approach for their problem.

## When to Use Each Approach

**Independent learners** (original design) are best when:
- Arms are fundamentally different (e.g., email vs push notification)
- Each arm needs different model types or hyperparameters
- Arms have non-overlapping feature spaces
- You have plenty of data per arm

**Shared model** (via Pipeline) excels when:
- Arms are variations of the same thing (products, articles, ads)
- New arms are frequently added (new products, new content)
- Arms have limited individual data but share common patterns

## Solution

The new `Pipeline` class bridges sklearn transformers with Bayesian learners:

```python
# Single shared model for all products
shared_model = NormalRegressor(alpha=1.0, beta=1.0, sparse=True)

arms = []
for product_id, product_features in catalog.items():
    pipeline = Pipeline([
        ('add_features', FunctionTransformer(
            # IMPORTANT: Use functools.partial and a defined function if you intend to persist it
            # with joblib. lambda is ONLY used for brevity here. 
            lambda df: df.assign(**{f'product_{k}': v for k, v in product_features.items()})
        )),
        ('vectorize', DictVectorizer()),
        ('model', shared_model)  # Shared across all products!
    ])
    arms.append(Arm(product_id, learner=pipeline))

# Use human-readable DataFrames instead of opaque matrices
users_df = pd.DataFrame({
    'user_income': [50000, 120000],
    'user_age': [25, 45],
    'days_since_purchase': [7, 30]
})
recommendations = agent.pull(users_df)
```

## Key Benefits

1. **Implement literature algorithms**: Direct implementation of LinUCB, LinTS, etc.
2. **Better cold-start**: New products benefit from patterns learned on existing ones
3. **Human-readable features**: Work with DataFrames/dicts instead of matrix indices
4. **Feature engineering**: Leverage sklearn's full transformer ecosystem
5. **Easier debugging**: Inspect intermediate transformations, log meaningful feature names

## Real-World Example: E-commerce

```python
# Products share a model but have different features
products = {
    'laptop': {'price': 999, 'category': 'electronics', 'margin': 0.15},
    'shoes': {'price': 89, 'category': 'fashion', 'margin': 0.40},
}

shared_model = NormalRegressor(alpha=1.0, beta=1.0)

for sku, product in products.items():
    pipeline = Pipeline([
        ('features', FunctionTransformer(lambda df, p=product: df.assign(
            # Static features
            product_price=p['price'],
            # Interactions  
            affordable=(df['income'] / 12) > p['price'],
            category_match=df['last_category'] == p['category']
        ))),
        ('vectorize', DictVectorizer()),
        ('model', shared_model)
    ])
    arms.append(Arm(sku, learner=pipeline))
```

## Implementation

Minimal, backward-compatible changes:
- New `Pipeline` class (~150 lines)
- Relaxed `ContextType` to accept `Iterable` 
- Minor fixes for code assuming `.shape` exists

All existing code continues to work unchanged.

## Summary

This PR gives users the flexibility to implement both independent and shared-model bandits, choosing the right approach for their problem. The shared-model approach via Pipeline is particularly powerful for domains with many similar arms (products, content, ads) where collective learning accelerates performance.