### PR TITLE
Replace CovViaSparsePrecision with type-safe SparseFactor abstraction

### DIFF
--- a/bayesianbandits/_estimators.py
+++ b/bayesianbandits/_estimators.py
@@ -7,8 +7,7 @@ from typing import Any, Callable, Dict, Optional, TypeVar, Union, cast
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 from scipy.linalg import cholesky, solve
-from scipy.sparse import csc_array, csc_matrix, diags, eye
-from scipy.sparse.linalg import splu
+from scipy.sparse import csc_array, diags, eye
 from scipy.special import expit
 from scipy.stats import (
     Covariance,
@@ -36,11 +35,12 @@ from ._gaussian import (
 )
 from ._np_utils import groupby_array
 from ._sparse_bayesian_linear_regression import (
-    CovViaSparsePrecision,
-    SparseSolver,
-    multivariate_normal_sample_from_sparse_covariance,
-    multivariate_t_sample_from_sparse_covariance,
-    solver,
+    CholmodSparseFactor,
+    SparseFactor,
+    SuperLUSparseFactor,
+    create_sparse_factor,
+    multivariate_normal_sample_from_sparse_precision,
+    multivariate_t_sample_from_sparse_precision,
 )
 
 Params = ParamSpec("Params")
@@ -709,12 +709,13 @@ class NormalRegressor(BaseEstimator, RegressorMixin):
             self.cov_inv_ = np.eye(self.n_features_) * self.alpha
 
     @cached_property
-    def cov_(self) -> Covariance:
+    def cov_(self) -> Union[Covariance, SparseFactor]:
         """
         The covariance matrix of the model.
         """
         if self.sparse:
-            return CovViaSparsePrecision(self.cov_inv_, solver=solver)  # type: ignore
+            assert isinstance(self.cov_inv_, csc_array)
+            return create_sparse_factor(self.cov_inv_)
         else:
             cov = solve(
                 self.cov_inv_,
@@ -854,10 +855,12 @@ class NormalRegressor(BaseEstimator, RegressorMixin):
         )
 
         if self.sparse:
+            cov = self.cov_
+            assert isinstance(cov, (CholmodSparseFactor, SuperLUSparseFactor))
             samples = np.atleast_1d(
-                multivariate_normal_sample_from_sparse_covariance(
+                multivariate_normal_sample_from_sparse_precision(
                     self.coef_,
-                    self.cov_,
+                    cov,
                     size=size,
                     random_state=self.random_state_,
                 )
@@ -1118,22 +1121,10 @@ class NormalInverseGammaRegressor(NormalRegressor):
 
         if self.sparse:
             # Update the mean vector
-            if solver == SparseSolver.CHOLMOD:
-                from sksparse.cholmod import cho_factor as cholmod_cho_factor
-
-                m_n = cholmod_cho_factor(csc_matrix(V_n)).solve(
-                    prior_decay * self.cov_inv_ @ self.coef_ + X.T @ y_weighted
-                )
-            else:
-                lu = splu(
-                    V_n,
-                    diag_pivot_thresh=0,
-                    permc_spec="MMD_AT_PLUS_A",
-                    options=dict(SymmetricMode=True),
-                )
-                m_n = lu.solve(
-                    prior_decay * self.cov_inv_ @ self.coef_ + X.T @ y_weighted,
-                )
+            assert isinstance(V_n, csc_array)
+            m_n = create_sparse_factor(V_n).solve(
+                prior_decay * self.cov_inv_ @ self.coef_ + X.T @ y_weighted
+            )
         else:
             # Update the mean vector
             m_n = solve(
@@ -1162,10 +1153,11 @@ class NormalInverseGammaRegressor(NormalRegressor):
         self.b_ = b_n
 
     @cached_property
-    def shape_(self) -> Covariance:
+    def shape_(self) -> Union[Covariance, SparseFactor]:
         shape_inv_ = self.cov_inv_ * (self.a_ / self.b_)
         if self.sparse:
-            return CovViaSparsePrecision(shape_inv_)  # type: ignore
+            assert isinstance(shape_inv_, csc_array)
+            return create_sparse_factor(shape_inv_)
         else:
             shape = solve(
                 shape_inv_,
@@ -1195,18 +1187,22 @@ class NormalInverseGammaRegressor(NormalRegressor):
 
         # Sparse sampling is not supported by scipy, so we use our own implementation
         if self.sparse:
-            samples = multivariate_t_sample_from_sparse_covariance(
-                self.coef_, self.shape_, df, size, self.random_state_
+            shape = self.shape_
+            assert isinstance(shape, (CholmodSparseFactor, SuperLUSparseFactor))
+            samples = multivariate_t_sample_from_sparse_precision(
+                self.coef_, shape, df, size, self.random_state_
             )
 
         else:
+            shape = self.shape_
+            assert isinstance(shape, Covariance)
             _, loc, _, df = multivariate_t._process_parameters(
-                self.coef_, self.shape_.covariance, df
+                self.coef_, shape.covariance, df
             )
 
             samples = multivariate_t_sample_from_covariance(
                 loc,
-                self.shape_,
+                shape,
                 df,
                 size,
                 self.random_state_,
@@ -1428,14 +1424,15 @@ class BayesianGLM(BaseEstimator, RegressorMixin):
         return super().__getstate__()  # type: ignore
 
     @cached_property
-    def cov_(self) -> Covariance:
+    def cov_(self) -> Union[Covariance, SparseFactor]:
         """Posterior covariance matrix (cached).
 
         Warning: O(p³) computation and O(p²) memory. For high dimensions,
         consider using only the diagonal or avoiding this property entirely.
         """
         if self.sparse:
-            return CovViaSparsePrecision(self.cov_inv_, solver=solver)  # type: ignore
+            assert isinstance(self.cov_inv_, csc_array)
+            return create_sparse_factor(self.cov_inv_)
         else:
             cov = solve(
                 self.cov_inv_,
@@ -1611,8 +1608,10 @@ class BayesianGLM(BaseEstimator, RegressorMixin):
 
         # Sample parameters from posterior
         if self.sparse:
-            param_samples = multivariate_normal_sample_from_sparse_covariance(
-                self.coef_, self.cov_, size=size, random_state=self.random_state_
+            cov = self.cov_
+            assert isinstance(cov, (CholmodSparseFactor, SuperLUSparseFactor))
+            param_samples = multivariate_normal_sample_from_sparse_precision(
+                self.coef_, cov, size=size, random_state=self.random_state_
             )
         else:
             from scipy.stats import multivariate_normal

--- a/bayesianbandits/_gaussian.py
+++ b/bayesianbandits/_gaussian.py
@@ -3,11 +3,9 @@ from typing import Literal, NamedTuple, Optional, Protocol, Union, cast
 
 import numpy as np
 from numpy.typing import NDArray
-from scipy.sparse import csc_array, csc_matrix
-from scipy.sparse.linalg import splu
+from scipy.sparse import csc_array
 from scipy.special import expit
 
-from ._sparse_bayesian_linear_regression import SparseSolver, solver
 
 # Type aliases
 ArrayType = Union[NDArray[np.float64], csc_array]
@@ -64,23 +62,10 @@ def solve_precision_weighted_mean(
 ) -> NDArray[np.float64]:
     """Solve precision @ mu = eta for mu."""
     if sparse:
-        if solver == SparseSolver.CHOLMOD:
-            from sksparse.cholmod import cho_factor as cholmod_cho_factor
+        from ._sparse_bayesian_linear_regression import create_sparse_factor
 
-            return cholmod_cho_factor(csc_matrix(precision)).solve(eta)
-        else:
-            lu = splu(
-                precision,
-                # These two settings tell SuperLU that we're decomposing a Hermitian
-                # positive-definite matrix, so we only want to pivot on the diagonal.
-                # This preserves the sparsity of the matrix better than the default,
-                # which allows for off-diagonal pivoting. See SuperLU User Guide
-                # for more details.
-                diag_pivot_thresh=0.0,
-                permc_spec="MMD_AT_PLUS_A",
-                options=dict(SymmetricMode=True),
-            )
-            return lu.solve(eta)
+        assert isinstance(precision, csc_array)
+        return create_sparse_factor(precision).solve(eta)
     else:
         from scipy.linalg import solve
 

--- a/bayesianbandits/_sparse_bayesian_linear_regression.py
+++ b/bayesianbandits/_sparse_bayesian_linear_regression.py
@@ -1,16 +1,10 @@
 import os
 from dataclasses import dataclass
 from enum import Enum
-from functools import cached_property
 from typing import (
     TYPE_CHECKING,
-    Callable,
-    Final,
+    Any,
     Literal,
-    Protocol,
-    Tuple,
-    TypeGuard,
-    TypeVar,
     Union,
     cast,
 )
@@ -22,12 +16,9 @@ from scipy.sparse import (  # type: ignore  # type: ignore
     csc_matrix,
     csr_matrix,
     diags,  # type: ignore
-    eye,  # type: ignore
     issparse,  # type: ignore
 )
 from scipy.sparse.linalg import splu, spsolve, use_solver  # type: ignore
-from scipy.stats import Covariance  # type: ignore
-from scipy.stats._multivariate import _squeeze_output  # type: ignore
 
 use_solver(useUmfpack=False)
 
@@ -63,176 +54,77 @@ if TYPE_CHECKING:
         Literal[SparseSolver.SUPERLU, SparseSolver.CHOLMOD], solver
     )  # type: ignore
 
-SM = TypeVar("SM", bound="Union[csc_matrix, csr_matrix]")
-SM_T = TypeVar("SM_T", bound="Union[csc_matrix, csr_matrix]")
 
+@dataclass
+class CholmodSparseFactor:
+    """Wraps a CHOLMOD factor for solving and sampling."""
 
-class SparseMatrixProtocol(Protocol[SM, SM_T]):
-    shape: tuple[int, int]
-    T: SM_T
+    _factor: Any  # sksparse.cholmod.Factor (C extension, no useful type)
+    _precision: csc_array
 
-    def dot(self, other: Union[SM, NDArray[np.float64]]) -> SM: ...
-    def diagonal(self) -> NDArray[np.float64]: ...
+    def solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
+        return self._factor.solve(b)
 
-
-class SparseCholeskyDecompositionOBject(Protocol):
-    @property
-    def perm(self) -> NDArray[np.int_]: ...
-    def solve(
-        self, b: NDArray[np.float64], system: str = ...
-    ) -> NDArray[np.float64]: ...
-
-
-class SuperLUObject(Protocol):
-    L: SparseMatrixProtocol[csr_matrix, csc_matrix]
-    U: SparseMatrixProtocol[csr_matrix, csc_matrix]
-    perm_r: NDArray[np.int_]
-    perm_c: NDArray[np.int_]
+    def colorize(self, z: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
+        """Solve L^T x = z, undo permutation."""
+        inv_perm = np.argsort(self._factor.perm)
+        return self._factor.solve(z, system="Lt")[inv_perm]
 
 
 @dataclass
-class LUObject:
-    L: SparseMatrixProtocol[csr_matrix, csc_matrix]
-    Pr: SparseMatrixProtocol[csc_matrix, csr_matrix]
+class SuperLUSparseFactor:
+    """Wraps SuperLU decomposition for solving and sampling."""
 
-    def solve_system(self, x: NDArray[np.float64]) -> NDArray[np.float64]:
-        return cast(NDArray[np.float64], self.Pr.T @ spsolve(self.L.T, x))
+    _L: csr_matrix
+    _Pr: csc_matrix
+    _precision: csc_array
+
+    def solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
+        return cast(NDArray[np.float64], spsolve(self._precision, b))
+
+    def colorize(self, z: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
+        """Solve L^T x = z, undo permutation."""
+        return cast(NDArray[np.float64], self._Pr.T @ spsolve(self._L.T, z))
 
 
-class CovViaSparsePrecision(Covariance):
-    """Covariance class for sparse precision matrices.
+SparseFactor = CholmodSparseFactor | SuperLUSparseFactor
 
-    Parameters
-    ----------
-    prec : csc_array
-        Sparse precision matrix.
-    use_suitesparse : bool, optional
-        Whether to use the sksparse.cholmod module for solving linear systems.
-        If False, use scipy.sparse.linalg.splu instead. Default is True if
-        sksparse.cholmod is installed, False otherwise.
 
-    Raises
-    ------
-    ValueError
-        If prec is not a sparse array.
-    ValueError
-        If prec is not symmetric.
-
-    Notes
-    -----
-    This class is used to colorize samples from a standard normal distribution
-    with a sparse precision matrix. The precision matrix is assumed to be
-    positive-definite, because our Bayesian linear regression models always
-    have positive-definite precision matrices (due to the prior).
-
-    A coloring transform from a precision matrix is performed by first finding
-    a factor W such that W W^T = P. Then, the colorizing transform is given by
-    W^T X = Z, where Z is a standard normal random variable. The resulting
-    random variable X has the precision matrix P.
-
-    If using suitesparse, this is done by computing the Cholesky decomposition
-    of P, which may or may not be permuted. CHOLMOD's solve(Z, system="Lt") solves W^T X = Z
-    to color X with the permuted precision matrix P'. This P' is the precision
-    matrix we would have gotten if we'd reordered the features of the training
-    data to be in the order given by the permutation. Therefore, we need only
-    apply the inverse permutation to X to get samples colored with our actual
-    precision matrix P.
-
-    If not using suitesparse, this is done by computing the LU decomposition
-    using SuperLU. By telling SuperLU that the matrix is symmetric by setting
-    options=dict(SymmetricMode=True), diag_pivot_thresh=0, and
-    permc_spec="MMD_AT_PLUS_A", we can prevent partial pivoting and get a
-    symmetric factorization L L^T = P', where P' is some permutation of P.
-    L^T X = Z is solved to color X with the permuted precision matrix P', same
-    as with suitesparse. The inverse permutation is applied to X to get samples
-    colored with the original precision matrix P.
-    """
-
-    def __init__(self, prec: csc_array, solver: SparseSolver = solver):
-        if not issparse(prec):
-            raise TypeError("prec must be a sparse array")
-
-        self.solver: Final[SparseSolver] = solver
-        self._precision: Final[csc_array] = prec
-
-        if self.solver == SparseSolver.CHOLMOD:
-            self._W: LUObject | SparseCholeskyDecompositionOBject = cast(
-                SparseCholeskyDecompositionOBject, cholmod_cho_factor(csc_matrix(prec))
-            )
-
-        else:
-            # Tells SuperLU that we have a symmetric matrix and we only want to pivot on the diagonal
-            splu_ = cast(
-                SuperLUObject,
-                splu(
-                    prec,
-                    diag_pivot_thresh=0,
-                    permc_spec="MMD_AT_PLUS_A",
-                    options=dict(SymmetricMode=True),
-                ),
-            )
-            if (splu_.perm_r != splu_.perm_c).any():
-                raise ValueError("W must be symmetric")
-
-            self._W = LUObject(  # type: ignore
-                L=cast(
-                    SparseMatrixProtocol[csr_matrix, csc_matrix],
-                    splu_.L.dot(diags(np.sqrt(splu_.U.diagonal()))),  # type: ignore
-                ),
-                Pr=cast(
-                    SparseMatrixProtocol[csc_matrix, csr_matrix],
-                    csc_matrix(
-                        (
-                            np.ones(splu_.L.shape[0]),
-                            (splu_.perm_r, np.arange(splu_.L.shape[0])),
-                        )
-                    ),
-                ),
-            )
-
-        self._rank = cast(Tuple[int, ...], prec.shape)[
-            -1
-        ]  # must be full rank for cholesky
-        self._shape = prec.shape
-        self._allow_singular = False
-
-    @property
-    def colorize_solve(self) -> Callable[[NDArray[np.float64]], NDArray[np.float64]]:
-        w: LUObject | SparseCholeskyDecompositionOBject = self._W
-        if self._is_cholmod(w):
-            inv_perm = np.argsort(w.perm)
-            return lambda x: w.solve(x, system="Lt")[inv_perm]
-        else:
-            assert isinstance(w, LUObject)
-            return lambda x: w.solve_system(x)
-
-    @cached_property
-    def _covariance(self) -> csc_array:
-        prec_shape: Tuple[int, ...] = cast(Tuple[int, ...], self._precision.shape)
-        return cast(
-            csc_array, spsolve(self._precision, eye(prec_shape[0], format="csc"))
+def create_sparse_factor(
+    precision: csc_array, solver: Union[SparseSolver, None] = None
+) -> SparseFactor:
+    """Create a SparseFactor from a precision matrix."""
+    if solver is None:
+        solver = globals()["solver"]
+    if not issparse(precision):
+        raise TypeError("precision must be a sparse array")
+    if solver == SparseSolver.CHOLMOD:
+        return CholmodSparseFactor(
+            _factor=cholmod_cho_factor(csc_matrix(precision)),
+            _precision=precision,
         )
+    else:
+        splu_ = splu(
+            precision,
+            diag_pivot_thresh=0,
+            permc_spec="MMD_AT_PLUS_A",
+            options=dict(SymmetricMode=True),
+        )
+        if (splu_.perm_r != splu_.perm_c).any():
+            raise ValueError("Matrix must be symmetric")
+        L = splu_.L.dot(diags(np.sqrt(splu_.U.diagonal())))
+        Pr = csc_matrix(
+            (
+                np.ones(splu_.L.shape[0]),
+                (splu_.perm_r, np.arange(splu_.L.shape[0])),
+            )
+        )
+        return SuperLUSparseFactor(_L=L, _Pr=Pr, _precision=precision)
 
-    def _whiten(self, x: NDArray[np.float64]) -> NDArray[np.float64]:
-        raise NotImplementedError("Not implemented for sparse matrices")
 
-    def _colorize(self, x: NDArray[np.float64]) -> NDArray[np.float64]:
-        samples = self.colorize_solve(x.T).T
-        # csc_arrray and csc_matrix have different behavior, so CHOLMOD doesn't
-        # auto-squeeze the output. We do it here.
-        if samples.shape[0] == 1:
-            return samples[0]
-        return samples
-
-    def _is_cholmod(
-        self, obj: SparseCholeskyDecompositionOBject | LUObject
-    ) -> TypeGuard[SparseCholeskyDecompositionOBject]:
-        return self.solver == SparseSolver.CHOLMOD
-
-
-def multivariate_normal_sample_from_sparse_covariance(
+def multivariate_normal_sample_from_sparse_precision(
     mean: Union[csc_array, NDArray[np.float64], None],
-    cov: Covariance,
+    factor: SparseFactor,
     size: int = 1,
     random_state: Union[int, None, np.random.Generator] = None,
 ) -> NDArray[np.float64]:
@@ -244,8 +136,8 @@ def multivariate_normal_sample_from_sparse_covariance(
     ----------
     mean : array_like, optional
         Mean of the distribution. Default is 0.
-    prec : array_like
-        Precision matrix of the distribution. Ideally a csc sparse array.
+    factor : SparseFactor
+        Factored precision matrix.
     size : int or tuple of ints, optional
         Given a shape of, for example, (m,n,k), m*n*k samples are generated,
         and packed in an m-by-n-by-k arrangement. Because each sample is
@@ -264,28 +156,20 @@ def multivariate_normal_sample_from_sparse_covariance(
         shape is (N,).
 
     """
-    # Set the random state
     rng = np.random.default_rng(random_state)
-
-    # Compute size from the shape of Q plus the size parameter
-    gen_size = cast(Tuple[int, int], (size,) + (cov.shape[-1],))  # type: ignore
-
-    # Sample Z from a standard multivariate normal distribution
-    _Z = rng.standard_normal(gen_size)
-
-    # Colorize Z
-    _y: NDArray[np.float64] = cast(NDArray[np.float64], cov.colorize(_Z))  # type: ignore
-
-    # Add the mean vector to each sample if provided
+    n_features = cast(tuple[int, int], factor._precision.shape)[0]
+    _Z = rng.standard_normal((size, n_features))
+    samples = factor.colorize(_Z.T).T
+    if samples.shape[0] == 1:
+        samples = samples[0]
     if mean is not None:
-        _y += mean  # type: ignore
+        samples = samples + mean
+    return samples
 
-    return cast(NDArray[np.float64], _y)
 
-
-def multivariate_t_sample_from_sparse_covariance(
+def multivariate_t_sample_from_sparse_precision(
     loc: Union[csc_array, NDArray[np.float64], None],
-    shape: Covariance,
+    factor: SparseFactor,
     df: float = 1.0,
     size: int = 1,
     random_state: Union[int, None, np.random.Generator] = None,
@@ -298,8 +182,8 @@ def multivariate_t_sample_from_sparse_covariance(
     ----------
     loc : array_like
         Mean of the distribution.
-    shape_inv_ : array_like
-        Inverse of the shape matrix of the distribution. Ideally a csc sparse array.
+    factor : SparseFactor
+        Factored precision (inverse shape) matrix.
     df : int or float, optional
         Degrees of freedom of the distribution. Default is 1.
     size : int or tuple of ints, optional
@@ -321,18 +205,18 @@ def multivariate_t_sample_from_sparse_covariance(
 
 
     """
-
-    # Set the random state
     rng = np.random.default_rng(random_state)
 
     x = rng.chisquare(df, size) / df
 
-    z = multivariate_normal_sample_from_sparse_covariance(
-        mean=None, cov=shape, size=size, random_state=random_state
+    z = multivariate_normal_sample_from_sparse_precision(
+        mean=None, factor=factor, size=size, random_state=random_state
     )
     if loc is None:
         loc = np.zeros_like(z)
     samples = cast(NDArray[np.float64], loc + z / np.sqrt(x)[..., None])
+    from scipy.stats._multivariate import _squeeze_output  # type: ignore
+
     samples = _squeeze_output(samples)
 
     return samples

--- a/tests/test_bayesian_glm.py
+++ b/tests/test_bayesian_glm.py
@@ -18,7 +18,7 @@ from bayesianbandits._sparse_bayesian_linear_regression import SparseSolver
 )
 def suitesparse_envvar(request):
     """Test with different sparse solvers."""
-    with mock.patch("bayesianbandits._gaussian.solver", request.param):
+    with mock.patch("bayesianbandits._sparse_bayesian_linear_regression.solver", request.param):
         yield
 
 
@@ -471,7 +471,7 @@ def test_bayesian_glm_serialization_after_sample(binary_data, sparse: bool) -> N
     )
     clf.fit(X_fit, y)
 
-    # Access cov_ (creates CovViaSparsePrecision with C objects for sparse)
+    # Access cov_ (creates SparseFactor with C objects for sparse)
     _ = clf.cov_
     # Also sample, which accesses cov_ internally
     clf.sample(X_fit[:5], size=5)

--- a/tests/test_normal_estimators.py
+++ b/tests/test_normal_estimators.py
@@ -26,7 +26,7 @@ suitespare_envvar_params = [
 )
 def suitesparse_envvar(request):
     """Allows running test suite with and without CHOLMOD."""
-    with mock.patch("bayesianbandits._estimators.solver", request.param):
+    with mock.patch("bayesianbandits._sparse_bayesian_linear_regression.solver", request.param):
         yield
 
 

--- a/tests/test_sparse_bayesian_linear_regression.py
+++ b/tests/test_sparse_bayesian_linear_regression.py
@@ -10,25 +10,25 @@ from scipy.stats import Covariance, multivariate_normal, multivariate_t
 
 from bayesianbandits._estimators import multivariate_t_sample_from_covariance
 from bayesianbandits._sparse_bayesian_linear_regression import (
-    CovViaSparsePrecision,
     SparseSolver,
-    multivariate_normal_sample_from_sparse_covariance,
-    multivariate_t_sample_from_sparse_covariance,
+    create_sparse_factor,
+    multivariate_normal_sample_from_sparse_precision,
+    multivariate_t_sample_from_sparse_precision,
 )
 
 
 @pytest.mark.parametrize("solver", [SparseSolver.SUPERLU, SparseSolver.CHOLMOD])
 @pytest.mark.parametrize("size", [1, 10])
-def test_multivariate_normal_sample_from_sparse_covariance_ill_conditioned_matrices(
+def test_multivariate_normal_sample_from_sparse_precision_ill_conditioned_matrices(
     size, solver
 ):
     this_file_path = Path(__file__)
     test_data_dir = this_file_path.parent / "ill_conditioned_matrices"
     for file_path in test_data_dir.glob("*"):
         sparse_array = joblib.load(file_path)
-        cov = CovViaSparsePrecision(sparse_array, solver=solver)
-        samples = multivariate_normal_sample_from_sparse_covariance(
-            mean=None, cov=cov, size=size
+        factor = create_sparse_factor(sparse_array, solver=solver)
+        samples = multivariate_normal_sample_from_sparse_precision(
+            mean=None, factor=factor, size=size
         )
         if size != 1:
             assert samples.shape == (size, sparse_array.shape[0])
@@ -36,7 +36,7 @@ def test_multivariate_normal_sample_from_sparse_covariance_ill_conditioned_matri
             assert samples.shape == (sparse_array.shape[0],)
 
 
-class TestCovViaSparsePrecision:
+class TestSparseFactor:
     @pytest.fixture(scope="class")
     def precision_matrix(self):
         mat = sp.random(500, 500, 0.001) * 100
@@ -46,15 +46,7 @@ class TestCovViaSparsePrecision:
 
     def test_prec_must_be_sparse(self):
         with pytest.raises(TypeError):
-            CovViaSparsePrecision(np.eye(10))  # type: ignore
-
-    def test_inversion(self, precision_matrix):
-        sparse_cov = CovViaSparsePrecision(
-            sp.csc_array(precision_matrix), solver=SparseSolver.SUPERLU
-        )
-        scipy_cov = Covariance.from_precision(precision_matrix)
-
-        assert_array_almost_equal(scipy_cov.covariance, sparse_cov.covariance.toarray())
+            create_sparse_factor(np.eye(10))  # type: ignore
 
     @pytest.mark.parametrize(
         "matrix",
@@ -69,19 +61,19 @@ class TestCovViaSparsePrecision:
         test by taking a large number of samples and checking that the variances are
         close.
         """
-        scipy_sparse_cov = CovViaSparsePrecision(
+        superlu_factor = create_sparse_factor(
             sp.csc_array(matrix), solver=SparseSolver.SUPERLU
         )
-        suitesparse_cov = CovViaSparsePrecision(
+        cholmod_factor = create_sparse_factor(
             sp.csc_array(matrix), solver=SparseSolver.CHOLMOD
         )
 
         random_samples = np.random.default_rng(0).normal(size=(1000, matrix.shape[0]))
-        scipy_samples = scipy_sparse_cov.colorize(random_samples)
-        suitesparse_samples = suitesparse_cov.colorize(random_samples)
+        superlu_samples = superlu_factor.colorize(random_samples.T).T
+        cholmod_samples = cholmod_factor.colorize(random_samples.T).T
 
         assert_allclose(
-            scipy_samples.var(axis=0), suitesparse_samples.var(axis=0), rtol=0.5
+            superlu_samples.var(axis=0), cholmod_samples.var(axis=0), rtol=0.5
         )
 
     def test_umfpack_and_superlu_errors_when_not_symmetric_and_positive_definite(
@@ -89,17 +81,17 @@ class TestCovViaSparsePrecision:
     ):
         matrix = np.array([[0.0, 2.0], [1.0, 0.0]])
         with pytest.raises(ValueError):
-            CovViaSparsePrecision(sp.csc_array(matrix), solver=SparseSolver.SUPERLU)
+            create_sparse_factor(sp.csc_array(matrix), solver=SparseSolver.SUPERLU)
 
     @pytest.mark.parametrize("solver", [SparseSolver.SUPERLU, SparseSolver.CHOLMOD])
     def test_mvn_sampling_against_scipy(self, precision_matrix, solver):
-        sparse_cov = CovViaSparsePrecision(
+        factor = create_sparse_factor(
             sp.csc_array(precision_matrix), solver=solver
         )
         scipy_cov = Covariance.from_precision(precision_matrix)
 
-        sparse_samples = multivariate_normal_sample_from_sparse_covariance(
-            mean=None, cov=sparse_cov, size=80000, random_state=0
+        sparse_samples = multivariate_normal_sample_from_sparse_precision(
+            mean=None, factor=factor, size=80000, random_state=0
         )
         scipy_samples = multivariate_normal.rvs(
             mean=None,
@@ -144,20 +136,20 @@ class TestCovViaSparsePrecision:
 
     @pytest.mark.parametrize("solver", [SparseSolver.SUPERLU, SparseSolver.CHOLMOD])
     def test_mvt_sampling_against_scipy(self, precision_matrix, solver):
-        sparse_cov = CovViaSparsePrecision(
+        factor = create_sparse_factor(
             sp.csc_array(precision_matrix), solver=solver
         )
         scipy_cov = Covariance.from_precision(precision_matrix)
 
-        sparse_samples = multivariate_t_sample_from_covariance(
-            loc=None, shape=sparse_cov, size=80000, random_state=0, df=300
+        sparse_samples = multivariate_t_sample_from_sparse_precision(
+            loc=None, factor=factor, size=80000, random_state=0, df=300
         )
-        scipy_samples = multivariate_t_sample_from_sparse_covariance(
+        scipy_samples = multivariate_t_sample_from_covariance(
             loc=None,
             shape=scipy_cov,
             size=80000,
             random_state=0,
-            df=300,  # type: ignore
+            df=300,
         )
 
         sparse_emp_cov = np.cov(sparse_samples.T)


### PR DESCRIPTION
## Summary

- Replace `CovViaSparsePrecision` (a `scipy.stats.Covariance` subclass with runtime `TypeGuard` discrimination) with two concrete dataclasses (`CholmodSparseFactor`, `SuperLUSparseFactor`) + `SparseFactor` union + `create_sparse_factor()` factory
- Use `assert isinstance` at sparse/dense branch points for type narrowing instead of `# type: ignore`
- Consolidate solver selection in `_gaussian.py`'s `solve_precision_weighted_mean()` via the factory
- Net -140 lines; eliminates 5 protocol/wrapper types

## Pickle backward compatibility

Factor objects never appear in pickles — `__getstate__` drops `cov_`/`shape_` before serialization, and they're lazily recreated from `cov_inv_` on next access. Old ↔ new pickle round-trips verified by existing serialization tests.

## Test plan

- [x] `pytest -xvs tests/test_sparse_bayesian_linear_regression.py` — 22 passed
- [x] `pytest -xvs tests/test_normal_estimators.py -k serialization` — 8 passed
- [x] `pytest -xvs tests/test_bayesian_glm.py -k serial` — 6 passed
- [x] Full suite: 1673 passed, 18 skipped
- [x] `pyright` on changed files: 13 errors, all pre-existing sklearn stub issues