### PR TITLE
Thread cached precision factor to posterior approximators

### DIFF
--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -1989,6 +1989,10 @@ scipy.sparse.csc_array
                 NDArray[np.float64], np.eye(self.n_features_) * self.alpha
             )
 
+        # A cached factor from a previous fit would be stale against
+        # the freshly-reset cov_inv_; drop it.
+        self.__dict__.pop("_precision_factor", None)
+
         # Initialize approximator if not provided
         if self.approximator is None:
             self.approximator_ = LaplaceApproximator()
@@ -2044,6 +2048,12 @@ scipy.sparse.csc_array
         sample_weight: Optional[NDArray[Any]] = None,
     ) -> None:
         """Update posterior using the configured approximation method."""
+        # For sparse partial_fit, hand the cached prior factor to the
+        # approximator so it can skip redundant factorization work.
+        prior_factor: Optional[Any] = (
+            self.__dict__.get("_precision_factor") if self.sparse else None
+        )
+
         posterior = self.approximator_.update_posterior(
             X,
             y,
@@ -2053,6 +2063,7 @@ scipy.sparse.csc_array
             sample_weight=sample_weight,
             learning_rate=self.learning_rate,
             sparse=self.sparse,
+            prior_factor=prior_factor,
         )
         self.coef_ = posterior.mean
         self.cov_inv_ = posterior.precision

--- a/src/bayesianbandits/_gaussian.py
+++ b/src/bayesianbandits/_gaussian.py
@@ -382,6 +382,13 @@ class PosteriorApproximator(Protocol):
     --------
     LaplaceApproximator : Default implementation using IRLS.
     BayesianGLM : Estimator that uses this protocol.
+
+    Notes
+    -----
+    ``prior_factor``, when provided, is a factorization of
+    ``prior_precision`` cached by the caller from the previous update.
+    Implementations may use it to skip refactorizing the prior; they
+    must not mutate it and may ignore it entirely.
     """
 
     def update_posterior(
@@ -394,6 +401,7 @@ class PosteriorApproximator(Protocol):
         sample_weight: Optional[NDArray[np.float64]],
         learning_rate: float,
         sparse: bool,
+        prior_factor: Optional[Any] = None,
     ) -> GaussianPosterior: ...
 
 
@@ -462,7 +470,9 @@ class LaplaceApproximator(PosteriorApproximator):
         sample_weight: Optional[NDArray[np.float64]],
         learning_rate: float,
         sparse: bool,
+        prior_factor: Optional[Any] = None,
     ) -> GaussianPosterior:
+        # prior_factor unused: IRLS builds its own factor each call.
         return update_gaussian_posterior_laplace(
             X,
             y,

--- a/tests/test_bayesian_glm.py
+++ b/tests/test_bayesian_glm.py
@@ -593,3 +593,54 @@ def test_bayesian_glm_custom_approximator(binary_data) -> None:
 
     # Precise approximator should do at least as well
     assert ll_precise >= ll_fast - 1e-6  # Allow tiny numerical differences
+
+
+class RecordingApproximator(LaplaceApproximator):
+    """Delegates to Laplace but records the prior_factor it receives."""
+
+    def __init__(self):
+        super().__init__()
+        self.received_factors = []
+
+    def update_posterior(self, *args, prior_factor=None, **kwargs):
+        self.received_factors.append(prior_factor)
+        return super().update_posterior(*args, prior_factor=prior_factor, **kwargs)
+
+
+@pytest.mark.parametrize("sparse", [True, False])
+def test_bayesian_glm_threads_prior_factor(binary_data, sparse: bool) -> None:
+    """Sparse partial_fit passes the cached precision factor through."""
+    X, y = binary_data
+    if sparse:
+        X = sp.csc_array(X)
+
+    approximator = RecordingApproximator()
+    clf = BayesianGLM(alpha=0.1, approximator=approximator, sparse=sparse)
+
+    clf.fit(X, y)
+    # Fresh fit: nothing cached yet, so no factor to thread.
+    assert approximator.received_factors == [None]
+
+    cached_factor = clf.__dict__.get("_precision_factor")
+    clf.partial_fit(X, y)
+    if sparse:
+        assert cached_factor is not None
+        assert approximator.received_factors[1] is cached_factor
+    else:
+        assert approximator.received_factors[1] is None
+
+
+def test_bayesian_glm_refit_does_not_pass_stale_factor(binary_data) -> None:
+    """Refitting resets the prior, so the old posterior's factor must not
+    be handed to the approximator as if it factored the fresh prior."""
+    X, y = binary_data
+    X = sp.csc_array(X)
+
+    approximator = RecordingApproximator()
+    clf = BayesianGLM(alpha=0.1, approximator=approximator, sparse=True)
+
+    clf.fit(X, y)
+    assert "_precision_factor" in clf.__dict__
+
+    clf.fit(X, y)
+    assert approximator.received_factors == [None, None]


### PR DESCRIPTION
## Summary

`BayesianGLM` caches a factorization of the posterior precision (`_precision_factor`) after each update, but approximators could not see it: every `update_posterior` call refactorized the prior from scratch.

This PR adds an optional `prior_factor` parameter to the `PosteriorApproximator` protocol and passes the cached factor through on sparse updates:

- `PosteriorApproximator.update_posterior` and `LaplaceApproximator.update_posterior` gain `prior_factor: Optional[Any] = None`. Laplace ignores it (IRLS builds its own factor each iteration); approximators that need prior solves (e.g. the upcoming R-VGA approximator, #TBD) can use it to skip redundant factorization work.
- `_fit_helper` hands the cached factor to the approximator for sparse models.
- `fit()` now drops any cached factor before re-initializing the prior. Since `_fit_helper` reads the cache at the start of an update, a refit would otherwise hand the approximator a factor of the *old posterior* as if it factored the freshly-reset prior.

## Tests

- Stub approximator verifies the exact factor object is threaded on sparse `partial_fit`, and that dense models always receive `None`.
- Regression test: refitting an already-fitted sparse model passes `prior_factor=None`, not the stale factor.

Full suite: 2133 passed, 30 skipped. Pyright error count unchanged from master.