### PR TITLE
Run CI on pull requests targeting any branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 jobs:
   lint:

--- a/.github/workflows/matrix_test.yml
+++ b/.github/workflows/matrix_test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
Both workflows trigger on `pull_request: branches: [master]`, so a **stacked PR** — one whose base is the branch below it rather than `master` — gets *no checks at all*. #262 and #263 currently show "no checks reported".

Removing the base-branch filter fixes that. The `push` trigger stays limited to `master`, so this adds no runs beyond the stacked PRs themselves.

Worth landing before the #261 → #262 → #263 stack so those get real CI instead of being verified only locally.