### PR TITLE
Add the InformationDirectedSampling policy

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -26,6 +26,7 @@ Policy Functions
    bayesianbandits.EpsilonGreedy
    bayesianbandits.ThompsonSampling
    bayesianbandits.UpperConfidenceBound
+   bayesianbandits.InformationDirectedSampling
    bayesianbandits.EXP3A
 
 Pipelines

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,15 @@ Unreleased
 
 **New features**
 
+- ``InformationDirectedSampling``: a variance-based information-directed
+  sampling (IDS) policy after Russo & Van Roy (2018). Each round it
+  estimates every arm's expected regret and variance-based information
+  gain from joint Monte Carlo posterior draws and samples from the
+  two-arm distribution minimizing the information ratio
+  :math:`\Delta(\pi)^2 / v(\pi)`, exploiting cross-arm correlation under
+  shared learners. ``top_k`` returns sequential IDS draws without
+  replacement, each slot re-solving the subgame of remaining arms (#240)
+
 - ``sample_marginal`` on ``NormalRegressor``, ``NormalInverseGammaRegressor``,
   and ``BayesianGLM``: iid draws from each prediction row's exact marginal
   posterior predictive, computed with one triangular half-solve per row

--- a/src/bayesianbandits/__init__.py
+++ b/src/bayesianbandits/__init__.py
@@ -37,6 +37,7 @@ policies of your bandit as your needs change.
     EpsilonGreedy
     ThompsonSampling
     UpperConfidenceBound
+    InformationDirectedSampling
     EXP3A
     Arm
 
@@ -134,7 +135,7 @@ from .api import (
 )
 from .featurizers import ArmColumnFeaturizer, FunctionArmFeaturizer
 from .pipelines import AgentPipeline, LearnerPipeline
-from .policies import EXP3A
+from .policies import EXP3A, InformationDirectedSampling
 
 __all__ = [
     "Arm",
@@ -157,6 +158,7 @@ __all__ = [
     "EpsilonGreedy",
     "ThompsonSampling",
     "UpperConfidenceBound",
+    "InformationDirectedSampling",
     "EXP3A",
     "AgentPipeline",
     "LearnerPipeline",

--- a/src/bayesianbandits/api.py
+++ b/src/bayesianbandits/api.py
@@ -50,6 +50,7 @@ Policy Functions
     EpsilonGreedy
     ThompsonSampling
     UpperConfidenceBound
+    InformationDirectedSampling
 
 """
 
@@ -87,6 +88,7 @@ from ._arm import (
 from ._arm_featurizer import ArmFeaturizer
 from .policies import (  # noqa: F401
     EpsilonGreedy,
+    InformationDirectedSampling,
     ThompsonSampling,
     UpperConfidenceBound,
 )

--- a/src/bayesianbandits/policies/__init__.py
+++ b/src/bayesianbandits/policies/__init__.py
@@ -1,11 +1,13 @@
 from ._epsilon_greedy import EpsilonGreedy
 from ._exp3a import EXP3A
+from ._information_directed_sampling import InformationDirectedSampling
 from ._thompson_sampling import ThompsonSampling
 from ._upper_confidence_bound import UpperConfidenceBound
 
 __all__ = [
     "EXP3A",
     "EpsilonGreedy",
+    "InformationDirectedSampling",
     "ThompsonSampling",
     "UpperConfidenceBound",
 ]

--- a/src/bayesianbandits/policies/_information_directed_sampling.py
+++ b/src/bayesianbandits/policies/_information_directed_sampling.py
@@ -1,0 +1,393 @@
+"""
+Information-directed sampling policy for Bayesian bandits.
+"""
+
+from typing import (
+    List,
+    Optional,
+    Tuple,
+    Union,
+    overload,
+)
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .._arm import Arm, ContextType, TokenType
+from ._base import PolicyDefaultUpdate
+
+
+def _vids_statistics(
+    samples: NDArray[np.float64],
+    alive: NDArray[np.bool_],
+    masked: Optional[NDArray[np.float64]] = None,
+    mu: Optional[NDArray[np.float64]] = None,
+) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Monte Carlo estimates of expected regret and variance-based information gain.
+
+    Parameters
+    ----------
+    samples : NDArray[np.float64]
+        Joint posterior samples, shape ``(n_arms, n_contexts, n_draws)``.
+        Draw ``m`` must be coherent across arms within a context: the
+        conditional means below condition on which arm is optimal *within
+        the same draw*.
+    alive : NDArray[np.bool_]
+        Shape ``(n_arms, n_contexts)``. Dead arms are excluded from the
+        argmax (they cannot be "the optimal arm"), and their returned
+        statistics are meaningless.
+    masked, mu : NDArray[np.float64], optional
+        Precomputed ``np.where(alive[:, :, np.newaxis], samples, -np.inf)``
+        and ``samples.mean(axis=-1)``. The top_k slot loop maintains these
+        across slots rather than re-materializing them here each slot.
+
+    Returns
+    -------
+    delta, v : NDArray[np.float64]
+        Shape ``(n_arms, n_contexts)``. ``delta[a, c]`` estimates
+        :math:`\\mathbb{E}[\\max_{a'} \\theta_{a'}] - \\mathbb{E}[\\theta_a]`
+        over alive arms, clipped at zero. ``v[a, c]`` estimates
+        :math:`\\sum_{a'} p(a') (\\mathbb{E}[\\theta_a \\mid A^* = a'] -
+        \\mathbb{E}[\\theta_a])^2`, the variance of arm ``a``'s posterior
+        mean under resolution of which alive arm is optimal.
+    """
+    n_arms, _, n_draws = samples.shape
+    if masked is None:
+        masked = np.where(alive[:, :, np.newaxis], samples, -np.inf)
+    means: NDArray[np.float64] = (
+        samples.mean(axis=-1) if mu is None else mu
+    )  # (n_arms, n_contexts)
+    argmax_idx = masked.argmax(axis=0)  # (n_contexts, n_draws)
+    # the values at the argmax are the max: gather them rather than
+    # sweeping the full (n_arms, n_contexts, n_draws) tensor a second time
+    rho_star = np.take_along_axis(masked, argmax_idx[np.newaxis], axis=0)[0].mean(
+        axis=-1
+    )  # (n_contexts,)
+    delta = np.clip(rho_star[np.newaxis, :] - means, 0.0, None)
+
+    onehot = (argmax_idx[:, :, np.newaxis] == np.arange(n_arms)).astype(np.float64)
+    counts = onehot.sum(axis=1).T  # (n_arms, n_contexts); zero for dead arms
+    p_opt = counts / n_draws
+    # cond_sums[a, b, c]: sum of arm a's draws over the draws where b is
+    # optimal, as a batched GEMM over contexts (much faster than einsum here)
+    cond_sums = np.matmul(samples.transpose(1, 0, 2), onehot).transpose(1, 2, 0)
+    mu_cond = cond_sums / np.maximum(counts, 1.0)[np.newaxis, :, :]
+    # counts == 0 leaves mu_cond at 0, but p_opt == 0 zeroes the term anyway
+    v = np.einsum("bc,abc->ac", p_opt, (mu_cond - means[:, np.newaxis, :]) ** 2)
+    return delta, v
+
+
+def _optimal_two_point(
+    delta: NDArray[np.float64],
+    v: NDArray[np.float64],
+    alive: NDArray[np.bool_],
+) -> Tuple[
+    NDArray[np.intp], NDArray[np.intp], NDArray[np.float64], NDArray[np.float64]
+]:
+    """Per context, the two-point distribution minimizing the information ratio.
+
+    The minimizer of :math:`\\Delta(\\pi)^2 / v(\\pi)` over distributions
+    :math:`\\pi` is supported on at most two arms (Russo & Van Roy 2018,
+    Prop. 6), so it suffices to scan all ordered pairs ``(a, b)``. For a
+    fixed pair, with mixing weight ``q`` on ``a``, the ratio is
+    ``(A q + B)^2 / (C q + D)`` where ``A = delta_a - delta_b``,
+    ``B = delta_b``, ``C = v_a - v_b``, ``D = v_b``; its stationary points
+    are ``q = -B / A`` (zero regret) and ``q = (C B - 2 A D) / (A C)``, so
+    the minimum over ``q`` in ``[0, 1]`` is attained at one of those
+    (clipped) or an endpoint.
+
+    Ratio conventions: a mixture with exactly zero regret has ratio 0
+    (optimal no matter the gain); positive regret with zero gain has ratio
+    ``inf``. Dead arms are excluded from the scan.
+
+    Returns
+    -------
+    a_idx, b_idx, q, ratio : NDArray
+        Each shape ``(n_contexts,)``: play ``a_idx`` with probability ``q``,
+        else ``b_idx``, achieving information ratio ``ratio``. An
+        infinite ``ratio`` means no alive pair has any information gain
+        with nonzero regret everywhere (the posterior has resolved).
+    """
+    n_arms, n_contexts = delta.shape
+    a_delta = delta[:, np.newaxis, :] - delta[np.newaxis, :, :]  # (K, K, C)
+    b_delta = np.broadcast_to(delta[np.newaxis, :, :], a_delta.shape)
+    c_gain = v[:, np.newaxis, :] - v[np.newaxis, :, :]
+    d_gain = np.broadcast_to(v[np.newaxis, :, :], a_delta.shape)
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        root_zero = -b_delta / a_delta
+        root_interior = (c_gain * b_delta - 2.0 * a_delta * d_gain) / (a_delta * c_gain)
+
+    # Running elementwise minimum over the four q candidates, rather than
+    # stacking them into (4, K, K, C) tensors: peak memory stays a few
+    # (K, K, C) arrays instead of several 4x-sized ones
+    best_ratio = np.full(a_delta.shape, np.inf)
+    best_q = np.zeros(a_delta.shape)
+    q_candidates = (
+        0.0,
+        1.0,
+        np.clip(np.nan_to_num(root_zero, nan=0.0, posinf=1.0, neginf=0.0), 0.0, 1.0),
+        np.clip(
+            np.nan_to_num(root_interior, nan=0.0, posinf=1.0, neginf=0.0), 0.0, 1.0
+        ),
+    )
+    for q_cand in q_candidates:
+        num = (a_delta * q_cand + b_delta) ** 2
+        den = c_gain * q_cand + d_gain
+        ratio = np.full_like(num, np.inf)
+        np.divide(num, den, out=ratio, where=den > 0.0)
+        ratio[num == 0.0] = 0.0
+        better = ratio < best_ratio
+        best_q = np.where(better, q_cand, best_q)
+        np.minimum(best_ratio, ratio, out=best_ratio)
+
+    pair_alive = alive[:, np.newaxis, :] & alive[np.newaxis, :, :]
+    best_ratio = np.where(pair_alive, best_ratio, np.inf)
+
+    flat_ratio = best_ratio.reshape(n_arms * n_arms, n_contexts)
+    pair_idx = flat_ratio.argmin(axis=0)  # (C,)
+    ctx_idx = np.arange(n_contexts)
+    a_idx = pair_idx // n_arms
+    b_idx = pair_idx % n_arms
+    q = best_q.reshape(n_arms * n_arms, n_contexts)[pair_idx, ctx_idx]
+    return a_idx, b_idx, q, flat_ratio[pair_idx, ctx_idx]
+
+
+def _sample_information_ratio_minimizer(
+    delta: NDArray[np.float64],
+    v: NDArray[np.float64],
+    alive: NDArray[np.bool_],
+    rng: np.random.Generator,
+) -> NDArray[np.intp]:
+    """Per context, sample an arm from the information-ratio-minimizing distribution.
+
+    Falls back to the greedy arm (``argmin delta`` among alive arms) in
+    contexts where every pair's ratio is infinite: the posterior has
+    resolved and there is no information left to buy.
+
+    Returns
+    -------
+    NDArray[np.intp]
+        Shape ``(n_contexts,)``, the sampled arm index per context.
+    """
+    a_idx, b_idx, q, ratio = _optimal_two_point(delta, v, alive)
+    picks = np.where(rng.random(delta.shape[1]) < q, a_idx, b_idx)
+
+    resolved = ~np.isfinite(ratio)
+    if np.any(resolved):
+        greedy = np.where(alive, delta, np.inf).argmin(axis=0)
+        picks = np.where(resolved, greedy, picks)
+    return picks
+
+
+class InformationDirectedSampling(PolicyDefaultUpdate[ContextType, TokenType]):
+    """
+    Policy object for variance-based information-directed sampling (IDS).
+
+    At each round, IDS plays the (possibly randomized) action distribution
+    minimizing the information ratio, the squared expected regret per unit
+    of information gained about the identity of the optimal arm:
+
+    .. math::
+
+        \\pi^* = \\arg\\min_{\\pi \\in \\Delta_K} \\;
+        \\frac{\\left(\\sum_a \\pi_a \\Delta_a\\right)^2}
+             {\\sum_a \\pi_a v_a}
+
+    where both terms are estimated from ``samples`` joint Monte Carlo draws
+    :math:`\\theta^{(m)}` of the arms' rewards:
+
+    .. math::
+
+        \\Delta_a = \\mathbb{E}\\left[\\max_{a'} \\theta_{a'}\\right]
+        - \\mathbb{E}[\\theta_a],
+        \\qquad
+        v_a = \\sum_{a'} p(A^* = a')
+        \\left(\\mathbb{E}[\\theta_a \\mid A^* = a'] -
+        \\mathbb{E}[\\theta_a]\\right)^2
+
+    :math:`v_a` is the variance-based information gain of Russo & Van Roy
+    [1]_: how much arm :math:`a`'s posterior mean moves upon learning which
+    arm is optimal. It is a lower bound on the mutual information
+    :math:`I(A^*; Y_a)` (up to a common noise factor) and is what makes IDS
+    exploit cross-arm correlation: with a shared learner, observing one arm
+    can be highly informative about another arm being optimal. The
+    minimizing distribution is supported on at most two arms, found here by
+    a closed-form scan over all pairs.
+
+    Parameters
+    ----------
+    samples : int, default=1000
+        Number of joint posterior samples used to estimate the regret and
+        information-gain terms.
+
+    Examples
+    --------
+    >>> from bayesianbandits import Agent, Arm, NormalInverseGammaRegressor
+    >>> from bayesianbandits import InformationDirectedSampling
+    >>>
+    >>> arms = [
+    ...     Arm(f"arm_{i}", learner=NormalInverseGammaRegressor())
+    ...     for i in range(3)
+    ... ]
+    >>> agent = Agent(arms, InformationDirectedSampling())
+
+    Fewer Monte Carlo draws trade estimation accuracy for speed:
+
+    >>> agent = Agent(arms, InformationDirectedSampling(samples=500))
+
+    See Also
+    --------
+    ThompsonSampling : Randomized exploration via posterior sampling.
+        Cheaper per decision; explores proportionally to uncertainty but
+        does not direct exploration toward informative arms.
+    UpperConfidenceBound : Deterministic optimism via posterior quantiles.
+    EpsilonGreedy : Simple exploration via random arm selection.
+
+    Notes
+    -----
+    **Regret bounds (standard setting).** Russo & Van Roy [1]_ show that
+    variance-based IDS satisfies the same
+    :math:`\\mathbb{E}[\\mathrm{Regret}(T)] \\le \\sqrt{K T \\log K / 2}`
+    Bayesian bound as the information-ratio analysis of Thompson sampling,
+    while its per-round ratio minimization can be substantially smaller in
+    structured problems (correlated arms, shared parameters), where
+    Thompson sampling may repeatedly re-explore arms whose value is already
+    implied by other observations.
+
+    **Joint draws matter.** The conditional means inside :math:`v_a`
+    condition on which arm is optimal *within the same posterior draw*, so
+    this policy requires coherent joint samples across arms
+    (``marginal_ok = False``). With a shared learner
+    (:class:`~bayesianbandits.LipschitzContextualAgent` or a shared
+    pipeline), joint weight-space draws provide this. When arms have
+    independent learners, independent per-arm draws *are* the correct joint
+    distribution. If a shared learner cannot be batch-sampled, the per-arm
+    fallback draws are incoherent across arms and :math:`v_a` degrades to
+    its independent-arms form: still a valid algorithm, but blind to
+    cross-arm correlation.
+
+    **top_k semantics.** ``top_k=k`` returns k sequential IDS draws without
+    replacement: slot 1 is exact IDS, and each later slot re-estimates
+    :math:`\\Delta` and :math:`v` restricted to the remaining arms (the
+    subgame with chosen arms removed), then plays exact IDS on it. Slot
+    order is meaningful and ``top_k=1`` matches the base policy in
+    distribution. No formal slate-bandit guarantee is claimed for
+    :math:`k > 1`.
+
+    **Applicability to this library.** The bounds above assume stationary
+    rewards and exact posteriors, and the observation-noise factor relating
+    :math:`v_a` to mutual information is common across arms only when
+    arms share a likelihood (e.g. one shared learner, or homoscedastic
+    Gaussian arms). Contextual features, approximate posteriors, and
+    variance-increasing decay fall outside the formal analysis, though the
+    regret-per-information principle driving exploration is preserved.
+
+    References
+    ----------
+    .. [1] Russo, D. and Van Roy, B. (2018). "Learning to optimize via
+       information-directed sampling." Operations Research 66(1), 230-252.
+
+    .. [2] Russo, D. and Van Roy, B. (2016). "An information-theoretic
+       analysis of Thompson sampling." Journal of Machine Learning Research
+       17(68), 1-30.
+    """
+
+    def __repr__(self) -> str:
+        return f"InformationDirectedSampling(samples={self.samples})"
+
+    def __init__(self, samples: int = 1000):
+        self.samples = samples
+
+    #: Requires joint draws (information gain conditions on the argmax
+    #: within each draw), so marginal sampling must not be used.
+    marginal_ok = False
+
+    @property
+    def samples_needed(self) -> int:
+        """Number of samples per arm per context needed for decision making."""
+        return self.samples
+
+    @overload
+    def select(
+        self,
+        samples: NDArray[np.float64],  # Shape: (n_arms, n_contexts, samples_needed)
+        arms: List[Arm[ContextType, TokenType]],
+        rng: np.random.Generator,
+        top_k: None = None,
+    ) -> List[Arm[ContextType, TokenType]]: ...
+
+    @overload
+    def select(
+        self,
+        samples: NDArray[np.float64],  # Shape: (n_arms, n_contexts, samples_needed)
+        arms: List[Arm[ContextType, TokenType]],
+        rng: np.random.Generator,
+        top_k: int,
+    ) -> List[List[Arm[ContextType, TokenType]]]: ...
+
+    def select(
+        self,
+        samples: NDArray[np.float64],  # Shape: (n_arms, n_contexts, samples_needed)
+        arms: List[Arm[ContextType, TokenType]],
+        rng: np.random.Generator,
+        top_k: Optional[int] = None,
+    ) -> Union[
+        List[Arm[ContextType, TokenType]], List[List[Arm[ContextType, TokenType]]]
+    ]:
+        """Select arms by minimizing the information ratio over pre-generated samples."""
+        n_arms, n_contexts, _ = samples.shape
+        n_slots = 1 if top_k is None else min(top_k, n_arms)
+
+        alive = np.ones((n_arms, n_contexts), dtype=np.bool_)
+        # mu is alive-invariant; masked is maintained in place across
+        # slots (dead arms' draws set to -inf) instead of re-materialized
+        mu = samples.mean(axis=-1)
+        masked = samples if n_slots == 1 else samples.astype(np.float64, copy=True)
+        ctx_idx = np.arange(n_contexts)
+        choices = np.empty((n_slots, n_contexts), dtype=np.intp)
+        for slot in range(n_slots):
+            delta, v = _vids_statistics(samples, alive, masked=masked, mu=mu)
+            picks = _sample_information_ratio_minimizer(delta, v, alive, rng)
+            choices[slot] = picks
+            alive[picks, ctx_idx] = False
+            if slot + 1 < n_slots:
+                masked[picks, ctx_idx, :] = -np.inf
+
+        if top_k is None:
+            return [arms[idx] for idx in choices[0]]
+        return [
+            [arms[choices[slot, ctx]] for slot in range(n_slots)]
+            for ctx in range(n_contexts)
+        ]
+
+    @overload
+    def __call__(
+        self,
+        arms: List[Arm[ContextType, TokenType]],
+        X: ContextType,
+        rng: np.random.Generator,
+        top_k: None = None,
+    ) -> List[Arm[ContextType, TokenType]]: ...
+
+    @overload
+    def __call__(
+        self,
+        arms: List[Arm[ContextType, TokenType]],
+        X: ContextType,
+        rng: np.random.Generator,
+        top_k: int,
+    ) -> List[List[Arm[ContextType, TokenType]]]: ...
+
+    def __call__(
+        self,
+        arms: List[Arm[ContextType, TokenType]],
+        X: ContextType,
+        rng: np.random.Generator,
+        top_k: Optional[int] = None,
+    ) -> Union[
+        List[Arm[ContextType, TokenType]], List[List[Arm[ContextType, TokenType]]]
+    ]:
+        """Choose arm(s) using information-directed sampling."""
+        samples = self._draw_samples(arms, X, self.samples_needed)
+        return self.select(samples, arms, rng, top_k)

--- a/tests/test_information_directed_sampling.py
+++ b/tests/test_information_directed_sampling.py
@@ -65,9 +65,13 @@ class TestPairOptimizer:
         rng = np.random.default_rng(seed)
         delta = rng.uniform(0.0, 2.0, size=(4, 3))
         v = rng.uniform(0.0, 1.5, size=(4, 3))
+        # context 2 has regret but no information gain anywhere: its
+        # ratio is infinite, which the loop below must skip
+        v[:, 2] = 0.0
         alive = np.ones((4, 3), dtype=bool)
 
         a_idx, b_idx, q, ratio = _optimal_two_point(delta, v, alive)
+        assert not np.isfinite(ratio[2])
         for c in range(3):
             if not np.isfinite(ratio[c]):
                 continue
@@ -122,6 +126,32 @@ class TestPairOptimizer:
         freq_a = np.mean(picks == a_idx[0])
         sigma = np.sqrt(q[0] * (1 - q[0]) / n_trials)
         assert abs(freq_a - q[0]) < 5 * sigma
+
+    def test_resolved_posterior_falls_back_to_greedy(self):
+        """With no information left to buy, every pair's ratio is
+        infinite and the minimizer plays the lowest-regret alive arm
+        rather than whatever pair (0, 0) the argmin happens to land on."""
+        # positive regret, zero gain everywhere -> ratio inf
+        delta = np.array([[0.5, 2.0], [0.2, 1.0], [0.9, 0.4]])
+        v = np.zeros((3, 2))
+        alive = np.ones((3, 2), dtype=bool)
+        _, _, _, ratio = _optimal_two_point(delta, v, alive)
+        assert not np.isfinite(ratio).any()
+
+        rng = np.random.default_rng(0)
+        picks = _sample_information_ratio_minimizer(delta, v, alive, rng)
+        assert picks.tolist() == [1, 2]  # argmin delta per context
+
+    def test_resolved_greedy_respects_dead_arms(self):
+        """The greedy fallback must not resurrect an arm already taken
+        by an earlier top_k slot, even when it has the lowest regret."""
+        delta = np.array([[0.5], [0.2], [0.9]])
+        v = np.zeros((3, 1))
+        alive = np.array([[True], [False], [True]])  # best arm is dead
+        picks = _sample_information_ratio_minimizer(
+            delta, v, alive, np.random.default_rng(0)
+        )
+        assert picks.tolist() == [0]
 
 
 class TestVidsStatistics:

--- a/tests/test_information_directed_sampling.py
+++ b/tests/test_information_directed_sampling.py
@@ -1,0 +1,321 @@
+"""
+Test suite for the variance-based information-directed sampling (IDS) policy.
+"""
+
+from typing import List
+
+import numpy as np
+import pytest
+
+from bayesianbandits import (
+    Agent,
+    Arm,
+    ArmColumnFeaturizer,
+    ContextualAgent,
+    InformationDirectedSampling,
+    LipschitzContextualAgent,
+    NormalInverseGammaRegressor,
+    NormalRegressor,
+)
+from bayesianbandits.policies._information_directed_sampling import (
+    _optimal_two_point,
+    _sample_information_ratio_minimizer,
+    _vids_statistics,
+)
+
+
+def brute_force_min_ratio(
+    delta: np.ndarray, v: np.ndarray, n_grid: int = 4001
+) -> float:
+    """Reference: grid-search the information ratio over all pairs and mixtures."""
+    q = np.linspace(0.0, 1.0, n_grid)
+    best = np.inf
+    for a in range(len(delta)):
+        for b in range(len(delta)):
+            num = (q * delta[a] + (1 - q) * delta[b]) ** 2
+            den = q * v[a] + (1 - q) * v[b]
+            ratio = np.full_like(num, np.inf)
+            np.divide(num, den, out=ratio, where=den > 0.0)
+            ratio[num == 0.0] = 0.0
+            best = min(best, ratio.min())
+    return best
+
+
+class TestPairOptimizer:
+    """Closed-form pair optimization against a brute-force grid."""
+
+    @pytest.mark.parametrize("seed", range(5))
+    @pytest.mark.parametrize("n_arms", [2, 3, 5, 8])
+    def test_matches_brute_force(self, seed: int, n_arms: int):
+        rng = np.random.default_rng(seed)
+        delta = rng.uniform(0.0, 2.0, size=(n_arms, 1))
+        v = rng.uniform(0.0, 1.5, size=(n_arms, 1))
+        alive = np.ones((n_arms, 1), dtype=bool)
+
+        a_idx, b_idx, q, ratio = _optimal_two_point(delta, v, alive)
+        reference = brute_force_min_ratio(delta[:, 0], v[:, 0])
+
+        # The closed form is exact, so it can only be at or below the grid
+        # minimum; the grid can only overshoot by its resolution.
+        assert ratio[0] <= reference + 1e-12
+        assert reference - ratio[0] <= 1e-4 * max(1.0, reference)
+
+    @pytest.mark.parametrize("seed", range(10))
+    def test_reported_mixture_achieves_reported_ratio(self, seed: int):
+        rng = np.random.default_rng(seed)
+        delta = rng.uniform(0.0, 2.0, size=(4, 3))
+        v = rng.uniform(0.0, 1.5, size=(4, 3))
+        alive = np.ones((4, 3), dtype=bool)
+
+        a_idx, b_idx, q, ratio = _optimal_two_point(delta, v, alive)
+        for c in range(3):
+            if not np.isfinite(ratio[c]):
+                continue
+            num = (q[c] * delta[a_idx[c], c] + (1 - q[c]) * delta[b_idx[c], c]) ** 2
+            den = q[c] * v[a_idx[c], c] + (1 - q[c]) * v[b_idx[c], c]
+            achieved = 0.0 if num == 0.0 else num / den
+            assert achieved == pytest.approx(ratio[c], abs=1e-12)
+
+    def test_zero_regret_arm_gives_zero_ratio(self):
+        # An arm with zero expected regret is played outright: ratio 0.
+        delta = np.array([[0.0], [0.7]])
+        v = np.array([[0.0], [0.3]])
+        alive = np.ones((2, 1), dtype=bool)
+        a_idx, b_idx, q, ratio = _optimal_two_point(delta, v, alive)
+        assert ratio[0] == 0.0
+        played = a_idx[0] if q[0] == 1.0 else b_idx[0]
+        assert played == 0 or q[0] not in (0.0, 1.0)
+
+    def test_no_information_anywhere_is_infinite(self):
+        # Positive regret everywhere, zero gain everywhere: nothing to buy.
+        delta = np.array([[0.5], [0.9]])
+        v = np.zeros((2, 1))
+        alive = np.ones((2, 1), dtype=bool)
+        *_, ratio = _optimal_two_point(delta, v, alive)
+        assert np.isinf(ratio[0])
+
+    def test_dead_arms_are_excluded(self):
+        # The globally best pair involves arm 0; killing it must change the answer.
+        delta = np.array([[0.0], [0.5], [0.6]])
+        v = np.array([[1.0], [0.4], [0.5]])
+        alive = np.array([[False], [True], [True]])
+        a_idx, b_idx, q, ratio = _optimal_two_point(delta, v, alive)
+        assert a_idx[0] != 0 and b_idx[0] != 0
+        assert np.isfinite(ratio[0])
+
+    def test_interior_mixture_sampling_frequencies(self):
+        # delta/v chosen so the optimum is a strict interior mixture.
+        delta = np.array([[0.1], [0.9]])
+        v = np.array([[0.01], [1.0]])
+        alive = np.ones((2, 1), dtype=bool)
+        a_idx, b_idx, q, ratio = _optimal_two_point(delta, v, alive)
+        assert 0.0 < q[0] < 1.0
+
+        rng = np.random.default_rng(0)
+        n_trials = 20_000
+        picks = np.concatenate(
+            [
+                _sample_information_ratio_minimizer(delta, v, alive, rng)
+                for _ in range(n_trials)
+            ]
+        )
+        freq_a = np.mean(picks == a_idx[0])
+        sigma = np.sqrt(q[0] * (1 - q[0]) / n_trials)
+        assert abs(freq_a - q[0]) < 5 * sigma
+
+
+class TestVidsStatistics:
+    """Monte Carlo regret and information-gain estimates."""
+
+    def test_hand_computed_two_arm_case(self):
+        # arm 0 draws [2, 0], arm 1 draws [1, 1]: each optimal in one draw.
+        samples = np.array([[[2.0, 0.0]], [[1.0, 1.0]]])
+        alive = np.ones((2, 1), dtype=bool)
+        delta, v = _vids_statistics(samples, alive)
+        # rho* = mean(max) = 1.5, mu = [1, 1]
+        np.testing.assert_allclose(delta, [[0.5], [0.5]])
+        # E[theta_0 | A*] in {2, 0} with p = 1/2 each -> v_0 = 1
+        # E[theta_1 | A*] = 1 always -> v_1 = 0
+        np.testing.assert_allclose(v, [[1.0], [0.0]])
+
+    def test_dominant_arm_has_zero_regret_and_no_information(self):
+        # arm 0 wins every draw: posterior resolved, all gains vanish.
+        samples = np.stack(
+            [np.full((1, 50), 3.0), np.random.default_rng(0).normal(0.0, 0.5, (1, 50))]
+        )
+        alive = np.ones((2, 1), dtype=bool)
+        delta, v = _vids_statistics(samples, alive)
+        assert delta[0, 0] == 0.0
+        np.testing.assert_allclose(v, 0.0, atol=1e-12)
+
+    def test_masked_arm_is_excluded_from_argmax(self):
+        # With arm 0 dead, the subgame is arms 1 vs 2.
+        samples = np.array(
+            [[[9.0, 9.0]], [[2.0, 0.0]], [[1.0, 1.0]]]
+        )  # arm 0 dominates when alive
+        alive = np.array([[False], [True], [True]])
+        delta, v = _vids_statistics(samples, alive)
+        np.testing.assert_allclose(delta[1:], [[0.5], [0.5]])
+        np.testing.assert_allclose(v[1:], [[1.0], [0.0]])
+
+    def test_correlated_draws_transfer_information(self):
+        # Perfectly anti-correlated arms: learning who is optimal moves
+        # both conditional means, so *both* arms carry information -- the
+        # signature shared-learner effect. With theta ~ N(0, 1) the gains
+        # have closed forms: E[theta | theta > 0] = sqrt(2/pi) gives
+        # v = 2/pi jointly, while independent draws of the same marginals
+        # give E[Y | Y < X] = -1/sqrt(pi) and v = 1/pi -- exactly half.
+        rng = np.random.default_rng(3)
+        theta = rng.normal(0.0, 1.0, size=100_000)
+        joint = np.stack([theta[None, :], -theta[None, :]])
+        alive = np.ones((2, 1), dtype=bool)
+        _, v_joint = _vids_statistics(joint, alive)
+
+        shuffled = joint.copy()
+        rng.shuffle(shuffled[1, 0])
+        _, v_indep = _vids_statistics(shuffled, alive)
+
+        np.testing.assert_allclose(v_joint, 2 / np.pi, rtol=0.05)
+        np.testing.assert_allclose(v_indep[1, 0], 1 / np.pi, rtol=0.05)
+
+
+class TestSelect:
+    """Policy-level selection semantics."""
+
+    def make_arms(self, n: int) -> List[Arm]:
+        return [Arm(i, learner=NormalInverseGammaRegressor()) for i in range(n)]
+
+    def test_resolved_posterior_plays_greedy(self):
+        # Constant samples with distinct means: no information anywhere,
+        # fallback plays the best arm deterministically.
+        samples = np.stack([np.full((1, 100), m) for m in [1.0, 3.0, 2.0]])
+        arms = self.make_arms(3)
+        policy = InformationDirectedSampling()
+        rng = np.random.default_rng(0)
+        for _ in range(10):
+            assert policy.select(samples, arms, rng)[0] is arms[1]
+
+    def test_pure_informative_arm_is_played(self):
+        # arm 0 known to give 1.0; arm 1 is a coin flip between 2 and 0.
+        # Regret is equal (0.5 each), all information sits on arm 1, so
+        # IDS plays arm 1 with probability one.
+        draws = np.tile([2.0, 0.0], 50)
+        samples = np.stack([np.full((1, 100), 1.0), draws[None, :]])
+        arms = self.make_arms(2)
+        policy = InformationDirectedSampling()
+        rng = np.random.default_rng(0)
+        for _ in range(10):
+            assert policy.select(samples, arms, rng)[0] is arms[1]
+
+    def test_top_k_one_matches_base_policy(self):
+        rng_state = np.random.default_rng(7)
+        samples = rng_state.normal(size=(4, 3, 200))
+        arms = self.make_arms(4)
+        policy = InformationDirectedSampling()
+
+        base = policy.select(samples, arms, np.random.default_rng(11))
+        slates = policy.select(samples, arms, np.random.default_rng(11), top_k=1)
+        assert [s[0] for s in slates] == base
+
+    def test_top_k_prefix_consistency_and_uniqueness(self):
+        samples = np.random.default_rng(5).normal(size=(5, 4, 300))
+        arms = self.make_arms(5)
+        policy = InformationDirectedSampling()
+
+        two = policy.select(samples, arms, np.random.default_rng(3), top_k=2)
+        three = policy.select(samples, arms, np.random.default_rng(3), top_k=3)
+        for slate2, slate3 in zip(two, three):
+            assert slate3[:2] == slate2
+            assert len(set(id(a) for a in slate3)) == 3  # without replacement
+
+    def test_top_k_at_least_n_arms_returns_all(self):
+        samples = np.random.default_rng(2).normal(size=(3, 2, 100))
+        arms = self.make_arms(3)
+        policy = InformationDirectedSampling()
+        slates = policy.select(samples, arms, np.random.default_rng(0), top_k=10)
+        for slate in slates:
+            assert sorted(a.action_token for a in slate) == [0, 1, 2]
+
+    def test_top_k_resolved_posterior_sorts_by_mean(self):
+        samples = np.stack([np.full((1, 50), m) for m in [1.0, 4.0, 2.0, 3.0]])
+        arms = self.make_arms(4)
+        policy = InformationDirectedSampling()
+        (slate,) = policy.select(samples, arms, np.random.default_rng(0), top_k=4)
+        assert [a.action_token for a in slate] == [1, 3, 2, 0]
+
+
+class TestPolicyBasics:
+    def test_initialization_and_repr(self):
+        policy = InformationDirectedSampling()
+        assert policy.samples == 1000
+        assert policy.samples_needed == 1000
+        assert repr(policy) == "InformationDirectedSampling(samples=1000)"
+
+        policy = InformationDirectedSampling(samples=250)
+        assert policy.samples_needed == 250
+
+    def test_requires_joint_draws(self):
+        assert InformationDirectedSampling.marginal_ok is False
+
+
+class TestAgentIntegration:
+    """End-to-end pulls and updates through each agent type."""
+
+    def test_agent_pull_update_cycle(self):
+        arms = [Arm(i, learner=NormalInverseGammaRegressor()) for i in range(3)]
+        agent = Agent(arms, InformationDirectedSampling(samples=200), random_seed=0)
+        for reward in [1.0, 0.5, 2.0, 1.5]:
+            (token,) = agent.pull()
+            assert token in {0, 1, 2}
+            agent.update(np.array([reward]))
+
+        slates = agent.pull(top_k=2)
+        assert len(slates[0]) == 2
+
+    @pytest.mark.parametrize("sparse", [False, True])
+    def test_contextual_agent_pull_update_cycle(self, sparse: bool):
+        arms = [
+            Arm(i, learner=NormalRegressor(alpha=1.0, beta=1.0, sparse=sparse))
+            for i in range(3)
+        ]
+        agent = ContextualAgent(
+            arms, InformationDirectedSampling(samples=200), random_seed=0
+        )
+        X = np.array([[1.0, 0.5], [0.2, 1.0]])
+        tokens = agent.pull(X[:1])
+        assert len(tokens) == 1
+        agent.update(X[:1], np.array([1.0]))
+
+        slates = agent.pull(X, top_k=2)
+        assert len(slates) == 2 and all(len(s) == 2 for s in slates)
+
+    def test_lipschitz_agent_shared_learner(self):
+        # Shared learner: batched joint sampling path (marginal_ok=False).
+        arms = [Arm(i, reward_function=None, learner=None) for i in range(4)]
+        agent = LipschitzContextualAgent(
+            arms=arms,
+            policy=InformationDirectedSampling(samples=200),
+            arm_featurizer=ArmColumnFeaturizer(column_name="product_id"),
+            learner=NormalInverseGammaRegressor(),
+            random_seed=0,
+        )
+        X = np.array([[1.0], [2.0], [0.5]])
+        tokens = agent.pull(X)
+        assert len(tokens) == 3
+        agent.update(X, np.array([1.0, 0.0, 2.0]))
+
+        slates = agent.pull(X, top_k=2)
+        assert len(slates) == 3 and all(len(s) == 2 for s in slates)
+
+    def test_concentrates_on_best_arm(self):
+        # After clearly separated observations, IDS should exploit.
+        arms = [Arm(i, learner=NormalInverseGammaRegressor()) for i in range(2)]
+        agent = Agent(arms, InformationDirectedSampling(samples=500), random_seed=42)
+        rng = np.random.default_rng(0)
+        for _ in range(60):
+            (token,) = agent.pull()
+            reward = rng.normal(loc=2.0 if token == 1 else 0.0, scale=0.1)
+            agent.update(np.array([reward]))
+
+        pulls = [agent.pull()[0] for _ in range(20)]
+        assert np.mean([t == 1 for t in pulls]) > 0.9


### PR DESCRIPTION
**Stack 2/3** for #240. Base is #261 — review that first, or read only the last commit here.

Purely additive: a new opt-in policy. No existing behavior touched, no sampling changes — uses whatever joint draws the learner already provides.

## What

Variance-based IDS after Russo & Van Roy (2018). Each round estimates every arm's expected regret and variance-based information gain from joint Monte Carlo draws, then plays the distribution minimizing the information ratio:

```
π* = argmin (Σ π_a Δ_a)² / (Σ π_a v_a)
```

That minimizer is supported on at most two arms (Prop. 6), so it's found in closed form by scanning ordered pairs and taking the best of the two stationary points and the endpoints, rather than by numerical optimization.

## Why joint draws matter

The point of IDS here is **cross-arm correlation**: under a shared learner an observation on one arm can be highly informative about another arm being optimal, which Thompson sampling ignores. The conditional means inside `v_a` condition on which arm is optimal *within the same draw*, so `marginal_ok` stays `False`.

Where arms cannot be batch-sampled, the per-arm fallback is incoherent across arms and the information gain degrades to its independent-arms form — still a valid algorithm, just blind to the correlation. Documented on the class.

## top_k

Returns sequential draws without replacement: slot 1 is exact IDS, each later slot re-solves exact IDS on the subgame of remaining arms. Slot order is meaningful; `top_k=1` matches the base policy in distribution. No formal slate-bandit guarantee is claimed for k > 1.

## Tests

321 lines. Covers the closed-form optimizer against a brute-force grid search over q, the Monte Carlo statistics against a naive loop implementation, the resolved-posterior greedy fallback, `top_k` slot semantics, and end-to-end agent integration.

2295 passed, 30 skipped. Lint clean.