### PR TITLE
Keep joint draws when a batch reward function combines arms

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,6 +32,19 @@ Unreleased
   class overrides ``sample`` without also overriding ``sample_marginal``,
   so customized joint sampling is not silently bypassed (#258)
 
+- The marginal path is likewise never used when a
+  ``LipschitzContextualAgent`` carries a user-supplied
+  ``batch_reward_function``. That function sees a whole draw at once and
+  may combine arms within it (share of total, cannibalization, softmax
+  over a slate), which requires the arms of a draw to be jointly
+  distributed; iid marginal draws leave such a reward's mean intact but
+  manufacture spread that a quantile-based policy reads as uncertainty.
+  A batch function that maps each ``(arm, context, draw)`` cell
+  independently can opt back into the faster path by carrying a truthy
+  ``elementwise`` attribute. Per-arm ``Arm.reward_function``s are applied
+  one arm at a time and never affect sampling, so the common cases --
+  no reward function, or per-arm functions only -- keep the speedup (#258)
+
 **Behavioral changes**
 
 - Seeded agent trajectories under ``UpperConfidenceBound``, ``EXP3A``, and

--- a/src/bayesianbandits/_arm.py
+++ b/src/bayesianbandits/_arm.py
@@ -195,6 +195,29 @@ def batch_identity(
     return samples
 
 
+def is_elementwise_batch_reward(func: Any) -> bool:
+    """Is ``func`` known to map each draw cell independently?
+
+    A batch reward function receives the whole
+    ``(n_arms, n_contexts, size)`` tensor, so it may combine arms
+    *within* a draw (share-of-total, cannibalization, softmax over a
+    slate). Such a function is only meaningful when the rows of one
+    draw are jointly distributed, which rules out the iid marginal
+    sampling path -- there, ``samples[:, c, m]`` is not a coherent
+    sample of the arm-reward vector, and the derived reward picks up
+    spurious spread even though its mean is unchanged.
+
+    ``None`` and :func:`batch_identity` are elementwise by
+    construction. Anything else is assumed to couple arms unless it
+    carries a truthy ``elementwise`` attribute, so the conservative
+    default is the correct one and users who know better can opt back
+    into the faster path.
+    """
+    if func is None or func is batch_identity:
+        return True
+    return bool(getattr(func, "elementwise", False))
+
+
 def apply_reward_function(
     reward_function: RewardFunction,
     samples: NDArray[np.float64],

--- a/src/bayesianbandits/api.py
+++ b/src/bayesianbandits/api.py
@@ -80,6 +80,7 @@ from ._arm import (
     TokenType,
     _accepts_context_batch,
     batch_identity,
+    is_elementwise_batch_reward,
     is_identity_function,
     resolve_marginal_sampler,
 )
@@ -98,7 +99,13 @@ class PolicyProtocol(Protocol[ContextType, TokenType]):
     when decisions consume per-(arm, context) statistics alone, for
     which marginal draws are exact and much cheaper; policies that
     compare arms within a shared posterior draw (e.g. Thompson
-    sampling) must keep it ``False``."""
+    sampling) must keep it ``False``.
+
+    This flag describes the policy only. Agents additionally require
+    the reward transform between sampler and policy to be elementwise,
+    so a ``LipschitzContextualAgent`` carrying an arm-combining
+    ``batch_reward_function`` keeps joint draws regardless of this
+    flag (see :func:`~bayesianbandits._arm.is_elementwise_batch_reward`)."""
 
     @overload
     def __call__(
@@ -846,6 +853,24 @@ class LipschitzContextualAgent(Generic[TokenType]):
         dimension of ``samples``. If None and all arms use the identity
         reward function, an optimized batch identity is used
         automatically.
+
+        Because the function sees a whole draw at once, it may combine
+        arms *within* one draw -- share of total, cannibalization,
+        softmax over a slate. Supplying one therefore disables the
+        cheaper iid marginal sampling path that ``marginal_ok``
+        policies (:class:`EpsilonGreedy`,
+        :class:`UpperConfidenceBound`, ``EXP3A``) would otherwise use,
+        since those draws are not jointly distributed across arms. A
+        function that maps each ``(arm, context, draw)`` cell
+        independently can opt back into the faster path by carrying a
+        truthy ``elementwise`` attribute::
+
+            def revenue(samples, action_tokens):
+                return samples * multipliers[:, None, None]
+            revenue.elementwise = True
+
+        Per-arm ``Arm.reward_function``s are always applied one arm at
+        a time and never affect sampling.
     random_seed : int, np.random.Generator, or None, default=None
         Controls the random number generator shared by the policy and
         the learner. Pass an int for reproducible results across calls.
@@ -1257,7 +1282,14 @@ class LipschitzContextualAgent(Generic[TokenType]):
         # 3. Get samples from learner (SINGLE MODEL CALL). Policies that
         # consume only per-(arm, context) statistics opt into iid
         # marginal draws, which are exact for them and much cheaper.
-        if getattr(self.policy, "marginal_ok", False):
+        # A batch reward function that combines arms within a draw needs
+        # those arms jointly distributed, which the marginal path does
+        # not provide -- the policy's own statistics are per-(arm,
+        # context), but the reward function runs before it (step 5)
+        marginal_ok = getattr(self.policy, "marginal_ok", False) and (
+            is_elementwise_batch_reward(self.batch_reward_function)
+        )
+        if marginal_ok:
             sampler = resolve_marginal_sampler(self.learner)
         else:
             sampler = self.learner.sample

--- a/tests/test_marginal_sampling.py
+++ b/tests/test_marginal_sampling.py
@@ -443,10 +443,15 @@ class TestBatchRewardCoupling:
         assert not is_elementwise_batch_reward(_share_of_total)
 
         def opted_in(samples, action_tokens):
-            return samples
+            return samples * 2.0
 
+        assert not is_elementwise_batch_reward(opted_in)
         opted_in.elementwise = True
         assert is_elementwise_batch_reward(opted_in)
+        # the attribute is a promise about the function, not a wrapper:
+        # it must not change what the function computes
+        samples = np.ones((2, 3, 4))
+        assert_allclose(opted_in(samples, [0, 1]), 2.0 * samples)
 
     @staticmethod
     def _min_cross_arm_corr(samples):

--- a/tests/test_marginal_sampling.py
+++ b/tests/test_marginal_sampling.py
@@ -31,15 +31,22 @@ from scipy.stats import t as t_dist
 from bayesianbandits import (
     EXP3A,
     Arm,
+    ArmColumnFeaturizer,
     BayesianGLM,
     ContextualAgent,
     EpsilonGreedy,
+    LipschitzContextualAgent,
     NormalInverseGammaRegressor,
     NormalRegressor,
     ThompsonSampling,
     UpperConfidenceBound,
 )
-from bayesianbandits._arm import batch_sample_arms, resolve_marginal_sampler
+from bayesianbandits._arm import (
+    batch_identity,
+    batch_sample_arms,
+    is_elementwise_batch_reward,
+    resolve_marginal_sampler,
+)
 from bayesianbandits.pipelines import LearnerPipeline
 from tests._helpers import cov_inv_dense
 
@@ -397,3 +404,118 @@ class TestPlumbing:
             learner.fit(rng.standard_normal((20, 3)), rng.standard_normal(20))
         tokens = agent.pull(X)
         assert len(tokens) == 2
+
+
+def _share_of_total(samples, action_tokens):
+    """Arm-combining batch reward: each arm's slice of the draw's total.
+
+    Only meaningful when the arms of one draw are jointly distributed.
+    """
+    return samples / samples.sum(axis=0, keepdims=True)
+
+
+class TestBatchRewardCoupling:
+    """A batch reward function may combine arms within a draw, so it
+    must not be handed iid marginal draws even under a ``marginal_ok``
+    policy."""
+
+    @staticmethod
+    def _agent(policy, batch_reward_function):
+        rng = np.random.default_rng(0)
+        featurizer = ArmColumnFeaturizer(column_name="arm")
+        learner = NormalRegressor(alpha=1.0, beta=1.0, random_state=0)
+        X = rng.standard_normal((300, 2))
+        X_enriched = featurizer.transform(X, action_tokens=[0, 1, 2])
+        y = np.concatenate([np.full(300, 5.0 + i) for i in range(3)])
+        learner.partial_fit(X_enriched, y + rng.standard_normal(900))
+        return LipschitzContextualAgent(
+            arms=[Arm(i) for i in range(3)],
+            learner=learner,
+            policy=policy,
+            arm_featurizer=featurizer,
+            batch_reward_function=batch_reward_function,
+            random_seed=0,
+        )
+
+    def test_elementwise_predicate(self):
+        assert is_elementwise_batch_reward(None)
+        assert is_elementwise_batch_reward(batch_identity)
+        assert not is_elementwise_batch_reward(_share_of_total)
+
+        def opted_in(samples, action_tokens):
+            return samples
+
+        opted_in.elementwise = True
+        assert is_elementwise_batch_reward(opted_in)
+
+    @staticmethod
+    def _min_cross_arm_corr(samples):
+        """Smallest |corr| between two arms' draws within a context.
+
+        The property an arm-combining reward function depends on: rows
+        of one draw share a weight vector, so arms move together. iid
+        marginal draws drive this to zero.
+        """
+        n_arms, n_contexts, _ = samples.shape
+        return min(
+            abs(np.corrcoef(samples[a, c], samples[b, c])[0, 1])
+            for c in range(n_contexts)
+            for a in range(n_arms)
+            for b in range(a + 1, n_arms)
+        )
+
+    def test_arm_combining_reward_keeps_joint_draws(self):
+        """The samples handed to an arm-combining batch reward function
+        must stay correlated across arms."""
+        seen = []
+
+        def recording_share(samples, action_tokens):
+            seen.append(np.asarray(samples))
+            return _share_of_total(samples, action_tokens)
+
+        agent = self._agent(
+            UpperConfidenceBound(alpha=0.9, samples=20_000), recording_share
+        )
+        agent.pull(np.random.default_rng(1).standard_normal((2, 2)))
+
+        assert len(seen) == 1
+        assert self._min_cross_arm_corr(seen[0]) > 0.3
+
+    def test_marginal_path_would_decouple_the_arms(self):
+        """Counterpart to the test above: confirms the guard is load
+        bearing, i.e. the marginal draws it blocks really are
+        uncorrelated across arms."""
+        agent = self._agent(
+            UpperConfidenceBound(alpha=0.9, samples=20_000), _share_of_total
+        )
+        X = np.random.default_rng(1).standard_normal((2, 2))
+        X_enriched = agent.arm_featurizer.transform(X, action_tokens=[0, 1, 2])
+        marginal = agent._reshape_samples(
+            resolve_marginal_sampler(agent.learner)(X_enriched, 20_000), 3, 2
+        )
+        assert self._min_cross_arm_corr(marginal) < 0.05
+
+    def test_elementwise_batch_reward_still_uses_marginal(self):
+        def revenue(samples, action_tokens):
+            return samples * np.asarray(action_tokens)[:, None, None]
+
+        revenue.elementwise = True
+        agent = self._agent(UpperConfidenceBound(alpha=0.9, samples=100), revenue)
+        with mock.patch(
+            "bayesianbandits.api.resolve_marginal_sampler",
+            wraps=resolve_marginal_sampler,
+        ) as resolve_marginal:
+            agent.pull(np.random.default_rng(1).standard_normal((2, 2)))
+        resolve_marginal.assert_called_once()
+
+    def test_identity_batch_reward_still_uses_marginal(self):
+        agent = self._agent(UpperConfidenceBound(alpha=0.9, samples=100), None)
+        # all arms use the identity reward, so the agent normalizes to
+        # batch_identity, which stays on the fast path
+        assert agent.batch_reward_function is batch_identity
+        with mock.patch(
+            "bayesianbandits.api.resolve_marginal_sampler",
+            wraps=resolve_marginal_sampler,
+        ) as resolve_marginal:
+            agent.pull(np.random.default_rng(1).standard_normal((2, 2)))
+        resolve_marginal.assert_called_once()


### PR DESCRIPTION
Bugfix against released #258 behavior. Independent of the IDS stack — **land this first.**

## Problem

`LipschitzContextualAgent.pull` applies `batch_reward_function` *between* sampling and policy selection, handing it the whole `(n_arms, n_contexts, size)` tensor. That contract lets a reward function combine arms **within** a draw — share of total, cannibalization, softmax over a slate — which is only meaningful when the arms of one draw are jointly distributed.

`marginal_ok` describes the *policy*, and the policies that set it (`EpsilonGreedy`, `UpperConfidenceBound`, `EXP3A`) genuinely do consume only per-(arm, context) statistics. But the reward function runs first, so under iid marginal draws an arm-combining reward silently computes a different quantity.

Measured with a fitted shared `NormalRegressor`, 3 arms, 200k draws, `share = s / s.sum(axis=0)`:

| | arm 1 mean share | arm 1 0.9-quantile |
|---|---|---|
| joint (pre-#258) | 0.33333 | 0.33333 |
| marginal (current) | 0.33333 | 0.3385 |

Joint draws make the shares near-deterministic because the arms move together. Decoupling them **manufactures spread** — the mean is untouched, which is why this is silent. A quantile-based policy like UCB reads that spread as uncertainty and can flip its choice among near-tied arms.

## Fix

Require the reward transform to be elementwise as well as the policy to be `marginal_ok`. `None` and `batch_identity` qualify by construction, so the common cases keep the speedup:

- no reward function at all (`_check_identity_optimization` normalises to `batch_identity`)
- per-arm `Arm.reward_function`s — applied one arm at a time, never touched sampling
- both documented examples (`revenue_batch_reward`, `gross_profit_reward`) are elementwise multipliers

Only unmarked user-supplied batch functions fall back to joint draws. Those can opt back in:

```python
def revenue(samples, action_tokens):
    return samples * multipliers[:, None, None]
revenue.elementwise = True
```

## Scope

`Agent` / `ContextualAgent` route through `batch_sample_arms`, which only applies per-arm functions — unaffected.

## Tests

New `TestBatchRewardCoupling`. The main test records the tensor actually handed to the reward function during `pull` and asserts arms stay correlated within a draw. Verified load-bearing: with the guard reverted it reports min |corr| 0.0035 against a 0.3 threshold; with it, 0.49. A counterpart test pins that the blocked marginal draws really are uncorrelated (< 0.05), so the pair fails if either side of the mechanism drifts.

2244 passed, 30 skipped. Lint clean.