### PR TITLE
Update pyright version and improve type hints

### DIFF
--- a/bayesianbandits/_arm.py
+++ b/bayesianbandits/_arm.py
@@ -17,8 +17,8 @@ from typing import (
 
 import numpy as np
 from numpy.typing import NDArray
-from scipy.sparse import csr_matrix, issparse
-from scipy.sparse import vstack as sparse_vstack
+from scipy.sparse import csr_matrix, issparse  # type: ignore[import]
+from scipy.sparse import vstack as sparse_vstack  # type: ignore[import]
 from typing_extensions import Concatenate, ParamSpec, Self
 
 HAS_PANDAS = importlib.util.find_spec("pandas") is not None
@@ -174,7 +174,7 @@ def stack_features(feature_list: List[Any]) -> Any:
 
     # Case 1: Pandas DataFrames (if pandas available)
     if HAS_PANDAS:
-        import pandas as pd  # Re-import for type narrowing
+        import pandas as pd  # type: ignore[import] # Re-import for type narrowing
 
         if isinstance(first, pd.DataFrame):
             if not all(isinstance(x, pd.DataFrame) for x in feature_list):
@@ -188,7 +188,7 @@ def stack_features(feature_list: List[Any]) -> Any:
         if not all(issparse(x) for x in feature_list):
             raise ValueError("Cannot stack mixed sparse and dense arrays")
         # Convert to CSR for efficient row operations
-        return sparse_vstack([csr_matrix(x) for x in feature_list], format="csr")
+        return sparse_vstack([csr_matrix(x) for x in feature_list], format="csr")  # type: ignore[return-value]
 
     # Case 3: Dense arrays - numpy is always available
     arrays = [np.asarray(x) for x in feature_list]
@@ -244,7 +244,7 @@ def batch_sample_arms(
 
     # Transform features for each arm
     n_arms = len(arms)
-    feature_list = []
+    feature_list: List[Any] = []
 
     # Pre-check context length for memory allocation
     n_contexts = len(X)

--- a/bayesianbandits/_arm_featurizer.py
+++ b/bayesianbandits/_arm_featurizer.py
@@ -5,11 +5,10 @@ transforming context features based on action tokens in shared model bandits.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Generic, Iterable, Sequence
-
-import numpy as np
+from typing import Any, Generic, Sequence, Sized
 
 from ._arm import TokenType
+
 
 __all__ = [
     "ArmFeaturizer",
@@ -22,22 +21,21 @@ class ArmFeaturizer(ABC, Generic[TokenType]):
     Transforms features for multiple arms in a single call to enable
     efficient batched processing in shared model bandits.
 
-    Parameters
-    ----------
+    Type Parameters
+    ---------------
     TokenType : type
         The type of action tokens this featurizer accepts.
     """
 
     @abstractmethod
-    def transform(self, X: Iterable[Any], *, action_tokens: Sequence[TokenType]) -> Any:
+    def transform(self, X: Sized, *, action_tokens: Sequence[TokenType]) -> Any:
         """Transform features for all arms in a single vectorized call.
 
         Parameters
         ----------
-        X : Iterable[Any]
-            Input context features. While this accepts any iterable,
-            implementations typically expect array-like of shape
-            (n_contexts, n_features).
+        X : Sized
+            Input context features. Implementations typically expect array-like
+            of shape (n_contexts, n_features).
         action_tokens : sequence of TokenType, length n_arms
             Action tokens for each arm to featurize.
 
@@ -59,6 +57,7 @@ class ArmFeaturizer(ABC, Generic[TokenType]):
 
         Examples
         --------
+        >>> import numpy as np
         >>> # Discrete action tokens
         >>> X = np.array([[1, 2], [3, 4]])  # 2 contexts, 2 features
         >>> action_tokens = [0, 1, 2]  # 3 arms

--- a/bayesianbandits/featurizers/_arm_column.py
+++ b/bayesianbandits/featurizers/_arm_column.py
@@ -1,7 +1,7 @@
 """Arm column featurizer that appends arm tokens as a column."""
 
 import importlib.util
-from typing import Any, Iterable, Sequence, TypeVar
+from typing import Any, Sequence, Sized, TypeVar
 
 import numpy as np
 
@@ -75,13 +75,13 @@ class ArmColumnFeaturizer(ArmFeaturizer[T]):
     >>> # Returns DataFrame with 'arm_token' column added
     >>> list(df_with_arms.columns)
     ['feature1', 'feature2', 'arm_token']
-    
+
     >>> # Example 4: Using custom column name
     >>> featurizer = ArmColumnFeaturizer(column_name='product_id')
     >>> df_with_arms = featurizer.transform(df, action_tokens=['A', 'B', 'C'])
     >>> list(df_with_arms.columns)
     ['feature1', 'feature2', 'product_id']
-    
+
     """
 
     def __init__(self, column_name: str = "arm_token"):
@@ -94,12 +94,12 @@ class ArmColumnFeaturizer(ArmFeaturizer[T]):
         """
         self.column_name = column_name
 
-    def transform(self, X: Iterable[Any], *, action_tokens: Sequence[T]) -> Any:
+    def transform(self, X: Sized, *, action_tokens: Sequence[T]) -> Any:
         """Append arm tokens as a column to context features.
 
         Parameters
         ----------
-        X : Iterable[Any]
+        X : Sized
             Input context features. Can be a pandas DataFrame, numpy array,
             or other array-like structure of shape (n_contexts, n_features).
         action_tokens : sequence of T
@@ -116,17 +116,17 @@ class ArmColumnFeaturizer(ArmFeaturizer[T]):
 
         # Handle pandas DataFrames
         if HAS_PANDAS:
-            import pandas as pd
+            import pandas as pd  # type: ignore[import]
 
             if isinstance(X, pd.DataFrame):
                 n_contexts = len(X)
 
                 if n_arms == 0:
                     # Return empty DataFrame with arm column
-                    result = pd.DataFrame(columns=list(X.columns) + [self.column_name])
+                    result = pd.DataFrame(columns=list(X.columns) + [self.column_name])  # type: ignore[misc]
                     # Preserve dtypes from original DataFrame
                     for col in X.columns:
-                        result[col] = result[col].astype(X[col].dtype)
+                        result[col] = result[col].astype(X[col].dtype)  # type: ignore[misc]
                     return result
 
                 # Tile the DataFrame for each arm

--- a/bayesianbandits/featurizers/_function.py
+++ b/bayesianbandits/featurizers/_function.py
@@ -1,6 +1,6 @@
 """Function-based arm featurizer wrapper."""
 
-from typing import Any, Callable, Iterable, Sequence
+from typing import Callable, Sequence, Sized
 
 import numpy as np
 from numpy.typing import NDArray
@@ -73,7 +73,7 @@ class FunctionArmFeaturizer(ArmFeaturizer[TokenType]):
     """
 
     def __init__(
-        self, func: Callable[[Iterable[Any], Sequence[TokenType]], NDArray[np.floating]]
+        self, func: Callable[[Sized, Sequence[TokenType]], NDArray[np.floating]]
     ):
         """Initialize the function-based arm featurizer.
 
@@ -85,13 +85,13 @@ class FunctionArmFeaturizer(ArmFeaturizer[TokenType]):
         self.func = func
 
     def transform(
-        self, X: Iterable[Any], *, action_tokens: Sequence[TokenType]
+        self, X: Sized, *, action_tokens: Sequence[TokenType]
     ) -> NDArray[np.floating]:
         """Transform features using the provided function.
 
         Parameters
         ----------
-        X : Iterable[Any]
+        X : Sized
             Input context features.
         action_tokens : sequence of TokenType
             Action tokens for each arm.

--- a/bayesianbandits/pipelines/_agent.py
+++ b/bayesianbandits/pipelines/_agent.py
@@ -5,14 +5,15 @@ before delegating to wrapped Agent/ContextualAgent instances. This enables
 efficient preprocessing at the agent level rather than per-arm.
 """
 
+
 from typing import Any, Dict, Generic, List, Optional, Tuple, Union, overload
 
 import numpy as np
 from numpy.typing import NDArray
 from typing_extensions import Self
 
-from .._arm import ContextType, TokenType
-from ..api import Agent, ContextualAgent
+from .._arm import Arm, ContextType, TokenType
+from ..api import Agent, ContextualAgent, PolicyProtocol
 
 
 def _validate_steps(steps: List[Tuple[str, Any]]) -> None:
@@ -184,7 +185,7 @@ class ContextualAgentPipeline(Generic[ContextType, TokenType]):
         self._agent.decay(X_transformed, decay_rate=decay_rate)
 
     # Delegation methods
-    def add_arm(self, arm) -> None:
+    def add_arm(self, arm: Arm[Any, TokenType]) -> None:
         """Add an arm to the wrapped agent."""
         self._agent.add_arm(arm)
 
@@ -192,7 +193,7 @@ class ContextualAgentPipeline(Generic[ContextType, TokenType]):
         """Remove an arm from the wrapped agent."""
         self._agent.remove_arm(token)
 
-    def arm(self, token: TokenType):
+    def arm(self, token: TokenType) -> Arm[Any, TokenType]:
         """Get an arm by its action token."""
         return self._agent.arm(token)
 
@@ -202,27 +203,27 @@ class ContextualAgentPipeline(Generic[ContextType, TokenType]):
         return self
 
     @property
-    def arms(self):
+    def arms(self) -> List[Arm[ContextType, TokenType]]:
         """Get the arms from the wrapped agent."""
         return self._agent.arms
 
     @property
-    def arm_to_update(self):
+    def arm_to_update(self) -> Arm[ContextType, TokenType]:
         """Get the arm to update from the wrapped agent."""
         return self._agent.arm_to_update
 
     @property
-    def policy(self):
+    def policy(self) -> PolicyProtocol[ContextType, TokenType]:
         """Get the policy from the wrapped agent."""
         return self._agent.policy
 
     @policy.setter
-    def policy(self, value):
+    def policy(self, value: PolicyProtocol[ContextType, TokenType]) -> None:
         """Set the policy on the wrapped agent."""
         self._agent.policy = value
 
     @property
-    def rng(self):
+    def rng(self) -> np.random.Generator:
         """Get the random generator from the wrapped agent."""
         return self._agent.rng
 
@@ -349,7 +350,7 @@ class NonContextualAgentPipeline(Generic[TokenType]):
         self._agent.decay(decay_rate=decay_rate)
 
     # Delegation methods
-    def add_arm(self, arm) -> None:
+    def add_arm(self, arm: Arm[NDArray[np.float64], TokenType]) -> None:
         """Add an arm to the wrapped agent."""
         self._agent.add_arm(arm)
 
@@ -357,7 +358,7 @@ class NonContextualAgentPipeline(Generic[TokenType]):
         """Remove an arm from the wrapped agent."""
         self._agent.remove_arm(token)
 
-    def arm(self, token: TokenType):
+    def arm(self, token: TokenType) -> Arm[NDArray[np.float64], TokenType]:
         """Get an arm by its action token."""
         return self._agent.arm(token)
 
@@ -367,27 +368,27 @@ class NonContextualAgentPipeline(Generic[TokenType]):
         return self
 
     @property
-    def arms(self):
+    def arms(self) -> List[Arm[NDArray[np.float64], TokenType]]:
         """Get the arms from the wrapped agent."""
         return self._agent.arms
 
     @property
-    def arm_to_update(self):
+    def arm_to_update(self) -> Arm[NDArray[np.float64], TokenType]:
         """Get the arm to update from the wrapped agent."""
         return self._agent.arm_to_update
 
     @property
-    def policy(self):
+    def policy(self) -> PolicyProtocol[NDArray[np.float64], TokenType]:
         """Get the policy from the wrapped agent."""
         return self._agent.policy
 
     @policy.setter
-    def policy(self, value):
+    def policy(self, value: PolicyProtocol[NDArray[np.float64], TokenType]) -> None:
         """Set the policy on the wrapped agent."""
         self._agent.policy = value
 
     @property
-    def rng(self):
+    def rng(self) -> np.random.Generator:
         """Get the random generator from the wrapped agent."""
         return self._agent.rng
 

--- a/bayesianbandits/policies/_epsilon_greedy.py
+++ b/bayesianbandits/policies/_epsilon_greedy.py
@@ -86,14 +86,14 @@ class EpsilonGreedy(PolicyDefaultUpdate[ContextType, TokenType]):
 
         # Apply epsilon-greedy exploration per context
         # Decide which contexts explore
-        choice_idx_to_explore = rng.random(size=means.shape[1]) < self.epsilon
+        choice_idx_to_explore = rng.random(size=means.shape[1]) < self.epsilon  # type: ignore[misc]
 
         # How many arms to mark as infinite
         k = 1 if top_k is None else top_k
 
         # For each exploring context, set k random arms to np.inf
         values = means.copy()
-        for idx, explore in enumerate(choice_idx_to_explore):
+        for idx, explore in enumerate(choice_idx_to_explore):  # type: ignore[misc]
             if explore:
                 random_arms = rng.choice(
                     means.shape[0],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
     "optuna>=4.0.0,<5",
     "ipywidgets>=8.1.5,<9",
     "pandas>=2.2.3",
-    "pyright>=1.1.401",
+    "pyright==1.1.402",
 ]
 cholmod = ["scikit-sparse>=0.4.15,<0.5"]
 
@@ -40,6 +40,13 @@ default-groups = [
     "dev",
     "cholmod",
 ]
+
+[tool.pyright]
+include = [
+    "bayesianbandits",
+    "tests",
+]
+typeCheckingMode = "standard"
 
 [build-system]
 requires = ["hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -125,7 +125,7 @@ dev = [
     { name = "numpydoc", specifier = ">=1.7.0,<2" },
     { name = "optuna", specifier = ">=4.0.0,<5" },
     { name = "pandas", specifier = ">=2.2.3" },
-    { name = "pyright", specifier = ">=1.1.401" },
+    { name = "pyright", specifier = "==1.1.402" },
     { name = "pytest", specifier = ">=8.1.1,<9" },
     { name = "pytest-cov", specifier = ">=5.0.0,<6" },
     { name = "sphinx", specifier = ">=7.2.6,<8" },
@@ -1633,15 +1633,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.401"
+version = "1.1.402"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/9a/7ab2b333b921b2d6bfcffe05a0e0a0bbeff884bd6fb5ed50cd68e2898e53/pyright-1.1.401.tar.gz", hash = "sha256:788a82b6611fa5e34a326a921d86d898768cddf59edde8e93e56087d277cc6f1", size = 3894193 }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/04/ce0c132d00e20f2d2fb3b3e7c125264ca8b909e693841210534b1ea1752f/pyright-1.1.402.tar.gz", hash = "sha256:85a33c2d40cd4439c66aa946fd4ce71ab2f3f5b8c22ce36a623f59ac22937683", size = 3888207 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/e6/1f908fce68b0401d41580e0f9acc4c3d1b248adcff00dfaad75cd21a1370/pyright-1.1.401-py3-none-any.whl", hash = "sha256:6fde30492ba5b0d7667c16ecaf6c699fab8d7a1263f6a18549e0b00bf7724c06", size = 5629193 },
+    { url = "https://files.pythonhosted.org/packages/fe/37/1a1c62d955e82adae588be8e374c7f77b165b6cb4203f7d581269959abbc/pyright-1.1.402-py3-none-any.whl", hash = "sha256:2c721f11869baac1884e846232800fe021c33f1b4acb3929cff321f7ea4e2982", size = 5624004 },
 ]
 
 [[package]]


### PR DESCRIPTION
Upgrade the pyright dependency to version 1.1.402 and refactor type hints across multiple modules to enhance clarity and consistency by using 'Sized' where appropriate. Type ignores were added for specific imports to address type checking issues.