### PR TITLE
Upgrade scikit-sparse from 0.4.x to 0.5.0

### DIFF
--- a/bayesianbandits/_estimators.py
+++ b/bayesianbandits/_estimators.py
@@ -1119,9 +1119,9 @@ class NormalInverseGammaRegressor(NormalRegressor):
         if self.sparse:
             # Update the mean vector
             if solver == SparseSolver.CHOLMOD:
-                from sksparse.cholmod import cholesky as cholmod_cholesky
+                from sksparse.cholmod import cho_factor as cholmod_cho_factor
 
-                m_n = cholmod_cholesky(csc_matrix(V_n))(
+                m_n = cholmod_cho_factor(csc_matrix(V_n)).solve(
                     prior_decay * self.cov_inv_ @ self.coef_ + X.T @ y_weighted
                 )
             else:

--- a/bayesianbandits/_gaussian.py
+++ b/bayesianbandits/_gaussian.py
@@ -65,9 +65,9 @@ def solve_precision_weighted_mean(
     """Solve precision @ mu = eta for mu."""
     if sparse:
         if solver == SparseSolver.CHOLMOD:
-            from sksparse.cholmod import cholesky as cholmod_cholesky
+            from sksparse.cholmod import cho_factor as cholmod_cho_factor
 
-            return cholmod_cholesky(csc_matrix(precision))(eta)
+            return cholmod_cho_factor(csc_matrix(precision)).solve(eta)
         else:
             lu = splu(
                 precision,

--- a/bayesianbandits/_sparse_bayesian_linear_regression.py
+++ b/bayesianbandits/_sparse_bayesian_linear_regression.py
@@ -32,7 +32,7 @@ from scipy.stats._multivariate import _squeeze_output  # type: ignore
 use_solver(useUmfpack=False)
 
 try:
-    from sksparse.cholmod import cholesky as cholmod_cholesky  # type: ignore
+    from sksparse.cholmod import cho_factor as cholmod_cho_factor  # type: ignore
 
     use_cholmod = True
 except ImportError:
@@ -55,7 +55,7 @@ else:
     solver = SparseSolver.SUPERLU
 
 if TYPE_CHECKING:
-    from sksparse.cholmod import cholesky as cholmod_cholesky  # type: ignore
+    from sksparse.cholmod import cho_factor as cholmod_cho_factor  # type: ignore
 
     # This helps Pylance understand that solver can be either SparseSolver.SUPERLU or SparseSolver.CHOLMOD.
     # For some reason, without this cast, it thinks solver is always SparseSolver.SUPERLU.
@@ -76,10 +76,11 @@ class SparseMatrixProtocol(Protocol[SM, SM_T]):
 
 
 class SparseCholeskyDecompositionOBject(Protocol):
-    def solve_Lt(
-        self, b: NDArray[np.float64], use_LDLt_decomposition: bool
+    @property
+    def perm(self) -> NDArray[np.int_]: ...
+    def solve(
+        self, b: NDArray[np.float64], system: str = ...
     ) -> NDArray[np.float64]: ...
-    def apply_Pt(self, x: NDArray[np.float64]) -> NDArray[np.float64]: ...
 
 
 class SuperLUObject(Protocol):
@@ -130,7 +131,7 @@ class CovViaSparsePrecision(Covariance):
     random variable X has the precision matrix P.
 
     If using suitesparse, this is done by computing the Cholesky decomposition
-    of P, which may or may not be permuted. CHOLMOD's solve_Lt solves W^T X = Z
+    of P, which may or may not be permuted. CHOLMOD's solve(Z, system="Lt") solves W^T X = Z
     to color X with the permuted precision matrix P'. This P' is the precision
     matrix we would have gotten if we'd reordered the features of the training
     data to be in the order given by the permutation. Therefore, we need only
@@ -156,7 +157,7 @@ class CovViaSparsePrecision(Covariance):
 
         if self.solver == SparseSolver.CHOLMOD:
             self._W: LUObject | SparseCholeskyDecompositionOBject = cast(
-                SparseCholeskyDecompositionOBject, cholmod_cholesky(csc_matrix(prec))
+                SparseCholeskyDecompositionOBject, cholmod_cho_factor(csc_matrix(prec))
             )
 
         else:
@@ -199,7 +200,8 @@ class CovViaSparsePrecision(Covariance):
     def colorize_solve(self) -> Callable[[NDArray[np.float64]], NDArray[np.float64]]:
         w: LUObject | SparseCholeskyDecompositionOBject = self._W
         if self._is_cholmod(w):
-            return lambda x: w.apply_Pt(w.solve_Lt(x, False))
+            inv_perm = np.argsort(w.perm)
+            return lambda x: w.solve(x, system="Lt")[inv_perm]
         else:
             assert isinstance(w, LUObject)
             return lambda x: w.solve_system(x)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
     "pandas>=2.2.3",
     "pyright==1.1.402",
 ]
-cholmod = ["scikit-sparse>=0.4.15,<0.5"]
+cholmod = ["scikit-sparse>=0.5.0,<0.6"]
 
 [tool.uv]
 default-groups = [


### PR DESCRIPTION
## Summary
- Upgrade `scikit-sparse` dependency from `>=0.4.15,<0.5` to `>=0.5.0,<0.6`
- Adapt all CHOLMOD call sites to the new 0.5.0 API (`cho_factor`, `.solve()`, `.perm`)
- Update the `SparseCholeskyDecompositionOBject` protocol to match the new interface

## Changes
| Old (0.4.x) | New (0.5.0) |
|---|---|
| `cholesky(A)` → `Factor` | `cho_factor(A)` → `CholeskyFactor` |
| `Factor(b)` (callable) | `CholeskyFactor.solve(b)` |
| `Factor.solve_Lt(b, False)` | `CholeskyFactor.solve(b, system="Lt")` |
| `Factor.apply_Pt(x)` | `x[np.argsort(factor.perm)]` |

## Test plan
- [x] All 1670 tests pass, no new warnings
- [x] Sparse-specific tests (`test_sparse_bayesian_linear_regression.py`) pass with both CHOLMOD and SuperLU solvers
- [x] Solver detection tests (`test_solver_detection.py`) pass