### PR TITLE
BREAKING: Fix DirichletClassifier.sample() output shape

### DIFF
--- a/bayesianbandits/_estimators.py
+++ b/bayesianbandits/_estimators.py
@@ -280,7 +280,7 @@ class DirichletClassifier(BaseEstimator, ClassifierMixin):
         alphas = list(self.known_alphas_[x.item()] for x in X)
         return np.stack(
             list(dirichlet.rvs(alpha, size, self.random_state_) for alpha in alphas),
-        )
+        ).transpose(1, 0, 2)
 
     def decay(self, X: NDArray[Any], *, decay_rate: Optional[float] = None) -> None:
         """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -89,7 +89,7 @@ def bandit_instance(
         def reward_func(
             x: NDArray[np.float64],
         ) -> NDArray[np.float64]:
-            return x[..., 0].T
+            return x[..., 0]
 
     else:
         reward_func = None  # type: ignore


### PR DESCRIPTION
## What Changed

`DirichletClassifier.sample()` now returns `(size, n_contexts, n_classes)` instead of `(n_contexts, size, n_classes)` to match all other learners.

```python
# Before: (n_contexts, size, n_classes) - inconsistent!
# After:  (size, n_contexts, n_classes) - consistent with other learners
```

## Why

DirichletClassifier was the only learner with a different output shape, which broke batching and required special cases throughout the codebase.

## How to Update Your Code

### If using DirichletClassifier in a bandit:

```python
# Old reward function (before)
def reward_func(x):
    return x[..., 0].T  # Had to transpose!

# New reward function (after)  
def reward_func(x):
    return x[..., 0]   # No transpose needed!
```

### If using sample() directly:

```python
# Add .transpose(1, 0, 2) to maintain old behavior
samples = model.sample(X, size=n).transpose(1, 0, 2)
```

## The Fix

```python
# In DirichletClassifier.sample()
return np.stack(
    list(dirichlet.rvs(alpha, size, self.random_state_) for alpha in alphas),
).transpose(1, 0, 2)  # Added this transpose
```