### PR TITLE
Add mathematical formulations and hedged regret bounds to policy docs…

### DIFF
--- a/src/bayesianbandits/policies/_epsilon_greedy.py
+++ b/src/bayesianbandits/policies/_epsilon_greedy.py
@@ -17,28 +17,69 @@ from ._base import PolicyDefaultUpdate
 
 
 class EpsilonGreedy(PolicyDefaultUpdate[ContextType, TokenType]):
-    """
-    Policy object for epsilon-greedy.
+    r"""
+    Policy object for :math:`\varepsilon`-greedy selection.
 
-    Epsilon-greedy chooses the best arm with probability 1 - epsilon and a random
-    arm with probability epsilon.
+    With probability :math:`1 - \varepsilon` the arm with the highest
+    estimated posterior mean reward is selected (exploit); with probability
+    :math:`\varepsilon` an arm is chosen uniformly at random (explore):
+
+    .. math::
+
+        a_t =
+        \begin{cases}
+        \arg\max_a \; \hat{\mu}_a(x_t)
+            & \text{with probability } 1 - \varepsilon, \\
+        \text{Uniform}\{1, \ldots, K\}
+            & \text{with probability } \varepsilon,
+        \end{cases}
+
+    where :math:`\hat{\mu}_a(x_t) = \mathbb{E}_{\theta_a \mid
+    \mathcal{D}_a}[g_a(\theta_a, x_t)]` is estimated via Monte Carlo with
+    ``samples`` posterior draws.
 
     Parameters
     ----------
     epsilon : float, default=0.1
         Probability of exploration.
     samples : int, default=1000
-        Number of samples to use for computing the arm means.
+        Number of posterior samples used to estimate the arm means.
 
     Notes
     -----
-    The implementation here is based on the implementation in [1]_.
+    **Regret bounds (standard setting).** For a :math:`K`-armed stochastic
+    bandit with fixed :math:`\varepsilon`, the expected regret is bounded by
+
+    .. math::
+
+        \mathbb{E}[\mathrm{Regret}(T)]
+        \;\le\; \varepsilon\,T\,\Delta_{\max}
+        \;+\; \sum_{a:\Delta_a>0}
+        \frac{C}{\Delta_a}
+
+    where :math:`\Delta_a = \mu^* - \mu_a` is the sub-optimality gap and
+    :math:`C` depends on the concentration of the mean estimator [2]_.
+    With a decaying schedule :math:`\varepsilon_t = O(K / t)` the minimax
+    rate :math:`O(\sqrt{KT})` is achievable.
+
+    **Applicability to this library.** The classical analysis assumes
+    stationary rewards and empirical sample means with known concentration
+    properties. This implementation replaces the empirical mean with a
+    Bayesian posterior mean (which may use approximate inference) and
+    supports contextual features and variance-increasing decay for
+    non-stationarity. Under these modifications the formal bounds do not
+    directly apply, but the basic explore-exploit trade-off controlled by
+    :math:`\varepsilon` is preserved.
 
     References
     ----------
-    .. [1] Chapelle, Olivier, and Lihong Li. "An empirical evaluation of
-       thompson sampling." Advances in neural information processing systems
-       24 (2011): 2249-2257.
+    .. [1] Chapelle, O. and Li, L. (2011). "An empirical evaluation of
+       Thompson sampling." Advances in Neural Information Processing Systems
+       24, 2249-2257.
+
+    .. [2] Auer, P., Cesa-Bianchi, N., and Fischer, P. (2002).
+       "Finite-time analysis of the multiarmed bandit problem." Machine
+       Learning, 47(2-3), 235-256.
     """
 
     def __repr__(self) -> str:

--- a/src/bayesianbandits/policies/_exp3a.py
+++ b/src/bayesianbandits/policies/_exp3a.py
@@ -21,10 +21,32 @@ class EXP3A:
     This algorithm provides adversarial robustness while solving several practical
     limitations of traditional adversarial bandit algorithms like EXP3/EXP4.
 
+    At each round the algorithm computes arm selection probabilities from
+    exponential weights over estimated average rewards:
+
+    .. math::
+
+        P_t(a) = (1 - \\gamma)\\,
+        \\frac{\\exp\\bigl(\\eta\\,\\hat{\\mu}_a(x_t)\\bigr)}
+        {\\sum_{j}\\exp\\bigl(\\eta\\,\\hat{\\mu}_j(x_t)\\bigr)}
+        \\;+\\; \\frac{\\gamma}{K}
+
+    where :math:`\\hat{\\mu}_a(x_t)` is the Monte Carlo posterior mean for
+    arm :math:`a` in context :math:`x_t`. After observing reward
+    :math:`r_t`, the selected arm's learner is updated with
+    importance-weighted observations:
+
+    .. math::
+
+        w_t = \\frac{1}{P_t(a_t) + \\gamma_{\\mathrm{ix}}}
+
+    The IX (Implicit eXploration) regularisation :math:`\\gamma_{\\mathrm{ix}}`
+    [2]_ replaces the forced-exploration mixture in classical EXP3.
+
     Core adversarial mechanism:
 
-    - Importance weighting: Uses weight = 1/(P(arm) + ix_gamma) to debias reward estimates
-    - Optional forced exploration: γ-mixing guarantees P(arm) ≥ γ/K when gamma > 0
+    - Importance weighting: Uses :math:`w = 1/(P(a) + \\gamma_{\\mathrm{ix}})` to debias reward estimates
+    - Optional forced exploration: :math:`\\gamma`-mixing guarantees :math:`P(a) \\ge \\gamma/K` when ``gamma > 0``
     - No assumptions: Works with arbitrary reward sequences, including adversarial
 
     Algorithm variants:
@@ -136,19 +158,34 @@ class EXP3A:
 
     Notes
     -----
-    This implementation is inspired by EXP3 (Auer et al., 2002) and EXP3-IX
-    (Neu, 2015) but makes several practical modifications that may affect
-    theoretical guarantees:
+    **Regret bounds (standard setting).** In the classical non-stochastic
+    :math:`K`-armed bandit with :math:`T` rounds, EXP3-IX achieves a
+    high-probability regret bound of
+
+    .. math::
+
+        \\mathrm{Regret}(T) = O\\!\\left(\\sqrt{KT\\ln K}\\right)
+
+    with appropriately tuned :math:`\\eta` and :math:`\\gamma_{\\mathrm{ix}}`
+    [2]_. The original EXP3 with forced exploration achieves the same
+    minimax rate in expectation [1]_.
+
+    **Applicability to this library.** This implementation is inspired by
+    EXP3/EXP3-IX but makes several practical modifications that affect
+    the formal guarantees:
 
     - Uses average-based rewards instead of cumulative sums
-    - Integrates with Bayesian learners rather than maintaining explicit weights
+    - Integrates with Bayesian learners rather than maintaining explicit
+      per-round weight tables
     - Employs Monte Carlo estimation for expected rewards
-    - Supports variance decay for non-stationary environments
+    - Supports variance-increasing decay for non-stationary environments
 
-    While these modifications improve practical performance, the theoretical
-    regret bounds from the original papers may not apply. This algorithm
-    should be viewed as a practical variant that maintains the adversarial
-    robustness intuition of EXP3 while adapting to real-world constraints.
+    Under these modifications the classical regret bounds do not formally
+    apply. However, the core adversarial-robustness mechanism---importance-
+    weighted updates that debias reward estimates under non-uniform
+    selection---is preserved, and the algorithm should be viewed as a
+    practical variant that maintains the adversarial robustness intuition of
+    EXP3 while adapting to contextual, anytime, and non-stationary settings.
     """
 
     def __init__(

--- a/src/bayesianbandits/policies/_thompson_sampling.py
+++ b/src/bayesianbandits/policies/_thompson_sampling.py
@@ -21,19 +21,53 @@ class ThompsonSampling(PolicyDefaultUpdate[ContextType, TokenType]):
     Policy object for Thompson sampling.
 
     Thompson sampling chooses the best arm with probability equal to the
-    probability that the arm is the best arm. That is, it takes a sample from
-    each arm's posterior distribution and chooses the arm with the highest
-    sample.
+    probability that the arm is the best arm. At each round, a single sample
+    is drawn from each arm's posterior and the arm with the highest sample is
+    selected:
+
+    .. math::
+
+        \\tilde{\\theta}_a \\sim p(\\theta_a \\mid \\mathcal{D}_a)
+        \\quad \\forall a, \\qquad
+        a^* = \\arg\\max_a \\; g_a(\\tilde{\\theta}_a)
+
+    where :math:`g_a` is the reward function (possibly context-dependent) and
+    :math:`\\mathcal{D}_a` is the data observed for arm :math:`a`.
 
     Notes
     -----
-    The implementation here is based on the implementation in [1]_.
+    **Regret bounds (standard setting).** For the :math:`K`-armed stochastic
+    bandit with Beta-Bernoulli or Gaussian conjugate models, Thompson sampling
+    achieves a Bayesian expected regret of
+
+    .. math::
+
+        \\mathbb{E}[\\mathrm{Regret}(T)]
+        = O\\!\\left(\\sqrt{KT \\ln K}\\right)
+
+    and an asymptotically optimal problem-dependent bound of
+    :math:`O\\!\\left(\\sum_{a:\\Delta_a>0}
+    \\frac{\\ln T}{\\Delta_a}\\right)` matching the Lai-Robbins lower bound
+    [2]_.
+
+    **Applicability to this library.** The bounds above are proven for
+    stationary, non-contextual bandits with exact conjugate posteriors. This
+    library targets anytime, contextual, and potentially non-stationary
+    problems, and the Bayesian learners may use approximate posteriors (e.g.
+    Laplace approximations) or variance-increasing decay. Under these
+    modifications the classical regret guarantees do not formally apply,
+    though the core explore-exploit mechanism---probability matching via
+    posterior sampling---is preserved.
 
     References
     ----------
-    .. [1] Chapelle, Olivier, and Lihong Li. "An empirical evaluation of
-       thompson sampling." Advances in neural information processing systems
-       24 (2011): 2249-2257.
+    .. [1] Chapelle, O. and Li, L. (2011). "An empirical evaluation of
+       Thompson sampling." Advances in Neural Information Processing Systems
+       24, 2249-2257.
+
+    .. [2] Agrawal, S. and Goyal, N. (2012). "Analysis of Thompson sampling
+       for the multi-armed bandit problem." Proceedings of the 25th Annual
+       Conference on Learning Theory (COLT), JMLR W&CP 23, 39.1-39.26.
     """
 
     def __repr__(self) -> str:

--- a/src/bayesianbandits/policies/_upper_confidence_bound.py
+++ b/src/bayesianbandits/policies/_upper_confidence_bound.py
@@ -18,28 +18,66 @@ from ._base import PolicyDefaultUpdate
 
 class UpperConfidenceBound(PolicyDefaultUpdate[ContextType, TokenType]):
     """
-    Policy object for upper confidence bound.
+    Policy object for Bayesian upper confidence bound.
 
-    Upper confidence bound takes `samples` samples from each arm's posterior
-    distribution and chooses the arm with the highest upper bound, as defined
-    by the `alpha` parameter.
+    At each round, posterior samples are used to estimate the
+    :math:`\\alpha`-quantile of each arm's reward distribution, and the arm
+    with the highest quantile is selected:
+
+    .. math::
+
+        a^* = \\arg\\max_a \\;
+        Q_{\\alpha}\\!\\bigl(g_a(\\theta_a) \\mid \\mathcal{D}_a\\bigr)
+
+    where :math:`Q_{\\alpha}` denotes the :math:`\\alpha`-quantile of the
+    posterior predictive reward, estimated via Monte Carlo with ``samples``
+    draws.
 
     Parameters
     ----------
     alpha : float, default=0.68
-        Confidence level (one-sided)
+        Quantile level used as the upper confidence bound. Higher values
+        produce more optimistic estimates and encourage exploration.
+        The default of 0.68 corresponds roughly to a one-standard-deviation
+        bound for a Gaussian posterior.
     samples : int, default=1000
-        Number of samples to use for computing the arm upper bounds.
+        Number of posterior samples used to estimate the quantile.
 
     Notes
     -----
-    The implementation here is based on the implementation in [1]_.
+    **Regret bounds (standard setting).** Kaufmann et al. (2012) show that
+    Bayesian UCB with a quantile schedule
+    :math:`\\alpha_t = 1 - 1/(t \\log^c(T))` achieves
+
+    .. math::
+
+        \\mathbb{E}[\\mathrm{Regret}(T)]
+        = O\\!\\left(\\sum_{a:\\Delta_a>0}
+        \\frac{\\ln T}{\\Delta_a}\\right)
+
+    matching the Lai-Robbins lower bound up to constants [2]_. With a fixed
+    :math:`\\alpha` (as used here), the problem-dependent bound is not
+    guaranteed, but a minimax rate of :math:`O(\\sqrt{KT \\ln T})` still
+    holds under mild conditions.
+
+    **Applicability to this library.** The bounds above assume stationary
+    rewards, exact conjugate posteriors, and a non-contextual setting. This
+    library uses a fixed quantile level, supports contextual features,
+    approximate posteriors, and variance-increasing decay for
+    non-stationarity. Under these modifications the formal guarantees do not
+    directly apply, though the optimism-in-the-face-of-uncertainty principle
+    that drives UCB's exploration is preserved.
 
     References
     ----------
-    .. [1] Chapelle, Olivier, and Lihong Li. "An empirical evaluation of
-       thompson sampling." Advances in neural information processing systems
-       24 (2011): 2249-2257.
+    .. [1] Chapelle, O. and Li, L. (2011). "An empirical evaluation of
+       Thompson sampling." Advances in Neural Information Processing Systems
+       24, 2249-2257.
+
+    .. [2] Kaufmann, E., Cappe, O., and Garivier, A. (2012). "On Bayesian
+       upper confidence bounds for bandit problems." Proceedings of the 15th
+       International Conference on Artificial Intelligence and Statistics
+       (AISTATS), JMLR W&CP 22, 592-600.
     """
 
     def __repr__(self) -> str:


### PR DESCRIPTION
…trings

Each policy class now documents:
- Formal selection rule as a display equation (.. math::)
- Classical regret bound with proper citation
- Explicit caveat that bounds are proven for stationary, non-contextual settings and do not formally transfer to this library's anytime, contextual, non-stationary Bayesian modifications

References added: Agrawal & Goyal (2012) for Thompson sampling, Kaufmann et al. (2012) for Bayesian UCB, Auer et al. (2002) for epsilon-greedy. EXP3A gains explicit formulas for the probability computation and importance-weighting rule.

https://claude.ai/code/session_014Qm4nHNGDx3tYyJU8PSbFV