### PR TITLE
Update test matrix to sklearn 1.7.2

### DIFF
--- a/.github/workflows/matrix_test.yml
+++ b/.github/workflows/matrix_test.yml
@@ -39,13 +39,13 @@ jobs:
             sklearn-version: '1.6.1'
 
           - python-version: '3.10'
-            sklearn-version: '1.7.1'
+            sklearn-version: '1.7.2'
           - python-version: '3.11'
-            sklearn-version: '1.7.1'
+            sklearn-version: '1.7.2'
           - python-version: '3.12'
-            sklearn-version: '1.7.1'
+            sklearn-version: '1.7.2'
           - python-version: '3.13'
-            sklearn-version: '1.7.1'  
+            sklearn-version: '1.7.2'  
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ While the API is still evolving, this library is already being used in productio
 
 ## Compatibility
 
-`bayesianbandits` is tested with Python 3.10, 3.11, 3.12 and 3.13 with `scikit-learn` 1.4.2, 1.5.2, 1.6.1, 1.7.1.
+`bayesianbandits` is tested with Python 3.10, 3.11, 3.12 and 3.13 with `scikit-learn` 1.4.2, 1.5.2, 1.6.1, 1.7.2.
 
 ## Getting Started
 

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "bayesianbandits"
-version = "1.1.0"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
- Replace sklearn 1.7.1 with 1.7.2 in CI test matrix
- Update README compatibility section to reflect sklearn 1.7.2 testing