### PR TITLE
Avoid copying X in the sampling entry points

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -45,6 +45,11 @@ Unreleased
   one arm at a time and never affect sampling, so the common cases --
   no reward function, or per-arm functions only -- keep the speedup (#258)
 
+- ``sample`` and ``sample_marginal`` no longer copy ``X`` while validating
+  it. Neither mutates the validated array nor retains a reference to it,
+  so the copy was pure overhead, costing O(nnz(X)) per draw on sparse
+  models. ``fit``, ``partial_fit``, and ``predict`` are unchanged (#265)
+
 **Behavioral changes**
 
 - Seeded agent trajectories under ``UpperConfidenceBound``, ``EXP3A``, and

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -847,7 +847,7 @@ def _validated_marginal_mean_sd(
     return the per-row predictive mean and standard deviation of the
     linear predictor ``X @ w``."""
     X_pred = check_array(
-        X, copy=True, ensure_2d=True, accept_sparse="csc" if est.sparse else False
+        X, copy=False, ensure_2d=True, accept_sparse="csc" if est.sparse else False
     )
     try:
         check_is_fitted(est, "coef_")
@@ -1288,7 +1288,7 @@ scipy.sparse.csc_array
             self._initialize_prior(X)
 
         X_sample = check_array(
-            X, copy=True, ensure_2d=True, accept_sparse="csc" if self.sparse else False
+            X, copy=False, ensure_2d=True, accept_sparse="csc" if self.sparse else False
         )
 
         samples = np.atleast_2d(
@@ -1759,7 +1759,7 @@ scipy.sparse.csc_array
             self._initialize_prior(X)
 
         X_sample = check_array(
-            X, copy=True, ensure_2d=True, accept_sparse="csc" if self.sparse else False
+            X, copy=False, ensure_2d=True, accept_sparse="csc" if self.sparse else False
         )
         df = 2 * self.a_
 
@@ -2418,7 +2418,7 @@ scipy.sparse.csc_array
             self._initialize_prior(X)
 
         X_sample = check_array(
-            X, copy=True, ensure_2d=True, accept_sparse="csc" if self.sparse else False
+            X, copy=False, ensure_2d=True, accept_sparse="csc" if self.sparse else False
         )
 
         param_samples = np.atleast_2d(


### PR DESCRIPTION
`sample` on `NormalRegressor`, `NormalInverseGammaRegressor`, and `BayesianGLM`, along with the shared `sample_marginal` preamble `_validated_marginal_mean_sd`, all validated `X` with `copy=True`. None of them mutate the validated array or keep a reference to it, so the copy is pure overhead, and on sparse models it costs O(nnz(X)) on every draw.

### Why it is safe

- The joint draws only read `X_sample`, via `samples @ X_sample.T`.
- `_marginal_predictive_sd` only reads `X_pred`, on both branches: the dense one-shot `factor.half_solve(X.T)` and the blocked sparse loop, which densifies each block into fresh scratch (`X[start:stop].T.toarray()`).
- All three `_initialize_prior` overloads touch `X.shape[1]` only, and store nothing derived from `X`.

`fit`, `partial_fit`, and `predict` still pass `copy=True` and are not touched here.

### Verification

Full suite passes (2244 passed, 30 skipped). `ruff format` and `ruff check` clean. `pyright` on `_estimators.py` is unchanged against a stashed baseline.