### PR TITLE
Allow users to define context-aware reward functions

### DIFF
--- a/bayesianbandits/pipelines/_agent.py
+++ b/bayesianbandits/pipelines/_agent.py
@@ -5,7 +5,6 @@ before delegating to wrapped Agent/ContextualAgent instances. This enables
 efficient preprocessing at the agent level rather than per-arm.
 """
 
-
 from typing import Any, Dict, Generic, List, Optional, Tuple, Union, overload
 
 import numpy as np
@@ -284,9 +283,9 @@ class NonContextualAgentPipeline(Generic[TokenType]):
     def __init__(
         self, steps: List[Tuple[str, Any]], final_agent: Agent[TokenType]
     ) -> None:
-        _validate_steps(
-            steps
-        ) if steps else None  # Allow empty steps for non-contextual
+        (
+            _validate_steps(steps) if steps else None
+        )  # Allow empty steps for non-contextual
         self.steps = steps
         self._agent = final_agent
 

--- a/bayesianbandits/policies/__init__.py
+++ b/bayesianbandits/policies/__init__.py
@@ -5,7 +5,7 @@ from ._upper_confidence_bound import UpperConfidenceBound
 
 __all__ = [
     "EXP3A",
-    "EpsilonGreedy", 
+    "EpsilonGreedy",
     "ThompsonSampling",
     "UpperConfidenceBound",
 ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -378,8 +378,10 @@ class TestTopK:
     @pytest.mark.parametrize("policy_class", [ThompsonSampling, UpperConfidenceBound])
     def test_other_policies_top_k(
         self,
-        policy_class: Type[ThompsonSampling[NDArray[np.float64], int]]
-        | Type[UpperConfidenceBound[NDArray[np.float64], int]],
+        policy_class: (
+            Type[ThompsonSampling[NDArray[np.float64], int]]
+            | Type[UpperConfidenceBound[NDArray[np.float64], int]]
+        ),
     ) -> None:
         """Test that other policies also support top_k."""
         arms = [Arm(i, None, learner=NormalInverseGammaRegressor()) for i in range(5)]

--- a/tests/test_arm.py
+++ b/tests/test_arm.py
@@ -99,3 +99,116 @@ class TestArm:
         with pytest.raises(ValueError):
             X = np.array([[1.0]])
             arm.sample(X=X, size=1)
+
+
+class TestContextAwareRewardFunctions:
+    """Test context-aware reward functions functionality."""
+
+    def test_context_aware_reward_function(self) -> None:
+        """Test reward function that uses context."""
+
+        def context_multiplier(samples: np.ndarray, X: np.ndarray) -> np.ndarray:
+            # Multiply by first feature (e.g., age) - maintain same dimensions
+            # samples shape: (size, n_contexts), X shape: (n_contexts, n_features)
+            return samples * X[:, 0]  # Broadcasting: (1, 2) * (2,) -> (1, 2)
+
+        from bayesianbandits import NormalRegressor
+
+        arm = Arm(
+            0,
+            reward_function=context_multiplier,
+            learner=NormalRegressor(alpha=1, beta=1),
+        )
+        X = np.array([[2.0, 5.0], [3.0, 6.0]])
+
+        result = arm.sample(X, size=1)
+        # Should have shape (size, n_contexts) = (1, 2)
+        assert result.shape == (1, 2)
+
+    def test_traditional_reward_function_compatibility(self) -> None:
+        """Test that traditional reward functions still work."""
+        identity = lambda samples: samples
+
+        from bayesianbandits import NormalRegressor
+
+        arm = Arm(0, reward_function=identity, learner=NormalRegressor(alpha=1, beta=1))
+        X = np.array([[1.0, 2.0]])
+
+        result = arm.sample(X, size=1)
+        assert result.shape == (1, 1)
+
+    def test_accepts_context_detection(self) -> None:
+        """Test parameter detection utility."""
+        from bayesianbandits._arm import _accepts_context
+
+        traditional = lambda samples: samples
+        context_aware = lambda samples, X: samples * 2
+
+        assert not _accepts_context(traditional)
+        assert _accepts_context(context_aware)
+
+    def test_context_aware_with_complex_logic(self) -> None:
+        """Test complex context-aware reward function."""
+
+        def premium_user_reward(samples: np.ndarray, X: np.ndarray) -> np.ndarray:
+            """Higher rewards for premium users in certain contexts."""
+            age, income, premium_status = X[0, 0], X[0, 1], X[0, 2]
+
+            if premium_status and age > 35:
+                return samples * 2.0
+            elif income > 100000:
+                return samples * 1.5
+            else:
+                return samples
+
+        from bayesianbandits import NormalRegressor
+
+        arm = Arm(
+            0,
+            reward_function=premium_user_reward,
+            learner=NormalRegressor(alpha=1, beta=1),
+        )
+
+        # Test premium user over 35
+        X_premium = np.array([[40, 50000, 1]])  # age=40, income=50k, premium=1
+        result = arm.sample(X_premium, size=1)
+        assert result.shape == (1, 1)
+
+        # Test high income non-premium
+        X_high_income = np.array([[30, 150000, 0]])  # age=30, income=150k, premium=0
+        result = arm.sample(X_high_income, size=1)
+        assert result.shape == (1, 1)
+
+    def test_fixed_reward_based_on_context(self) -> None:
+        """Test fixed rewards based on context lookup."""
+
+        def fixed_reward_table(samples: np.ndarray, X: np.ndarray) -> np.ndarray:
+            """Fixed rewards based on context lookup."""
+            context_key = tuple(X[0])
+            reward_table = {
+                (25, 50000): 5.0,
+                (35, 75000): 8.0,
+                (45, 100000): 10.0,
+            }
+            default_reward = 3.0
+
+            reward_value = reward_table.get(context_key, default_reward)
+            return np.full_like(samples, reward_value)
+
+        from bayesianbandits import NormalRegressor
+
+        arm = Arm(
+            0,
+            reward_function=fixed_reward_table,
+            learner=NormalRegressor(alpha=1, beta=1),
+        )
+
+        # Test known context
+        X_known = np.array([[25, 50000]])
+        result = arm.sample(X_known, size=1)
+        assert result.shape == (1, 1)
+
+        # Test unknown context
+        X_unknown = np.array([[20, 30000]])
+        result = arm.sample(X_unknown, size=1)
+        assert result.shape == (1, 1)

--- a/tests/test_arm_column_featurizer.py
+++ b/tests/test_arm_column_featurizer.py
@@ -16,20 +16,20 @@ class TestArmColumnFeaturizer:
         """Test basic functionality with numpy arrays."""
         featurizer = ArmColumnFeaturizer()
         X = np.array([[1.0, 2.0], [3.0, 4.0]])
-        
+
         result = featurizer.transform(X, action_tokens=[0, 1, 2])
-        
+
         assert result.shape == (6, 3)  # 2 contexts * 3 arms, 2 + 1 features
         assert isinstance(result, np.ndarray)
-        
+
         # Check first arm (token 0)
         np.testing.assert_array_equal(result[:2, :2], X)
         np.testing.assert_array_equal(result[:2, 2], [0, 0])
-        
+
         # Check second arm (token 1)
         np.testing.assert_array_equal(result[2:4, :2], X)
         np.testing.assert_array_equal(result[2:4, 2], [1, 1])
-        
+
         # Check third arm (token 2)
         np.testing.assert_array_equal(result[4:6, :2], X)
         np.testing.assert_array_equal(result[4:6, 2], [2, 2])
@@ -38,11 +38,11 @@ class TestArmColumnFeaturizer:
         """Test with string action tokens."""
         featurizer = ArmColumnFeaturizer()
         X = np.array([[1.0, 2.0], [3.0, 4.0]])
-        
+
         result = featurizer.transform(X, action_tokens=["apple", "banana", "cherry"])
-        
+
         assert result.shape == (6, 3)
-        
+
         # Check that string tokens are properly repeated
         assert result[0, 2] == "apple"
         assert result[1, 2] == "apple"
@@ -55,11 +55,11 @@ class TestArmColumnFeaturizer:
         """Test with float action tokens."""
         featurizer = ArmColumnFeaturizer()
         X = np.array([[1.0, 2.0], [3.0, 4.0]])
-        
+
         result = featurizer.transform(X, action_tokens=[0.1, 0.5, 0.9])
-        
+
         assert result.shape == (6, 3)
-        
+
         # Check float tokens
         np.testing.assert_array_almost_equal(result[:2, 2], [0.1, 0.1])
         np.testing.assert_array_almost_equal(result[2:4, 2], [0.5, 0.5])
@@ -69,9 +69,9 @@ class TestArmColumnFeaturizer:
         """Test with empty action_tokens."""
         featurizer = ArmColumnFeaturizer()
         X = np.array([[1, 2], [3, 4]])
-        
+
         result = featurizer.transform(X, action_tokens=[])
-        
+
         assert result.shape == (0, 3)
         assert isinstance(result, np.ndarray)
 
@@ -79,15 +79,15 @@ class TestArmColumnFeaturizer:
         """Test with single context and multiple arms."""
         featurizer = ArmColumnFeaturizer()
         X = np.array([[5.0, 6.0]])  # Single context
-        
+
         result = featurizer.transform(X, action_tokens=[10, 20, 30])
-        
+
         assert result.shape == (3, 3)
-        
+
         # All rows should have same context features
         for i in range(3):
             np.testing.assert_array_equal(result[i, :2], [5.0, 6.0])
-        
+
         # Check arm tokens
         np.testing.assert_array_equal(result[:, 2], [10, 20, 30])
 
@@ -95,9 +95,9 @@ class TestArmColumnFeaturizer:
         """Test with list input for X."""
         featurizer = ArmColumnFeaturizer()
         X_list = [[1.0, 2.0], [3.0, 4.0]]
-        
+
         result = featurizer.transform(X_list, action_tokens=["a", "b"])
-        
+
         assert result.shape == (4, 3)
         assert isinstance(result, np.ndarray)
 
@@ -105,53 +105,47 @@ class TestArmColumnFeaturizer:
     def test_pandas_dataframe(self):
         """Test with pandas DataFrame input."""
         import pandas as pd
-        
+
         featurizer = ArmColumnFeaturizer()
-        X = pd.DataFrame({
-            'feature1': [1.0, 3.0],
-            'feature2': [2.0, 4.0]
-        })
-        
+        X = pd.DataFrame({"feature1": [1.0, 3.0], "feature2": [2.0, 4.0]})
+
         result = featurizer.transform(X, action_tokens=[0, 1, 2])
-        
+
         # Should return a DataFrame
         assert isinstance(result, pd.DataFrame)
         assert result.shape == (6, 3)
-        assert list(result.columns) == ['feature1', 'feature2', 'arm_token']
-        
+        assert list(result.columns) == ["feature1", "feature2", "arm_token"]
+
         # Check values
-        assert list(result['arm_token']) == [0, 0, 1, 1, 2, 2]
-        assert list(result['feature1']) == [1.0, 3.0, 1.0, 3.0, 1.0, 3.0]
-        assert list(result['feature2']) == [2.0, 4.0, 2.0, 4.0, 2.0, 4.0]
+        assert list(result["arm_token"]) == [0, 0, 1, 1, 2, 2]
+        assert list(result["feature1"]) == [1.0, 3.0, 1.0, 3.0, 1.0, 3.0]
+        assert list(result["feature2"]) == [2.0, 4.0, 2.0, 4.0, 2.0, 4.0]
 
     @pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")
     def test_pandas_empty_arms(self):
         """Test pandas DataFrame with empty arms."""
         import pandas as pd
-        
+
         featurizer = ArmColumnFeaturizer()
-        X = pd.DataFrame({
-            'feature1': [1.0, 3.0],
-            'feature2': [2.0, 4.0]
-        })
-        
+        X = pd.DataFrame({"feature1": [1.0, 3.0], "feature2": [2.0, 4.0]})
+
         result = featurizer.transform(X, action_tokens=[])
-        
+
         assert isinstance(result, pd.DataFrame)
         assert result.shape == (0, 3)
-        assert list(result.columns) == ['feature1', 'feature2', 'arm_token']
+        assert list(result.columns) == ["feature1", "feature2", "arm_token"]
         # Check dtypes are preserved
-        assert result['feature1'].dtype == X['feature1'].dtype
-        assert result['feature2'].dtype == X['feature2'].dtype
+        assert result["feature1"].dtype == X["feature1"].dtype
+        assert result["feature2"].dtype == X["feature2"].dtype
 
     def test_mixed_type_tokens(self):
         """Test with mixed type tokens (numpy converts to common type)."""
         featurizer = ArmColumnFeaturizer()
         X = np.array([[1.0, 2.0]])
-        
+
         # Mixed types in tokens - numpy will convert to strings
         result = featurizer.transform(X, action_tokens=[1, "two", 3.0])
-        
+
         assert result.shape == (3, 3)
         # When mixed types are provided, numpy converts all to strings
         assert str(result[0, 2]) == "1"
@@ -166,21 +160,23 @@ class TestArmColumnFeaturizerWithSklearn:
         """Test integration with sklearn ColumnTransformer."""
         from sklearn.compose import ColumnTransformer
         from sklearn.preprocessing import OneHotEncoder, StandardScaler
-        
+
         featurizer = ArmColumnFeaturizer()
         X = np.array([[1.0, 2.0], [3.0, 4.0]])
-        
+
         # Transform with discrete arm tokens
         X_with_arms = featurizer.transform(X, action_tokens=[0, 1, 2])
-        
+
         # Apply ColumnTransformer
-        transformer = ColumnTransformer([
-            ('context', StandardScaler(), [0, 1]),
-            ('arm', OneHotEncoder(sparse_output=False), [2])
-        ])
-        
+        transformer = ColumnTransformer(
+            [
+                ("context", StandardScaler(), [0, 1]),
+                ("arm", OneHotEncoder(sparse_output=False), [2]),
+            ]
+        )
+
         X_final = transformer.fit_transform(X_with_arms)
-        
+
         # Should have 2 scaled features + 3 one-hot features
         assert X_final.shape == (6, 5)
 
@@ -188,20 +184,22 @@ class TestArmColumnFeaturizerWithSklearn:
         """Test with PolynomialFeatures for continuous arms."""
         from sklearn.compose import ColumnTransformer
         from sklearn.preprocessing import PolynomialFeatures
-        
+
         featurizer = ArmColumnFeaturizer()
         X = np.array([[1.0, 2.0], [3.0, 4.0]])
-        
+
         # Transform with continuous arm values
         X_with_arms = featurizer.transform(X, action_tokens=[0.1, 0.5, 0.9])
-        
+
         # Apply polynomial features to arm column
-        transformer = ColumnTransformer([
-            ('context', 'passthrough', [0, 1]),
-            ('arm', PolynomialFeatures(degree=2, include_bias=False), [2])
-        ])
-        
+        transformer = ColumnTransformer(
+            [
+                ("context", "passthrough", [0, 1]),
+                ("arm", PolynomialFeatures(degree=2, include_bias=False), [2]),
+            ]
+        )
+
         X_final = transformer.fit_transform(X_with_arms)
-        
+
         # Should have 2 context features + 2 polynomial features (x, x^2)
         assert X_final.shape == (6, 4)

--- a/tests/test_batch_pull.py
+++ b/tests/test_batch_pull.py
@@ -61,9 +61,11 @@ def mock_model():
     """Create a mock model with sample method"""
     model = Mock()
     model.sample = Mock(
-        side_effect=lambda X, size=1: np.random.randn(size, X.shape[0])
-        if size > 1
-        else np.random.randn(X.shape[0])
+        side_effect=lambda X, size=1: (
+            np.random.randn(size, X.shape[0])
+            if size > 1
+            else np.random.randn(X.shape[0])
+        )
     )
     return model
 

--- a/tests/test_exp3a.py
+++ b/tests/test_exp3a.py
@@ -658,22 +658,25 @@ class TestEXP3ASampleWeight:
 
     def test_exp3a_top_k_with_zero_probabilities(self):
         """Test EXP3A top_k when some arms have zero probability due to extreme parameters."""
-        
+
         class FixedRewardArm(Arm):
             """Arm that returns fixed rewards for testing extreme probability scenarios."""
+
             def __init__(self, action_token: int, fixed_reward: float):
                 super().__init__(action_token, learner=NormalInverseGammaRegressor())
                 self.fixed_reward = fixed_reward
-            
-            def sample(self, X: NDArray[np.float64], size: int = 1) -> NDArray[np.float64]:
+
+            def sample(
+                self, X: NDArray[np.float64], size: int = 1
+            ) -> NDArray[np.float64]:
                 return np.full((size, len(X)), self.fixed_reward)
 
         # Create scenario with extreme reward differences
         arms = [
             FixedRewardArm(0, 100.0),  # High reward -> high probability
-            FixedRewardArm(1, 0.0),    # Low reward -> low/zero probability  
-            FixedRewardArm(2, 0.0),    # Low reward -> low/zero probability
-            FixedRewardArm(3, 0.0),    # Low reward -> low/zero probability
+            FixedRewardArm(1, 0.0),  # Low reward -> low/zero probability
+            FixedRewardArm(2, 0.0),  # Low reward -> low/zero probability
+            FixedRewardArm(3, 0.0),  # Low reward -> low/zero probability
         ]
 
         # Extreme parameters that cause zero probabilities for most arms
@@ -683,29 +686,29 @@ class TestEXP3ASampleWeight:
 
         # This should not raise "Fewer non-zero entries in p than size" ValueError
         result = agent.pull(X, top_k=3)
-        
+
         # Should return exactly 3 arms for the single context
         assert len(result) == 1  # One context
         assert len(result[0]) == 3  # Three arms selected
-        
+
         # Should include the high-probability arm (arm 0)
         selected_arms = result[0]
         assert 0 in selected_arms, "High-probability arm should be selected"
-        
+
         # Should have no duplicates
         assert len(set(selected_arms)) == 3, "Should have no duplicate arms"
-        
+
         # Test edge case where top_k equals number of arms
         result_all = agent.pull(X, top_k=4)
         assert len(result_all[0]) == 4
         assert set(result_all[0]) == {0, 1, 2, 3}
-        
+
         # Test with multiple contexts
         X_multi = np.array([[1.0], [2.0]])
         result_multi = agent.pull(X_multi, top_k=2)
         assert len(result_multi) == 2  # Two contexts
         assert all(len(context_result) == 2 for context_result in result_multi)
-        
+
         # Each context should include the high-probability arm
         for context_result in result_multi:
             assert 0 in context_result, "High-probability arm should be in each context"

--- a/tests/test_learner_pipeline.py
+++ b/tests/test_learner_pipeline.py
@@ -52,15 +52,14 @@ class TestLearnerPipelineInit:
         with pytest.raises(ValueError, match="Step names must be unique"):
             LearnerPipeline(
                 steps=[("dup", StandardScaler()), ("dup", StandardScaler())],
-                learner=mock_learner
+                learner=mock_learner,
             )
 
     def test_valid_initialization_with_transformers(self):
         """Test initialization with transformers."""
         mock_learner = MockLearner()
         pipeline = LearnerPipeline(
-            steps=[("scale", StandardScaler())],
-            learner=mock_learner
+            steps=[("scale", StandardScaler())], learner=mock_learner
         )
 
         assert len(pipeline.steps) == 1
@@ -84,8 +83,7 @@ class TestLearnerPipelineInit:
         """Test valid initialization."""
         mock_learner = MockLearner()
         pipeline = LearnerPipeline(
-            steps=[("scale", StandardScaler())],
-            learner=mock_learner
+            steps=[("scale", StandardScaler())], learner=mock_learner
         )
 
         assert len(pipeline.steps) == 1
@@ -102,7 +100,10 @@ class TestLearnerPipelineTransformers:
             return X * 2
 
         mock_learner = MockLearner()
-        pipeline = LearnerPipeline(steps=[("double", FunctionTransformer(double_transform))], learner=mock_learner)
+        pipeline = LearnerPipeline(
+            steps=[("double", FunctionTransformer(double_transform))],
+            learner=mock_learner,
+        )
 
         X = np.array([[1, 2], [3, 4]])
         y = np.array([1, 2])
@@ -144,7 +145,13 @@ class TestLearnerPipelineTransformers:
             return X * 2
 
         mock_learner = MockLearner()
-        pipeline = LearnerPipeline(steps=[("add", FunctionTransformer(add_one)), ("multiply", FunctionTransformer(multiply_two))], learner=mock_learner)
+        pipeline = LearnerPipeline(
+            steps=[
+                ("add", FunctionTransformer(add_one)),
+                ("multiply", FunctionTransformer(multiply_two)),
+            ],
+            learner=mock_learner,
+        )
 
         X = np.array([[1, 2]])
         y = np.array([1])
@@ -190,10 +197,12 @@ class TestLearnerPipelineTransformers:
     def test_transformer_not_fitted_error(self):
         """Test helpful error message when transformer is not fitted."""
         from sklearn.preprocessing import StandardScaler
-        
+
         mock_learner = MockLearner()
         # Create pipeline with unfitted transformer
-        pipeline = LearnerPipeline(steps=[("unfitted_scaler", StandardScaler())], learner=mock_learner)
+        pipeline = LearnerPipeline(
+            steps=[("unfitted_scaler", StandardScaler())], learner=mock_learner
+        )
 
         X = np.array([[1, 2], [3, 4]])
         y = np.array([1, 2])
@@ -218,7 +227,9 @@ class TestLearnerPipelineInterface:
         # Pre-fit the scaler for testing
         scaler = StandardScaler()
         scaler.fit(np.random.randn(100, 2))  # Fit on dummy data
-        self.pipeline = LearnerPipeline(steps=[("scale", scaler)], learner=self.mock_learner)
+        self.pipeline = LearnerPipeline(
+            steps=[("scale", scaler)], learner=self.mock_learner
+        )
 
     def test_sample_method(self):
         """Test sample method delegates correctly."""
@@ -286,8 +297,7 @@ class TestLearnerPipelineIntegration:
         scaler.fit(np.random.randn(50, 3))  # Fit on dummy data
 
         pipeline = LearnerPipeline(
-            steps=[("scale", scaler)],
-            learner=NormalRegressor(alpha=1.0, beta=1.0)
+            steps=[("scale", scaler)], learner=NormalRegressor(alpha=1.0, beta=1.0)
         )
 
         # Generate training data
@@ -335,7 +345,7 @@ class TestLearnerPipelineIntegration:
 
         shared_learner: LearnerPipeline[NDArray[np.float64]] = LearnerPipeline(
             steps=[("scale", scaler)],  # Pre-fitted scaler
-            learner=NormalRegressor(alpha=1.0, beta=1.0)
+            learner=NormalRegressor(alpha=1.0, beta=1.0),
         )
 
         # Create arms that all share this learner
@@ -375,7 +385,7 @@ class TestLearnerPipelineIntegration:
 
         pipeline = LearnerPipeline(
             steps=[("scale", scaler), ("pca", pca)],
-            learner=NormalRegressor(alpha=0.1, beta=1.0)
+            learner=NormalRegressor(alpha=0.1, beta=1.0),
         )
 
         # High-dimensional data
@@ -419,7 +429,9 @@ class TestLearnerPipelineProperties:
 
     def test_len_method(self):
         """Test __len__ method."""
-        pipeline = LearnerPipeline(steps=[("scale", StandardScaler())], learner=MockLearner())
+        pipeline = LearnerPipeline(
+            steps=[("scale", StandardScaler())], learner=MockLearner()
+        )
         assert len(pipeline) == 1  # Only transformer steps
 
     def test_getitem_method(self):
@@ -436,7 +448,9 @@ class TestLearnerPipelineProperties:
 
     def test_repr_method(self):
         """Test __repr__ method."""
-        pipeline = LearnerPipeline(steps=[("scale", StandardScaler())], learner=MockLearner())
+        pipeline = LearnerPipeline(
+            steps=[("scale", StandardScaler())], learner=MockLearner()
+        )
 
         repr_str = repr(pipeline)
         assert "LearnerPipeline" in repr_str

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "bayesianbandits"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
Custom reward functions that have an `X` parameter in their signature will be provided the context at inference-time. This allows more complex, business-logic sensitive reward computations. 

This is important when the context actually informs the reward, i.e. in dynamic pricing, the geography also encodes information about local taxes, etc. These are not necessarily important for the model's target, but they are important for the reward function to determine the expected value of each arm for a given context. 

```python
  # Before: Reward functions only see model predictions
  def traditional_reward(samples):
      return samples  # Just the predicted value

  # After: Reward functions can access context for business logic
  def revenue_reward(samples, X):
      # samples: predicted click-through rate
      # X: context containing user features
      # Business logic: different revenue per click by user segment
      user_segment = X[:, 2]  # e.g., 0=free, 1=premium
      revenue_per_click = np.where(user_segment == 1, 5.0, 1.0)
      return samples * revenue_per_click
```