### PR TITLE
Add half_solve to the precision factor interface

### DIFF
--- a/src/bayesianbandits/_sparse_bayesian_linear_regression.py
+++ b/src/bayesianbandits/_sparse_bayesian_linear_regression.py
@@ -12,6 +12,7 @@ from typing import (
 
 import numpy as np
 from numpy.typing import NDArray
+from scipy.linalg import cho_solve, solve_triangular  # type: ignore
 from scipy.sparse import (  # type: ignore  # type: ignore
     csc_array,
     csc_matrix,
@@ -117,11 +118,17 @@ class SuperLUSparseFactor:
     _inv_perm: NDArray[np.intp]
     _precision: csc_array
     _Lt_csc: csc_array = field(init=False, repr=False)
-    _perm: NDArray[np.intp] = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         self._Lt_csc = csc_array(self._L.T)
-        self._perm = np.argsort(self._inv_perm)
+
+    @cached_property
+    def _perm(self) -> NDArray[np.intp]:
+        """Inverse of ``_inv_perm``, computed lazily so that ``fit``/
+        ``partial_fit`` (which never call ``half_solve``) pay no extra cost."""
+        perm = np.empty_like(self._inv_perm)
+        perm[self._inv_perm] = np.arange(self._inv_perm.size)
+        return perm
 
     def solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
         return cast(NDArray[np.float64], spsolve(self._precision, b))
@@ -136,10 +143,8 @@ class SuperLUSparseFactor:
     def half_solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
         """Apply the transpose of the ``colorize`` operator: L^{-1} P b.
 
-        If ``M`` is the colorize operator (``M M^T = Λ^{-1}``), this
-        returns ``M^T b``, so ``half_solve(X.T).T @ half_solve(X.T)``
-        equals ``X Λ^{-1} X^T`` -- a half-solve per column against the
-        cached triangular factor (no refactorization, unlike ``solve``).
+        Same contract as :meth:`CholmodSparseFactor.half_solve`, against
+        the cached triangular factor (no refactorization, unlike ``solve``).
         """
         return cast(
             NDArray[np.float64],
@@ -242,15 +247,11 @@ class DenseFactor:
 
     @cached_property
     def _U_inv(self) -> NDArray[np.float64]:
-        from scipy.linalg import solve_triangular
-
         return solve_triangular(
             self._U, np.eye(self._n_features), lower=False, check_finite=False
         )
 
     def solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
-        from scipy.linalg import cho_solve
-
         return cho_solve((self._U, False), b, check_finite=False)
 
     def colorize(self, z: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
@@ -260,11 +261,9 @@ class DenseFactor:
     def half_solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
         """Solve U^T x = b, the transpose of the ``colorize`` operator.
 
-        ``half_solve(X.T).T @ half_solve(X.T)`` equals ``X Λ^{-1} X^T``
-        -- one triangular solve, without building ``U^{-1}``.
+        Same contract as :meth:`CholmodSparseFactor.half_solve`; one
+        triangular solve, without building ``U^{-1}``.
         """
-        from scipy.linalg import solve_triangular
-
         return cast(
             NDArray[np.float64],
             solve_triangular(self._U, b, trans=1, lower=False, check_finite=False),

--- a/src/bayesianbandits/_sparse_bayesian_linear_regression.py
+++ b/src/bayesianbandits/_sparse_bayesian_linear_regression.py
@@ -79,6 +79,16 @@ class CholmodSparseFactor:
         """Solve L^T x = z, undo permutation."""
         return self._factor.solve(z, system="Lt")[self._inv_perm]
 
+    def half_solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
+        """Apply the transpose of the ``colorize`` operator: L^{-1} P b.
+
+        If ``M`` is the colorize operator (``M M^T = Λ^{-1}``), this
+        returns ``M^T b``, so ``half_solve(X.T).T @ half_solve(X.T)``
+        equals ``X Λ^{-1} X^T`` -- a half-solve per column against the
+        cached factor, without ever forming ``Λ^{-1}``.
+        """
+        return self._factor.solve(b[self._factor.perm], system="L")
+
     def logdet(self) -> float:
         """Log-determinant of the factored matrix via CHOLMOD."""
         return float(self._factor.logdet())
@@ -107,9 +117,11 @@ class SuperLUSparseFactor:
     _inv_perm: NDArray[np.intp]
     _precision: csc_array
     _Lt_csc: csc_array = field(init=False, repr=False)
+    _perm: NDArray[np.intp] = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         self._Lt_csc = csc_array(self._L.T)
+        self._perm = np.argsort(self._inv_perm)
 
     def solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
         return cast(NDArray[np.float64], spsolve(self._precision, b))
@@ -119,6 +131,19 @@ class SuperLUSparseFactor:
         return cast(
             NDArray[np.float64],
             spsolve_triangular(self._Lt_csc, z, lower=False)[self._inv_perm],
+        )
+
+    def half_solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
+        """Apply the transpose of the ``colorize`` operator: L^{-1} P b.
+
+        If ``M`` is the colorize operator (``M M^T = Λ^{-1}``), this
+        returns ``M^T b``, so ``half_solve(X.T).T @ half_solve(X.T)``
+        equals ``X Λ^{-1} X^T`` -- a half-solve per column against the
+        cached triangular factor (no refactorization, unlike ``solve``).
+        """
+        return cast(
+            NDArray[np.float64],
+            spsolve_triangular(self._L, b[self._perm], lower=True),
         )
 
     def logdet(self) -> float:
@@ -163,6 +188,7 @@ class ScaledSparseFactor:
     If L L^T = P, then (s*P) has factor (√s * L).
     - solve(s*P, b) = (1/s) * solve(P, b)
     - colorize(s*P, z) = (1/√s) * colorize(P, z)
+    - half_solve(s*P, b) = (1/√s) * half_solve(P, b)
     """
 
     _inner: ConcreteFactor
@@ -174,6 +200,11 @@ class ScaledSparseFactor:
 
     def colorize(self, z: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
         return cast(NDArray[np.float64], self._inner.colorize(z) / np.sqrt(self._scale))
+
+    def half_solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
+        return cast(
+            NDArray[np.float64], self._inner.half_solve(b) / np.sqrt(self._scale)
+        )
 
     def logdet(self) -> float:
         """Log-determinant: log|s*P| = p*log(s) + log|P|."""
@@ -225,6 +256,19 @@ class DenseFactor:
     def colorize(self, z: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
         """Compute U^{-1} z, producing samples from N(0, Λ^{-1})."""
         return cast(NDArray[np.float64], self._U_inv @ z)
+
+    def half_solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
+        """Solve U^T x = b, the transpose of the ``colorize`` operator.
+
+        ``half_solve(X.T).T @ half_solve(X.T)`` equals ``X Λ^{-1} X^T``
+        -- one triangular solve, without building ``U^{-1}``.
+        """
+        from scipy.linalg import solve_triangular
+
+        return cast(
+            NDArray[np.float64],
+            solve_triangular(self._U, b, trans=1, lower=False, check_finite=False),
+        )
 
     def logdet(self) -> float:
         """log|Λ| = 2·sum(log(diag(U)))."""

--- a/tests/test_sparse_bayesian_linear_regression.py
+++ b/tests/test_sparse_bayesian_linear_regression.py
@@ -11,6 +11,7 @@ from scipy.stats import Covariance, multivariate_normal, multivariate_t
 from bayesianbandits._estimators import multivariate_t_sample_from_covariance
 from bayesianbandits._sparse_bayesian_linear_regression import (
     CholmodSparseFactor,
+    DenseFactor,
     SparseSolver,
     create_sparse_factor,
     multivariate_normal_sample_from_sparse_precision,
@@ -223,3 +224,62 @@ class TestRefactorize:
         refactored = scaled.refactorize(A2)
         assert isinstance(refactored, CholmodSparseFactor)
         assert refactored is factor
+
+
+class TestHalfSolve:
+    """half_solve is the transpose of the colorize operator.
+
+    If M is the colorize map (M @ M.T = inv(P)), half_solve applies M.T,
+    so B = half_solve(X.T) satisfies B.T @ B = X @ inv(P) @ X.T -- the
+    projected covariance, computed with one triangular solve per column
+    against the cached factor and without ever forming inv(P).
+    """
+
+    D = 300
+
+    @pytest.fixture(scope="class")
+    def precision(self):
+        rng = np.random.default_rng(42)
+        mat = sp.random(self.D, self.D, 0.01, random_state=1) * 10
+        return sp.csc_array((mat @ mat.T) + sp.diags(1 + rng.gamma(1, 1, self.D)))
+
+    @pytest.fixture(scope="class")
+    def X(self):
+        return np.random.default_rng(7).standard_normal((8, self.D))
+
+    def _reference(self, precision, X):
+        return X @ np.linalg.solve(precision.toarray(), X.T)
+
+    def _assert_gram_matches(self, B, S_ref):
+        sd = np.sqrt(np.diag(S_ref))
+        assert np.abs((B.T @ B - S_ref) / np.outer(sd, sd)).max() < 1e-10
+
+    @pytest.mark.parametrize("solver", [SparseSolver.SUPERLU, SparseSolver.CHOLMOD])
+    def test_sparse_gram_identity(self, precision, X, solver):
+        factor = create_sparse_factor(precision, solver=solver)
+        B = np.asarray(factor.half_solve(X.T))
+        assert B.shape == (self.D, 8)
+        self._assert_gram_matches(B, self._reference(precision, X))
+
+    @pytest.mark.parametrize("solver", [SparseSolver.SUPERLU, SparseSolver.CHOLMOD])
+    def test_scaled_factor_gram_identity(self, precision, X, solver):
+        """A factor scaled by s represents s*P, so the projected
+        covariance shrinks by 1/s."""
+        factor = scale_factor(create_sparse_factor(precision, solver=solver), 0.7)
+        B = np.asarray(factor.half_solve(X.T))
+        self._assert_gram_matches(B, self._reference(precision, X) / 0.7)
+
+    def test_dense_gram_identity(self, precision, X):
+        from scipy.linalg import cholesky
+
+        prec = precision.toarray()
+        factor = DenseFactor(_U=cholesky(prec, lower=False), _n_features=self.D)
+        B = np.asarray(factor.half_solve(X.T))
+        assert B.shape == (self.D, 8)
+        self._assert_gram_matches(B, self._reference(precision, X))
+
+    @pytest.mark.parametrize("solver", [SparseSolver.SUPERLU, SparseSolver.CHOLMOD])
+    def test_single_column_rhs_keeps_2d_shape(self, precision, X, solver):
+        factor = create_sparse_factor(precision, solver=solver)
+        B = np.asarray(factor.half_solve(X.T[:, :1]))
+        assert B.shape == (self.D, 1)

--- a/tests/test_sparse_bayesian_linear_regression.py
+++ b/tests/test_sparse_bayesian_linear_regression.py
@@ -170,7 +170,7 @@ class TestRefactorize:
         """Two SPD matrices with the same sparsity pattern but different values."""
         rng = np.random.default_rng(42)
         n = 200
-        base = sp.random(n, n, density=0.01, random_state=rng)
+        base = sp.random(n, n, density=0.01, random_state=rng)  # type: ignore[call-arg]  # scipy>=1.14 floor predates the rng= kwarg
         A1 = (base @ base.T) + 50 * sp.diags(1 + rng.gamma(1, 1, n))
         A2 = (base @ base.T) + 80 * sp.diags(1 + rng.gamma(1, 1, n))
         return sp.csc_array(A1), sp.csc_array(A2)
@@ -240,7 +240,7 @@ class TestHalfSolve:
     @pytest.fixture(scope="class")
     def precision(self):
         rng = np.random.default_rng(42)
-        mat = sp.random(self.D, self.D, 0.01, random_state=1) * 10
+        mat = sp.random(self.D, self.D, 0.01, random_state=1) * 10  # type: ignore[call-arg]  # scipy>=1.14 floor predates the rng= kwarg
         return sp.csc_array((mat @ mat.T) + sp.diags(1 + rng.gamma(1, 1, self.D)))
 
     @pytest.fixture(scope="class")
@@ -257,7 +257,7 @@ class TestHalfSolve:
     @pytest.mark.parametrize("solver", [SparseSolver.SUPERLU, SparseSolver.CHOLMOD])
     def test_sparse_gram_identity(self, precision, X, solver):
         factor = create_sparse_factor(precision, solver=solver)
-        B = np.asarray(factor.half_solve(X.T))
+        B = factor.half_solve(X.T)
         assert B.shape == (self.D, 8)
         self._assert_gram_matches(B, self._reference(precision, X))
 
@@ -266,7 +266,7 @@ class TestHalfSolve:
         """A factor scaled by s represents s*P, so the projected
         covariance shrinks by 1/s."""
         factor = scale_factor(create_sparse_factor(precision, solver=solver), 0.7)
-        B = np.asarray(factor.half_solve(X.T))
+        B = factor.half_solve(X.T)
         self._assert_gram_matches(B, self._reference(precision, X) / 0.7)
 
     def test_dense_gram_identity(self, precision, X):
@@ -274,12 +274,12 @@ class TestHalfSolve:
 
         prec = precision.toarray()
         factor = DenseFactor(_U=cholesky(prec, lower=False), _n_features=self.D)
-        B = np.asarray(factor.half_solve(X.T))
+        B = factor.half_solve(X.T)
         assert B.shape == (self.D, 8)
         self._assert_gram_matches(B, self._reference(precision, X))
 
     @pytest.mark.parametrize("solver", [SparseSolver.SUPERLU, SparseSolver.CHOLMOD])
     def test_single_column_rhs_keeps_2d_shape(self, precision, X, solver):
         factor = create_sparse_factor(precision, solver=solver)
-        B = np.asarray(factor.half_solve(X.T[:, :1]))
+        B = factor.half_solve(X.T[:, :1])
         assert B.shape == (self.D, 1)


### PR DESCRIPTION
Adds a `half_solve` method to every precision factor backend (CHOLMOD, SuperLU, scaled, dense).

`half_solve` applies the transpose of the existing `colorize` operator: if `M` is the colorize map (`M @ M.T = inv(L)` for a factor of `L`), then `B = factor.half_solve(X.T)` satisfies `B.T @ B = X @ inv(L) @ X.T`. This gives callers an exact square root of any projected covariance -- one triangular substitution pass per column against the cached factor, without materializing `inv(L)` or the covariance itself.

Two properties worth noting:

- Because only the forward half of the solve runs, results live at square-root scale: quadratic forms that would overflow or square the condition number when computed via a full solve stay well-conditioned.
- The SuperLU implementation runs against the cached triangular factor. (`SuperLUSparseFactor.solve` currently re-runs a full LU factorization per call; `half_solve` does not.)

Tests verify the gram identity `B.T @ B == X @ inv(L) @ X.T` at 1e-10 relative precision on all four backends, plus the scaled-factor identity and 2-D shape handling.

First of a stack: #258 (reward-space sampling) builds on this to draw posterior predictive samples via a QR decomposition of the half-solve, replacing its jittered explicit-covariance Cholesky.
