### PR TITLE
Hoist the policy sampling block into PolicyDefaultUpdate

### DIFF
--- a/src/bayesianbandits/policies/_base.py
+++ b/src/bayesianbandits/policies/_base.py
@@ -11,10 +11,50 @@ from typing import (
 import numpy as np
 from numpy.typing import NDArray
 
-from .._arm import Arm, ContextType, TokenType
+from .._arm import Arm, ContextType, TokenType, batch_sample_arms
 
 
 class PolicyDefaultUpdate(Generic[ContextType, TokenType]):
+    #: Safe default satisfying ``PolicyProtocol``: joint ``sample``
+    #: draws serve every policy. Subclasses opt into cheaper sampling
+    #: modes by overriding this (see
+    #: :class:`~bayesianbandits.api.PolicyProtocol` for the semantics).
+    marginal_ok: bool = False
+
+    def _draw_samples(
+        self,
+        arms: List[Arm[ContextType, TokenType]],
+        X: ContextType,
+        size: int,
+    ) -> NDArray[np.float64]:
+        """Draw ``(n_arms, n_contexts, size)`` samples for ``select``.
+
+        Tries one batched call across arms sharing a learner, forwarding
+        ``marginal_ok`` (iid per-row draws are exact for policies
+        consuming only per-(arm, context) statistics); falls back to
+        per-arm sampling (marginal when ``marginal_ok``) otherwise.
+        Always returns a 3-D array, re-expanding the size axis
+        ``batch_sample_arms`` squeezes when ``size == 1``.
+        """
+        samples = batch_sample_arms(
+            arms,
+            X,
+            size=size,
+            marginal=self.marginal_ok,
+        )
+        if samples is None:
+            samples = np.array(
+                [
+                    (arm.sample_marginal if self.marginal_ok else arm.sample)(X, size)
+                    for arm in arms
+                ]
+            )
+            # Convert from (n_arms, size, n_contexts) to (n_arms, n_contexts, size)
+            samples = samples.transpose(0, 2, 1)
+        elif samples.ndim == 2:
+            samples = samples[:, :, np.newaxis]
+        return samples
+
     def update(
         self,
         arm: Arm[ContextType, TokenType],

--- a/src/bayesianbandits/policies/_epsilon_greedy.py
+++ b/src/bayesianbandits/policies/_epsilon_greedy.py
@@ -12,7 +12,7 @@ from typing import (
 import numpy as np
 from numpy.typing import NDArray
 
-from .._arm import Arm, ContextType, TokenType, batch_sample_arms
+from .._arm import Arm, ContextType, TokenType
 from ._base import PolicyDefaultUpdate
 
 
@@ -210,21 +210,5 @@ class EpsilonGreedy(PolicyDefaultUpdate[ContextType, TokenType]):
         List[Arm[ContextType, TokenType]], List[List[Arm[ContextType, TokenType]]]
     ]:
         """Choose arm(s) using epsilon-greedy."""
-        # Marginal draws when marginal_ok: this policy reduces samples to
-        # per-(arm, context) statistics, so iid marginal sampling is exact
-        # and much cheaper; subclasses can opt out via marginal_ok = False
-        samples = batch_sample_arms(
-            arms, X, size=self.samples_needed, marginal=self.marginal_ok
-        )
-        if samples is None:
-            samples = np.array(
-                [
-                    (arm.sample_marginal if self.marginal_ok else arm.sample)(
-                        X, self.samples_needed
-                    )
-                    for arm in arms
-                ]
-            )
-            # Convert from (n_arms, size, n_contexts) to (n_arms, n_contexts, size)
-            samples = samples.transpose(0, 2, 1)
+        samples = self._draw_samples(arms, X, self.samples_needed)
         return self.select(samples, arms, rng, top_k)

--- a/src/bayesianbandits/policies/_exp3a.py
+++ b/src/bayesianbandits/policies/_exp3a.py
@@ -11,10 +11,11 @@ from typing import List, Optional, Union, overload
 import numpy as np
 from numpy.typing import NDArray
 
-from .._arm import Arm, ContextType, TokenType, batch_sample_arms
+from .._arm import Arm, ContextType, TokenType
+from ._base import PolicyDefaultUpdate
 
 
-class EXP3A:
+class EXP3A(PolicyDefaultUpdate[ContextType, TokenType]):
     """
     EXP3.A: Average-based anytime variant of EXP3 for adversarial bandits.
 
@@ -352,23 +353,7 @@ class EXP3A:
             Selected arms, one per context if top_k is None,
             or k arms per context if top_k is specified.
         """
-        # Marginal draws when marginal_ok: this policy reduces samples to
-        # per-(arm, context) statistics, so iid marginal sampling is exact
-        # and much cheaper; subclasses can opt out via marginal_ok = False
-        samples = batch_sample_arms(
-            arms, X, size=self.samples_needed, marginal=self.marginal_ok
-        )
-        if samples is None:
-            samples = np.array(
-                [
-                    (arm.sample_marginal if self.marginal_ok else arm.sample)(
-                        X, self.samples_needed
-                    )
-                    for arm in arms
-                ]
-            )
-            # Convert from (n_arms, size, n_contexts) to (n_arms, n_contexts, size)
-            samples = samples.transpose(0, 2, 1)
+        samples = self._draw_samples(arms, X, self.samples_needed)
         return self.select(samples, arms, rng, top_k)
 
     def update(
@@ -404,14 +389,7 @@ class EXP3A:
         """
         # Recompute probabilities (stateless design); only per-arm means
         # are consumed, so marginal draws are exact when marginal_ok
-        rewards = np.stack(
-            [
-                (a.sample_marginal if self.marginal_ok else a.sample)(
-                    X, size=self.samples
-                ).mean(axis=0)
-                for a in all_arms
-            ]
-        )
+        rewards = self._draw_samples(all_arms, X, self.samples).mean(axis=-1)
         weights = np.exp(self.eta * (rewards - rewards.max(axis=0)))
 
         # TODO: This is not actually correct if top_k is used, but top_k is currently

--- a/src/bayesianbandits/policies/_thompson_sampling.py
+++ b/src/bayesianbandits/policies/_thompson_sampling.py
@@ -12,7 +12,7 @@ from typing import (
 import numpy as np
 from numpy.typing import NDArray
 
-from .._arm import Arm, ContextType, TokenType, batch_sample_arms
+from .._arm import Arm, ContextType, TokenType
 from ._base import PolicyDefaultUpdate
 
 
@@ -176,9 +176,5 @@ class ThompsonSampling(PolicyDefaultUpdate[ContextType, TokenType]):
         List[Arm[ContextType, TokenType]], List[List[Arm[ContextType, TokenType]]]
     ]:
         """Choose arm(s) using Thompson sampling."""
-        samples = batch_sample_arms(arms, X, size=self.samples_needed)
-        if samples is None:
-            samples = np.array([arm.sample(X, self.samples_needed) for arm in arms])
-            # Convert from (n_arms, size, n_contexts) to (n_arms, n_contexts, size)
-            samples = samples.transpose(0, 2, 1)
+        samples = self._draw_samples(arms, X, self.samples_needed)
         return self.select(samples, arms, rng, top_k)

--- a/src/bayesianbandits/policies/_upper_confidence_bound.py
+++ b/src/bayesianbandits/policies/_upper_confidence_bound.py
@@ -12,7 +12,7 @@ from typing import (
 import numpy as np
 from numpy.typing import NDArray
 
-from .._arm import Arm, ContextType, TokenType, batch_sample_arms
+from .._arm import Arm, ContextType, TokenType
 from ._base import PolicyDefaultUpdate
 
 
@@ -197,21 +197,5 @@ class UpperConfidenceBound(PolicyDefaultUpdate[ContextType, TokenType]):
         List[Arm[ContextType, TokenType]], List[List[Arm[ContextType, TokenType]]]
     ]:
         """Choose arm(s) using upper confidence bound."""
-        # Marginal draws when marginal_ok: this policy reduces samples to
-        # per-(arm, context) statistics, so iid marginal sampling is exact
-        # and much cheaper; subclasses can opt out via marginal_ok = False
-        samples = batch_sample_arms(
-            arms, X, size=self.samples_needed, marginal=self.marginal_ok
-        )
-        if samples is None:
-            samples = np.array(
-                [
-                    (arm.sample_marginal if self.marginal_ok else arm.sample)(
-                        X, self.samples_needed
-                    )
-                    for arm in arms
-                ]
-            )
-            # Convert from (n_arms, size, n_contexts) to (n_arms, n_contexts, size)
-            samples = samples.transpose(0, 2, 1)
+        samples = self._draw_samples(arms, X, self.samples_needed)
         return self.select(samples, arms, rng, top_k)

--- a/tests/test_batch_pull.py
+++ b/tests/test_batch_pull.py
@@ -466,3 +466,90 @@ class TestPerformance:
         assert result.shape == (n_arms, 50)
         # Should only call sample once due to batching
         assert shared_model.sample.call_count == 1
+
+
+class _SharedLearner:
+    """Minimal real (non-Mock) batchable learner.
+
+    ``can_batch_arms`` needs ``transform`` plus a ``final_estimator``
+    shared by every arm. No learner shipped in this library exposes
+    both, so without a stub like this the batched branch of
+    ``batch_sample_arms`` is only ever reached through ``Mock``s.
+    ``transform`` shifts one feature per arm so the arms' rows differ,
+    as they would under a real shared-model setup.
+    """
+
+    def __init__(self, model, shift):
+        self.final_estimator = model
+        self._shift = shift
+
+    def transform(self, X):
+        X = np.asarray(X, dtype=np.float64).copy()
+        X[:, 0] += self._shift
+        return X
+
+
+class TestDrawSamplesBatchedPath:
+    """``PolicyDefaultUpdate._draw_samples`` over genuinely batchable arms.
+
+    ``batch_sample_arms`` squeezes the size axis at ``size == 1``, but
+    ``select`` reduces over the last axis and so needs 3-D. Before
+    ``_draw_samples`` existed nothing re-expanded it, which took down
+    every ``ThompsonSampling`` pull over batchable arms --
+    ``samples_needed`` is always 1 there, so the squeeze always fired.
+    """
+
+    @staticmethod
+    def _arms(n_arms=3):
+        from bayesianbandits import Arm, NormalRegressor
+
+        model = NormalRegressor(alpha=1.0, beta=1.0, random_state=0)
+        model.fit(
+            np.random.default_rng(0).standard_normal((30, 2)),
+            np.random.default_rng(1).standard_normal(30),
+        )
+        return [Arm(i, learner=_SharedLearner(model, float(i))) for i in range(n_arms)]
+
+    @pytest.mark.parametrize("size", [1, 4])
+    def test_batched_draws_are_always_3d(self, size):
+        from bayesianbandits import ThompsonSampling
+
+        arms = self._arms()
+        X = np.random.default_rng(2).standard_normal((5, 2))
+        assert can_batch_arms(arms)
+
+        samples = ThompsonSampling()._draw_samples(arms, X, size)
+        assert samples.shape == (3, 5, size)
+
+    @pytest.mark.parametrize(
+        "policy_name", ["ThompsonSampling", "UpperConfidenceBound", "EpsilonGreedy"]
+    )
+    def test_every_policy_pulls_over_batchable_arms(self, policy_name):
+        """Regression: ThompsonSampling raised
+        ``TypeError: 'numpy.int64' object is not iterable`` here, because
+        its 2-D draws made ``select`` reduce over contexts and argmax down
+        to a scalar. The other policies default to samples > 1 and so
+        never hit the squeeze."""
+        import bayesianbandits
+
+        policy = getattr(bayesianbandits, policy_name)()
+        arms = self._arms()
+        X = np.random.default_rng(2).standard_normal((5, 2))
+
+        chosen = policy(arms, X, np.random.default_rng(0))
+        assert len(chosen) == 5  # one arm per context
+        assert all(a in arms for a in chosen)
+
+    def test_batched_matches_per_arm_fallback(self):
+        """The batched path and the per-arm fallback agree on shape."""
+        from bayesianbandits import Arm, NormalRegressor, ThompsonSampling
+
+        X = np.random.default_rng(2).standard_normal((5, 2))
+        batched = ThompsonSampling()._draw_samples(self._arms(), X, 4)
+
+        model = NormalRegressor(alpha=1.0, beta=1.0, random_state=0)
+        unbatchable = [Arm(i, learner=model) for i in range(3)]
+        assert not can_batch_arms(unbatchable)
+        per_arm = ThompsonSampling()._draw_samples(unbatchable, X, 4)
+
+        assert batched.shape == per_arm.shape == (3, 5, 4)


### PR DESCRIPTION
**Stack 1/3** — prep refactor for information-directed sampling (#240).

| | PR |
|---|---|
| 1/3 | **this** — hoist the sampling block |
| 2/3 | #262 IDS policy |
| 3/3 | #263 reward-space sampling |

## What

#258 left the same batch-sample-then-fall-back-per-arm block copy-pasted into four policies. Hoist it into `PolicyDefaultUpdate._draw_samples`, which also gives the capability flags a single home and guarantees a 3-D result.

`EXP3A` now inherits `PolicyDefaultUpdate` for access to the helper. It keeps its own `update()`, so the inherited default is unused; that `update()` also drops its hand-rolled per-arm sampling loop in favor of the helper.

Four copies of a ~14-line block collapse into one helper: **−21 lines of source code**
(−18 including comments). The `+139` in the header above is the 87-line test file below,
which is not dedup work — it is the regression test for the crash described next.

## Not quite a pure move: it fixes a ThompsonSampling crash

Guaranteeing 3-D is new behavior, and it turns out to matter.

`batch_sample_arms` squeezes the size axis at `size == 1`. Nothing re-expanded it before, so `select` reduced over *contexts* instead of draws and argmaxed down to a scalar. `ThompsonSampling.samples_needed` is always 1, so **every** Thompson pull over batchable arms died:

```
TypeError: 'numpy.int64' object is not iterable
```

`UpperConfidenceBound` (1000), `EpsilonGreedy` (1000) and `EXP3A` (100) default to `samples > 1` and never hit the squeeze.

This was invisible because `can_batch_arms` requires a learner exposing **both** `transform` and `final_estimator`, and no learner shipped in this library does — only the `Mock`s in `test_batch_pull.py`. `git log -S final_estimator -- src/bayesianbandits/pipelines/` is empty; it has been that way since #206 introduced the protocol. The batched path is reachable only by a user implementing `LearnerWithTransform` themselves.

Added a real (non-`Mock`) stub learner and a regression test pulling all three policies over batchable arms.

## Behavior on shipped classes

Unchanged. `can_batch_arms` returns `False` for every learner in this library, so `_draw_samples` takes the same per-arm path the policies took before. Verified by identical seeded trajectories against `master` for `ContextualAgent` with independent learners, arms sharing a `LearnerPipeline`, and `LipschitzContextualAgent`.

The one other difference a custom `LearnerWithTransform` would see: `EXP3A.update` issues one batched draw where it previously issued one per arm — same distribution, different RNG stream.

## Worth deciding separately

Whether `LearnerPipeline` *should* satisfy `LearnerWithTransform`. Until something does, `batch_sample_arms` and its `marginal=` / `reward_space=` plumbing are dead for anyone not implementing the protocol by hand.

