### PR TITLE
Remove swig installation from CI workflows 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          sudo apt-get install -y swig libsuitesparse-dev
+          sudo apt-get install -y libsuitesparse-dev
           uv sync
 
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          sudo apt-get install -y swig libsuitesparse-dev
+          sudo apt-get install -y libsuitesparse-dev
           uv sync
 
       - name: Run tests

--- a/.github/workflows/matrix_test.yml
+++ b/.github/workflows/matrix_test.yml
@@ -65,7 +65,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get install -y swig libsuitesparse-dev
+        sudo apt-get install -y libsuitesparse-dev
         python -m pip install --upgrade pip pytest
         pip install scikit-learn==${{ matrix.sklearn-version }} scikit-sparse pandas
 


### PR DESCRIPTION
THis was for umfpack and we don't have that as a dependency anymore