### PR TITLE
Reduce joint predictive draws through the cheapest exact route

### DIFF
--- a/benchmarks/test_bench_reward_space_sampling.py
+++ b/benchmarks/test_bench_reward_space_sampling.py
@@ -98,11 +98,6 @@ def test_sample_1000_nig_dense_100_reward(benchmark, nig_dense_100):
     benchmark(est.sample_reward_space, X, 1000)
 
 
-def test_sample_1000_nig_dense_100_reward_blocked(benchmark, nig_dense_100):
-    est, X, _ = nig_dense_100
-    benchmark(est.sample_reward_space, X, 1000, block_size=5)
-
-
 # -- glm_logit dense 100, size=1000, n=10 -------------------------------------
 
 

--- a/benchmarks/test_bench_reward_space_sampling.py
+++ b/benchmarks/test_bench_reward_space_sampling.py
@@ -1,0 +1,154 @@
+"""Benchmarks for ``sample_reward_space``: joint predictive draws in reward space.
+
+Regimes:
+
+- Many draws, few rows (``size=1000``, ``n=10``): reward-space should win
+  decisively (expected ~5-6x dense at d=100, ~100x+ sparse at d=100k).
+- Many rows (``n=320 > d=100``): weight-space wins even against blocked
+  mode -- generating ``n*size`` normals costs more than ``d*size`` --
+  and the resolver's cost model (calibrated against these numbers) must
+  keep such calls on ``sample``. Blocked mode's role is bounding the QR
+  cost so many-context batches stay in the win region whenever
+  ``n_arms * n_contexts`` draws remain RNG-cheaper than ``d``-dim
+  weight draws (always at sparse d=100k).
+- ``size=1`` stays on the weight path via the resolver flop gate; the
+  existing ``test_sample_1_*`` benchmarks in ``test_bench_estimators.py``
+  guard that regime.
+
+``sample`` here is the weight-space baseline (it never dispatches);
+``sample_reward_space`` is the explicit fast path the IDS policy routes
+through.
+"""
+
+import numpy as np
+
+# -- normal dense 100, size=1000, n=10 (reward-space regime) ------------------
+
+
+def test_sample_1000_normal_dense_100_weight(benchmark, normal_dense_100):
+    est, X, _ = normal_dense_100
+    benchmark(est.sample, X, size=1000)
+
+
+def test_sample_1000_normal_dense_100_reward(benchmark, normal_dense_100):
+    est, X, _ = normal_dense_100
+    benchmark(est.sample_reward_space, X, 1000)
+
+
+def test_sample_1000_normal_dense_100_reward_blocked(benchmark, normal_dense_100):
+    est, X, _ = normal_dense_100
+    benchmark(est.sample_reward_space, X, 1000, block_size=5)
+
+
+# -- normal dense 100, n=320 (blocked mode rescues the many-rows regime) ------
+
+
+def test_sample_1000_rows_320_normal_dense_100_weight(benchmark, normal_dense_100):
+    est, _, _ = normal_dense_100
+    X = np.random.default_rng(7).standard_normal((320, 100))
+    benchmark(est.sample, X, size=1000)
+
+
+def test_sample_1000_rows_320_normal_dense_100_reward_full(benchmark, normal_dense_100):
+    est, _, _ = normal_dense_100
+    X = np.random.default_rng(7).standard_normal((320, 100))
+    benchmark(est.sample_reward_space, X, 1000)
+
+
+def test_sample_1000_rows_320_normal_dense_100_reward_blocked(
+    benchmark, normal_dense_100
+):
+    est, _, _ = normal_dense_100
+    X = np.random.default_rng(7).standard_normal((320, 100))
+    benchmark(est.sample_reward_space, X, 1000, block_size=10)
+
+
+# -- normal sparse 100k, size=1000, n=10 (reward-space regime) ----------------
+
+
+def test_sample_1000_normal_sparse_100k_weight(benchmark, normal_sparse_100k):
+    est, X, _ = normal_sparse_100k
+    benchmark(est.sample, X, size=1000)
+
+
+def test_sample_1000_normal_sparse_100k_reward(benchmark, normal_sparse_100k):
+    est, X, _ = normal_sparse_100k
+    benchmark(est.sample_reward_space, X, 1000)
+
+
+def test_sample_1000_normal_sparse_100k_reward_blocked(benchmark, normal_sparse_100k):
+    est, X, _ = normal_sparse_100k
+    benchmark(est.sample_reward_space, X, 1000, block_size=5)
+
+
+# -- nig dense 100, size=1000, n=10 -------------------------------------------
+
+
+def test_sample_1000_nig_dense_100_weight(benchmark, nig_dense_100):
+    est, X, _ = nig_dense_100
+    benchmark(est.sample, X, size=1000)
+
+
+def test_sample_1000_nig_dense_100_reward(benchmark, nig_dense_100):
+    est, X, _ = nig_dense_100
+    benchmark(est.sample_reward_space, X, 1000)
+
+
+def test_sample_1000_nig_dense_100_reward_blocked(benchmark, nig_dense_100):
+    est, X, _ = nig_dense_100
+    benchmark(est.sample_reward_space, X, 1000, block_size=5)
+
+
+# -- glm_logit dense 100, size=1000, n=10 -------------------------------------
+
+
+def test_sample_1000_glm_logit_dense_100_weight(benchmark, glm_logit_dense_100):
+    est, X, _ = glm_logit_dense_100
+    benchmark(est.sample, X, size=1000)
+
+
+def test_sample_1000_glm_logit_dense_100_reward(benchmark, glm_logit_dense_100):
+    est, X, _ = glm_logit_dense_100
+    benchmark(est.sample_reward_space, X, 1000)
+
+
+# -- end-to-end: IDS pull through LipschitzContextualAgent --------------------
+
+
+def _ids_lipschitz_agent(learner, n_arms=10, d_ctx=99, n_train=300):
+    from bayesianbandits import (
+        Arm,
+        ArmColumnFeaturizer,
+        InformationDirectedSampling,
+        LipschitzContextualAgent,
+    )
+
+    rng = np.random.default_rng(0)
+    arms = [Arm(i, reward_function=None, learner=None) for i in range(n_arms)]
+    agent = LipschitzContextualAgent(
+        arms=arms,
+        policy=InformationDirectedSampling(samples=1000),
+        arm_featurizer=ArmColumnFeaturizer(column_name="product_id"),
+        learner=learner,
+        random_seed=0,
+    )
+    X_train = rng.standard_normal((n_train, d_ctx))
+    agent.pull(X_train[:1])
+    agent.update(X_train, rng.standard_normal(n_train))
+    return agent, rng.standard_normal((8, d_ctx))
+
+
+def test_ids_pull_lipschitz_dense_100(benchmark):
+    from bayesianbandits import NormalRegressor
+
+    agent, X = _ids_lipschitz_agent(NormalRegressor(alpha=1.0, beta=1.0))
+    benchmark(agent.pull, X)
+
+
+def test_ids_pull_lipschitz_dense_100_weight_space(benchmark):
+    """Forced weight-space baseline for the pull above."""
+    from bayesianbandits import NormalRegressor
+
+    agent, X = _ids_lipschitz_agent(NormalRegressor(alpha=1.0, beta=1.0))
+    agent.learner._use_reward_space = lambda *a, **k: False
+    benchmark(agent.pull, X)

--- a/benchmarks/test_bench_reward_space_sampling.py
+++ b/benchmarks/test_bench_reward_space_sampling.py
@@ -1,33 +1,34 @@
-"""Benchmarks for ``sample_reward_space``: joint predictive draws in reward space.
+"""Benchmarks for joint predictive draws: weight space against reward space.
 
-Regimes:
-
-- Many draws, few rows (``size=1000``, ``n=10``): reward-space should win
-  decisively (expected ~5-6x dense at d=100, ~100x+ sparse at d=100k).
-- Many rows (``n=320 > d=100``): weight-space wins even against blocked
-  mode -- generating ``n*size`` normals costs more than ``d*size`` --
-  and the resolver's cost model (calibrated against these numbers) must
-  keep such calls on ``sample``. Blocked mode's role is bounding the QR
-  cost so many-context batches stay in the win region whenever
-  ``n_arms * n_contexts`` draws remain RNG-cheaper than ``d``-dim
-  weight draws (always at sparse d=100k).
-- ``size=1`` stays on the weight path via the resolver flop gate; the
-  existing ``test_sample_1_*`` benchmarks in ``test_bench_estimators.py``
-  guard that regime.
-
-``sample`` here is the weight-space baseline (it never dispatches);
-``sample_reward_space`` is the explicit fast path the IDS policy routes
-through.
+``sample`` reduces through the cheapest exact route on its own, so the
+``_weight`` cases below patch the reduction out to keep a true weight-space
+baseline. ``sample_reward_space`` is the explicit row-side route, in full
+and blocked mode. The ``rows_320`` cases (``n_rows > d``) sit in the
+region where weight space should win and the gate must keep ``sample``
+there; ``size=1`` is covered by ``test_bench_estimators.py``.
 """
 
+from contextlib import contextmanager
+from unittest import mock
+
 import numpy as np
+
+from bayesianbandits import _estimators
+
+
+@contextmanager
+def _weight_space():
+    with mock.patch.object(_estimators, "build_joint_reduction", return_value=None):
+        yield
+
 
 # -- normal dense 100, size=1000, n=10 (reward-space regime) ------------------
 
 
 def test_sample_1000_normal_dense_100_weight(benchmark, normal_dense_100):
     est, X, _ = normal_dense_100
-    benchmark(est.sample, X, size=1000)
+    with _weight_space():
+        benchmark(est.sample, X, size=1000)
 
 
 def test_sample_1000_normal_dense_100_reward(benchmark, normal_dense_100):
@@ -40,13 +41,14 @@ def test_sample_1000_normal_dense_100_reward_blocked(benchmark, normal_dense_100
     benchmark(est.sample_reward_space, X, 1000, block_size=5)
 
 
-# -- normal dense 100, n=320 (blocked mode rescues the many-rows regime) ------
+# -- normal dense 100, n=320 > d (weight space should win) --------------------
 
 
 def test_sample_1000_rows_320_normal_dense_100_weight(benchmark, normal_dense_100):
     est, _, _ = normal_dense_100
     X = np.random.default_rng(7).standard_normal((320, 100))
-    benchmark(est.sample, X, size=1000)
+    with _weight_space():
+        benchmark(est.sample, X, size=1000)
 
 
 def test_sample_1000_rows_320_normal_dense_100_reward_full(benchmark, normal_dense_100):
@@ -68,7 +70,8 @@ def test_sample_1000_rows_320_normal_dense_100_reward_blocked(
 
 def test_sample_1000_normal_sparse_100k_weight(benchmark, normal_sparse_100k):
     est, X, _ = normal_sparse_100k
-    benchmark(est.sample, X, size=1000)
+    with _weight_space():
+        benchmark(est.sample, X, size=1000)
 
 
 def test_sample_1000_normal_sparse_100k_reward(benchmark, normal_sparse_100k):
@@ -86,7 +89,8 @@ def test_sample_1000_normal_sparse_100k_reward_blocked(benchmark, normal_sparse_
 
 def test_sample_1000_nig_dense_100_weight(benchmark, nig_dense_100):
     est, X, _ = nig_dense_100
-    benchmark(est.sample, X, size=1000)
+    with _weight_space():
+        benchmark(est.sample, X, size=1000)
 
 
 def test_sample_1000_nig_dense_100_reward(benchmark, nig_dense_100):
@@ -104,51 +108,10 @@ def test_sample_1000_nig_dense_100_reward_blocked(benchmark, nig_dense_100):
 
 def test_sample_1000_glm_logit_dense_100_weight(benchmark, glm_logit_dense_100):
     est, X, _ = glm_logit_dense_100
-    benchmark(est.sample, X, size=1000)
+    with _weight_space():
+        benchmark(est.sample, X, size=1000)
 
 
 def test_sample_1000_glm_logit_dense_100_reward(benchmark, glm_logit_dense_100):
     est, X, _ = glm_logit_dense_100
     benchmark(est.sample_reward_space, X, 1000)
-
-
-# -- end-to-end: IDS pull through LipschitzContextualAgent --------------------
-
-
-def _ids_lipschitz_agent(learner, n_arms=10, d_ctx=99, n_train=300):
-    from bayesianbandits import (
-        Arm,
-        ArmColumnFeaturizer,
-        InformationDirectedSampling,
-        LipschitzContextualAgent,
-    )
-
-    rng = np.random.default_rng(0)
-    arms = [Arm(i, reward_function=None, learner=None) for i in range(n_arms)]
-    agent = LipschitzContextualAgent(
-        arms=arms,
-        policy=InformationDirectedSampling(samples=1000),
-        arm_featurizer=ArmColumnFeaturizer(column_name="product_id"),
-        learner=learner,
-        random_seed=0,
-    )
-    X_train = rng.standard_normal((n_train, d_ctx))
-    agent.pull(X_train[:1])
-    agent.update(X_train, rng.standard_normal(n_train))
-    return agent, rng.standard_normal((8, d_ctx))
-
-
-def test_ids_pull_lipschitz_dense_100(benchmark):
-    from bayesianbandits import NormalRegressor
-
-    agent, X = _ids_lipschitz_agent(NormalRegressor(alpha=1.0, beta=1.0))
-    benchmark(agent.pull, X)
-
-
-def test_ids_pull_lipschitz_dense_100_weight_space(benchmark):
-    """Forced weight-space baseline for the pull above."""
-    from bayesianbandits import NormalRegressor
-
-    agent, X = _ids_lipschitz_agent(NormalRegressor(alpha=1.0, beta=1.0))
-    agent.learner._use_reward_space = lambda *a, **k: False
-    benchmark(agent.pull, X)

--- a/benchmarks/test_bench_support_covariance.py
+++ b/benchmarks/test_bench_support_covariance.py
@@ -1,0 +1,128 @@
+"""Benchmarks for the support-covariance sampling route.
+
+The route trades one solve per draw (or per row) for one solve per
+distinct column touched, so it helps exactly when a sparse design matrix
+has many rows or many draws over a small feature support -- the
+``LipschitzContextualAgent`` shape, where rows are arms.
+
+Each pair below benchmarks the same call with the route enabled and
+disabled. The ``declines_`` pair is as important as the others: it
+guards the region where the pre-existing path is better, so a future
+change to the gate cannot silently regress it.
+"""
+
+from contextlib import contextmanager
+from unittest import mock
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+from bayesianbandits import NormalRegressor
+from bayesianbandits import _support_covariance as sc
+
+N_FEATURES = 100_000
+
+
+@contextmanager
+def _gate_off():
+    with mock.patch.object(sc, "build", lambda *a, **k: None):
+        yield
+
+
+def _fit(n_features, rng):
+    est = NormalRegressor(alpha=1.0, beta=1.0, sparse=True, random_state=0)
+    X = sp.csc_array(sp.random(200, n_features, density=1e-4, random_state=42))
+    est.fit(X, rng.standard_normal(200))
+    return est
+
+
+def _design(n_features, n_rows, n_u, rng, nnz_per_row=8):
+    support = np.sort(rng.choice(n_features, n_u, replace=False))
+    rows, cols, vals = [], [], []
+    for i in range(n_rows):
+        pick = rng.choice(n_u, nnz_per_row, replace=False)
+        rows += [i] * nnz_per_row
+        cols += list(support[pick])
+        vals += list(rng.standard_normal(nnz_per_row))
+    return sp.csc_array(sp.csr_array((vals, (rows, cols)), shape=(n_rows, n_features)))
+
+
+@pytest.fixture(scope="module")
+def arms_96():
+    """96 arms over a 49-column support: the production agent's shape."""
+    rng = np.random.default_rng(0)
+    return _fit(N_FEATURES, rng), _design(N_FEATURES, 96, 49, rng)
+
+
+@pytest.fixture(scope="module")
+def rows_2000():
+    """Many prediction rows over a small support."""
+    rng = np.random.default_rng(1)
+    return _fit(N_FEATURES, rng), _design(N_FEATURES, 2_000, 49, rng)
+
+
+@pytest.fixture(scope="module")
+def wide_support_10_rows():
+    """Few rows, wide support: the route must decline here."""
+    rng = np.random.default_rng(2)
+    return _fit(N_FEATURES, rng), _design(N_FEATURES, 10, 800, rng)
+
+
+# -- joint draws, size=500 (the UCB/EXP3A regime) ------------------------------
+
+
+@pytest.mark.benchmark(group="support_cov_joint_arms96")
+def test_sample_500_arms96_route(benchmark, arms_96):
+    est, X = arms_96
+    benchmark(est.sample, X, size=500)
+
+
+@pytest.mark.benchmark(group="support_cov_joint_arms96")
+def test_sample_500_arms96_weight_space(benchmark, arms_96):
+    est, X = arms_96
+    with _gate_off():
+        benchmark(est.sample, X, size=500)
+
+
+# -- per-row standard deviations ----------------------------------------------
+
+
+@pytest.mark.benchmark(group="support_cov_marginal_rows2000")
+def test_sample_marginal_500_rows2000_route(benchmark, rows_2000):
+    est, X = rows_2000
+    benchmark(est.sample_marginal, X, size=500)
+
+
+@pytest.mark.benchmark(group="support_cov_marginal_rows2000")
+def test_sample_marginal_500_rows2000_half_solves(benchmark, rows_2000):
+    est, X = rows_2000
+    with _gate_off():
+        benchmark(est.sample_marginal, X, size=500)
+
+
+# -- the region the gate must keep declining ----------------------------------
+
+
+@pytest.mark.benchmark(group="support_cov_declines_wide")
+def test_sample_marginal_500_wide_support_route_declines(
+    benchmark, wide_support_10_rows
+):
+    est, X = wide_support_10_rows
+    benchmark(est.sample_marginal, X, size=500)
+
+
+@pytest.mark.benchmark(group="support_cov_declines_wide")
+def test_sample_marginal_500_wide_support_half_solves(benchmark, wide_support_10_rows):
+    est, X = wide_support_10_rows
+    with _gate_off():
+        benchmark(est.sample_marginal, X, size=500)
+
+
+# -- Thompson hot path: must be untouched -------------------------------------
+
+
+@pytest.mark.benchmark(group="support_cov_thompson")
+def test_sample_1_arms96_route_declines(benchmark, arms_96):
+    est, X = arms_96
+    benchmark(est.sample, X, size=1)

--- a/benchmarks/test_bench_support_covariance.py
+++ b/benchmarks/test_bench_support_covariance.py
@@ -1,14 +1,9 @@
-"""Benchmarks for the support-covariance sampling route.
+"""Benchmarks for the support-covariance route: one solve per distinct
+column touched instead of one per draw or per row.
 
-The route trades one solve per draw (or per row) for one solve per
-distinct column touched, so it helps exactly when a sparse design matrix
-has many rows or many draws over a small feature support -- the
-``LipschitzContextualAgent`` shape, where rows are arms.
-
-Each pair below benchmarks the same call with the route enabled and
-disabled. The ``declines_`` pair is as important as the others: it
-guards the region where the pre-existing path is better, so a future
-change to the gate cannot silently regress it.
+Each pair benchmarks the same call with the route on and off; the
+``declines_`` pair guards the region where the pre-existing path is
+better.
 """
 
 from contextlib import contextmanager

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -55,6 +55,18 @@ Unreleased
 
 **Performance**
 
+- Dense sampling no longer forms an explicit :math:`U^{-1}`. The precision
+  factor is rebuilt after every ``partial_fit``, so materializing the
+  inverse charged an :math:`O(d^3)` triangular inversion to every update
+  -- 13x to 17x the Cholesky that preceded it, and the largest single term
+  in a pull-and-update round -- to save nothing, since solving against
+  ``U`` costs the same per draw as multiplying by the inverse.
+  ``DenseFactor.colorize`` now calls ``dtrsm``, which also keeps the draw
+  inside scipy's BLAS pool. A dense ``size = 1`` pull plus update at
+  :math:`d` = 1,000 falls from 106 ms to 11 ms. ``trace_inv`` genuinely
+  needs the inverse and still builds it lazily, now through ``dtrtri``
+  rather than a solve against a dense identity (#269)
+
 - Joint ``sample`` draws reduce through whichever exact route is cheapest.
   :math:`\operatorname{Cov}(Xw) = X \Lambda^{-1} X^T` has a square root
   on each side: weight space costs ``size`` solves against the cached
@@ -73,12 +85,31 @@ Unreleased
   of memory beyond ~2,600 draws. The column side also serves
   ``sample_marginal`` when :math:`|U|` beats the row count (#269)
 
-- The reward-space path is ``scipy.linalg`` throughout (``dgeqrf``,
-  ``dgemm``, ``dgemv``). ``numpy`` and ``scipy`` bind separate copies of
-  OpenBLAS with separate thread pools, and alternating between them
-  within one call parks and unparks both: on a 28-core box a 100x100 QR
-  took 81 ms through ``numpy.linalg.qr`` and 0.9 ms through ``dgeqrf``
-  (#269)
+  Those dense figures were measured before the BLAS thread-pool fixes
+  below, which cut the weight-space side by up to 8.9x and so narrowed
+  the row side's dense margin; the swept shapes stay wins, but past them
+  the ``2 n_rows <= size`` guard is now slightly loose. At
+  :math:`p` = 1,000 with 448 rows and ``size`` = 900 the row side is
+  taken and runs 0.76x to 0.81x, the crossover there having moved from
+  ``2 n_rows`` to roughly ``4 n_rows``. The guard is left alone
+  deliberately: tightening it would need a fitted constant, and dense
+  cost models are dependent on a BLAS threading configuration the
+  library cannot observe.
+
+- The reward-space, support-covariance, weight-space, and dense sampling
+  paths are ``scipy.linalg`` throughout (``dgeqrf``, ``dgemm``,
+  ``dgemv``, ``dtrsm``, ``dpotrf``). ``numpy`` and ``scipy`` bind
+  separate copies of OpenBLAS with separate thread pools, and
+  alternating between them within one call parks and unparks both: on a
+  28-core box a 100x100 QR took 81 ms through ``numpy.linalg.qr`` and
+  0.9 ms through ``dgeqrf``. The last two crossings to go were the
+  weight-space tail ``draws @ X.T``, which followed the triangular solve
+  that produced ``draws``, and the predictive mean ``X @ coef`` ahead of
+  the reduced draw. Routing both through ``dgemm``/``dgemv`` took a
+  dense ``sample`` at :math:`d` = 1,000 with 320 rows and ``size`` = 100
+  from 40.0 ms to 4.5 ms. Operands are passed in whichever orientation
+  they already hold, since a C-contiguous array's transpose is
+  Fortran-contiguous and the naive spelling would copy both (#269)
 
 - ``SuperLUSparseFactor.solve`` goes through the cached triangular factor
   for a dense right-hand side instead of refactorizing on every call, and
@@ -113,7 +144,10 @@ Unreleased
 - ``sample`` and ``sample_marginal`` no longer copy ``X`` while validating
   it. Neither mutates the validated array nor retains a reference to it,
   so the copy was pure overhead, costing O(nnz(X)) per draw on sparse
-  models. ``fit``, ``partial_fit``, and ``predict`` are unchanged (#265)
+  models. ``fit`` and ``partial_fit`` are unchanged (#265)
+
+- ``sample_reward_space``, ``predict``, and ``predict_proba`` likewise no
+  longer copy ``X``: they only read it (#269)
 
 **Behavioral changes**
 
@@ -130,8 +164,14 @@ Unreleased
 - Seeded ``sample`` trajectories change wherever a reduction applies: the
   row and column routes consume ``n_rows`` and :math:`|U|` normals per
   draw rather than one per feature. The draws are exact and jointly
-  distributed either way (verified by per-row KS tests). Thompson sampling (``size = 1``) never reduces and
-  is bit-for-bit unchanged (#269)
+  distributed either way (verified by per-row KS tests). Thompson sampling
+  (``size = 1``) never reduces, and on sparse models is bit-for-bit
+  unchanged (#269)
+
+- Dense seeded draws change in the last bits, Thompson sampling included:
+  ``colorize`` solves against ``U`` instead of multiplying by an explicit
+  ``U^{-1}``, the same operation in exact arithmetic but a different
+  rounding order (the two agree to ~2e-16). No distribution changes (#269)
 
 1.4.0 (2026-07-31)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -116,6 +116,34 @@ Unreleased
   now preserves the column of a single-column 2-D input, as CHOLMOD does
   (#269)
 
+- Every dense right-hand side handed to a sparse factor is now
+  Fortran-ordered. CHOLMOD's dense format is column-major, so a C-ordered
+  block is copied before the solve begins -- and on the
+  support-covariance route that block is ``(n_features, |U|)``, large
+  enough that the copy outweighed the solve. At :math:`p` = 100,000 with
+  96 rows over a 49-column support, ``sample`` at ``size`` = 100 goes
+  from 19.5 ms to 9.8 ms and ``sample_marginal`` at ``size`` = 10 from
+  19.8 ms to 9.6 ms (#269)
+
+- The sparse factors no longer precompute state only ``colorize`` needs,
+  which every ``fit``/``partial_fit`` was paying for and neither uses.
+  Sparse ``partial_fit`` at :math:`p` = 100,000 falls from 13.0 ms to
+  10.0 ms under CHOLMOD (#269)
+
+- ``CholmodSparseFactor`` inverts the fill-reducing permutation by
+  scattering rather than sorting, :math:`O(p)` instead of
+  :math:`O(p \log p)`. It is rebuilt with the factor, so a Thompson pull
+  pays it every round: a ``sample(size=1)`` and ``partial_fit`` round at
+  :math:`p` = 100,000 falls from 11.9 ms to 11.1 ms (#269)
+
+- ``SuperLUSparseFactor`` retains its decomposition, so ``solve`` runs
+  both triangular sweeps in one ``gstrs`` call instead of two trips
+  through ``spsolve_triangular``; the symmetric ``L`` that sampling needs
+  is derived from it on demand. At :math:`p` = 100,000, ``sample`` and
+  ``sample_marginal`` over a 49-column support run 4.3x faster and
+  ``partial_fit`` 1.8x. The factor holds ``L`` and ``U`` rather than one
+  folded ``L``, costing roughly one extra ``nnz(L)`` when sampling (#269)
+
 - ``UpperConfidenceBound``, ``EXP3A``, and ``EpsilonGreedy`` now draw
   through the marginal path (they consume only per-arm, per-context
   statistics, for which marginal draws are exact), giving large speedups

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,15 +11,15 @@ Unreleased
   two arms share one. Neither agent gives arms a way to differ in
   features, so arms sharing a learner were statistically
   indistinguishable; worse, the policies on that path sample one arm at a
-  time, which draws a separate weight vector per arm and silently discards
-  the dependence a shared posterior implies. A policy asking for joint
-  draws could therefore receive independent ones: on arms sharing a
-  learner, measured cross-arm correlation was 0.00 where the true value
-  was 1.00. Sharing one model across arms is
-  ``LipschitzContextualAgent``'s job -- it distinguishes arms with an
-  ``arm_featurizer`` and samples the shared learner once for all of them
-  -- and the error says so. Two distinct ``LearnerPipeline`` objects
-  wrapping the same estimator also count as sharing (#267)
+  time, which draws a separate weight vector per arm and silently
+  discards the dependence a shared posterior implies. A policy declaring
+  ``marginal_ok = False`` could therefore ask for joint draws and receive
+  independent ones: on arms sharing a learner, measured cross-arm
+  correlation was 0.00 where the true value was 1.00. Sharing one model
+  across arms is ``LipschitzContextualAgent``'s job -- it distinguishes
+  arms with an ``arm_featurizer`` and samples the shared learner once for
+  all of them -- and the error says so. Two distinct ``LearnerPipeline``
+  objects wrapping the same estimator also count as sharing (#267)
 
 - The batched arm-sampling path is removed: ``batch_sample_arms``,
   ``can_batch_arms``, ``stack_features``, and the ``LearnerWithTransform``
@@ -34,16 +34,12 @@ Unreleased
 
 - ``sample_reward_space`` on ``NormalRegressor``,
   ``NormalInverseGammaRegressor``, and ``BayesianGLM``: joint draws from
-  the exact posterior predictive, computed by QR-factoring ``half_solve``
-  output into a triangular square root of :math:`X \Lambda^{-1} X^T` and
-  drawing directly in reward space -- distributionally identical to
-  ``sample``, but per-draw cost is independent of the feature count
-  (neither :math:`\Lambda^{-1}` nor any covariance is ever formed;
-  rank-deficient ``X`` is exact). With ``block_size=k``, consecutive row
-  groups are drawn jointly within and independently across groups, which no
-  other route can produce, so it stays an explicit request rather than a
-  cost decision. Full-mode draws need no request: ``sample`` reduces through
-  this route on its own whenever it is cheapest (see below) (#269)
+  the exact posterior predictive, factored in reward space (one triangular
+  half-solve per prediction row against the cached precision factor, then
+  a QR), so per-draw cost is independent of the feature count.
+  Distributionally identical to ``sample``; with ``block_size=k``,
+  consecutive groups of ``k`` rows are drawn jointly within and
+  independently across groups (#269)
 
 - ``sample_marginal`` on ``NormalRegressor``, ``NormalInverseGammaRegressor``,
   and ``BayesianGLM``: iid draws from each prediction row's exact marginal
@@ -59,67 +55,47 @@ Unreleased
 
 **Performance**
 
-- Joint ``sample`` draws now reduce through whichever exact route is
-  cheapest. :math:`\operatorname{Cov}(Xw) = X \Lambda^{-1} X^T` has rank at
-  most :math:`\min(n_{\text{rows}}, |U|, p)`, and there is a reduction to a
-  small square root on each side, so the three routes differ only in how
-  many triangular solves against the cached factor they cost:
+- Joint ``sample`` draws reduce through whichever exact route is cheapest.
+  :math:`\operatorname{Cov}(Xw) = X \Lambda^{-1} X^T` has a square root
+  on each side: weight space costs ``size`` solves against the cached
+  factor, the row side ``n_rows`` solves and an ``n_rows x n_rows`` QR,
+  and, for sparse ``X`` touching ``|U|`` columns, the column side ``|U|``
+  solves and the ``|U| x |U|`` block of :math:`\Lambda^{-1}` (an identity,
+  since :math:`X = X_U E_U^T`). The choice is
+  ``min(size, n_rows, |U|)``, three known integers with no calibration
+  constants; at ``size = 1`` nothing beats weight space, so Thompson
+  sampling is bit-for-bit unchanged. Over 36 dense shapes (:math:`p` in
+  {100, 1000}, ``n_rows`` up to 320, ``size`` up to 1000): no regressions,
+  speedups to 45.9x. Sparse: :math:`p` = 100,000, one row, ``size`` = 1000
+  goes from 6.0 s to 7.0 ms; a :math:`2^{20}`-feature agent with 96 arms
+  over a 49-column support draws ``size=500`` in 0.99 s instead of 31.5 s,
+  without the ``size``-proportional weight-space allocation that ran out
+  of memory beyond ~2,600 draws. The column side also serves
+  ``sample_marginal`` when :math:`|U|` beats the row count (#269)
 
-  .. list-table::
-     :header-rows: 1
+- The reward-space path is ``scipy.linalg`` throughout (``dgeqrf``,
+  ``dgemm``, ``dgemv``). ``numpy`` and ``scipy`` bind separate copies of
+  OpenBLAS with separate thread pools, and alternating between them
+  within one call parks and unparks both: on a 28-core box a 100x100 QR
+  took 81 ms through ``numpy.linalg.qr`` and 0.9 ms through ``dgeqrf``
+  (#269)
 
-     * - route
-       - solves
-       - square root
-     * - weight space
-       - ``size``
-       - :math:`p \times p`, cached
-     * - row side
-       - ``n_rows``
-       - :math:`n_{\text{rows}} \times n_{\text{rows}}`
-     * - column side
-       - :math:`|U|`
-       - :math:`|U| \times |U|`
-
-  The choice is therefore :math:`\min(\text{size}, n_{\text{rows}}, |U|)`,
-  three exactly known integers, and the gate holds no calibration
-  constants. Weight space is the one whose square root is *cached* -- it
-  factors :math:`\Lambda`, which does not depend on ``X`` -- so it builds
-  nothing and pays per draw, while the other two refactor on every call.
-  That is why neither can win at small ``size``: there is nothing to
-  amortize. ``size = 1`` therefore always stays on weight space, and
-  Thompson sampling is bit-for-bit unchanged.
-
-  Previously the column side was chosen inside ``sample`` and the row side
-  out at the agent behind a policy flag, so neither could account for what
-  the other would have picked. Measured end-to-end over 36 dense shapes
-  (:math:`p` in {100, 1000}, ``n_rows`` in {1, 10, 32, 96, 320}, ``size``
-  in {1, 100, 500, 1000}): no regressions, and speedups to 45.9x. Sparse
-  gains reach 860x (:math:`p` = 100,000, one row, ``size`` = 1000: 6.0 s to
-  7.0 ms) (#269)
-
-- Every step of the reward-space path after the half-solve is taken from
-  ``scipy.linalg`` rather than ``numpy`` (``dgeqrf`` for the QR, ``dgemm``
-  for the draws, ``dgemv`` for the predictive mean). ``numpy`` and
-  ``scipy`` bind separate copies of OpenBLAS, each with its own thread
-  pool, and alternating between them within one call parks and unparks
-  both. On a 28-core box that cost more than every flop on the path: a
-  100x100 QR took 81 ms through ``numpy.linalg.qr`` and 0.9 ms through
-  ``dgeqrf``. Reward-space sampling is up to 102x faster than before this
-  routing (#269)
+- ``SuperLUSparseFactor.solve`` goes through the cached triangular factor
+  for a dense right-hand side instead of refactorizing on every call, and
+  now preserves the column of a single-column 2-D input, as CHOLMOD does
+  (#269)
 
 - ``UpperConfidenceBound``, ``EXP3A``, and ``EpsilonGreedy`` now draw
   through the marginal path (they consume only per-arm, per-context
   statistics, for which marginal draws are exact), giving large speedups
   for their Monte Carlo estimates, dense and sparse alike.
-  ``ThompsonSampling`` and joint ``sample`` are unchanged, byte-for-byte.
-  Custom policies can opt in by setting ``marginal_ok = True`` (declared on
-  ``PolicyProtocol``), and subclasses of the built-in policies can opt out
-  with ``marginal_ok = False``, which their ``__call__`` and the agents both
-  honor. The marginal path is never used
-  for a learner whose class overrides ``sample`` without also overriding
-  ``sample_marginal``, so customized joint sampling is not silently
-  bypassed (#258)
+  ``ThompsonSampling`` is unchanged, byte-for-byte.
+  Custom policies can opt in by setting ``marginal_ok = True`` (declared
+  on ``PolicyProtocol``), and subclasses of the built-in policies can
+  opt out with ``marginal_ok = False``, which their ``__call__`` and the
+  agents both honor. The marginal path is never used for a learner whose
+  class overrides ``sample`` without also overriding ``sample_marginal``,
+  so customized joint sampling is not silently bypassed (#258)
 
 - The marginal path is likewise never used when a
   ``LipschitzContextualAgent`` carries a user-supplied
@@ -127,58 +103,35 @@ Unreleased
   may combine arms within it (share of total, cannibalization, softmax
   over a slate), which requires the arms of a draw to be jointly
   distributed; iid marginal draws leave such a reward's mean intact but
-  manufacture spread that a quantile-based policy reads as uncertainty. A
-  per-arm ``Arm.reward_function`` is applied one arm at a time and never
-  affects sampling, so the common cases -- no reward function, or per-arm
-  functions only -- keep the speedup (#258)
-
-- The column-side reduction above. Writing :math:`U` for the columns a
-  sparse design matrix touches, :math:`X = X_U E_U^T` exactly, so
-  :math:`\operatorname{Cov}(Xw) = X_U (\Lambda^{-1})_{U,U} X_U^T`: the whole
-  predictive law follows from one :math:`|U| \times |U|` block, obtained
-  with :math:`|U|` solves against the cached factor. Every draw after that
-  is dense linear algebra on that small block, never touching the factor
-  again. The reformulation is exact, and the cost carries no dependence on
-  the factor's elimination tree. Dense models never take it, since there
-  :math:`|U|` is the full feature count and there is nothing to reduce. On a
-  production agent (:math:`2^{20}` features, 96 arms over a 49-column
-  support) a ``size=500`` joint draw goes from 31.5 s to 0.99 s, and
-  additionally drops the ``size``-proportional weight-space allocation,
-  which at that width exhausted memory beyond roughly 2,600 draws. It also
-  serves ``sample_marginal``, where it is taken when :math:`|U|` beats the
-  row count (#269)
+  manufacture spread that a quantile-based policy reads as uncertainty.
+  A batch function that maps each ``(arm, context, draw)`` cell
+  independently can opt back into the faster path by carrying a truthy
+  ``elementwise`` attribute. Per-arm ``Arm.reward_function``s are applied
+  one arm at a time and never affect sampling, so the common cases --
+  no reward function, or per-arm functions only -- keep the speedup (#258)
 
 - ``sample`` and ``sample_marginal`` no longer copy ``X`` while validating
-  it. Neither mutates the validated array nor retains a reference to it, so
-  the copy was pure overhead, costing O(nnz(X)) per draw on sparse models.
-  ``fit``, ``partial_fit``, and ``predict`` are unchanged (#265)
-
-- ``SuperLUSparseFactor.solve`` no longer refactorizes the precision on
-  every call for a dense right-hand side, going through the cached
-  triangular factor instead. Sparse right-hand sides are unchanged. This
-  also settles a discrepancy between the backends: SuperLU returned a
-  1-D result for a single-column 2-D input, where CHOLMOD preserved the
-  column; both now preserve it (#269)
+  it. Neither mutates the validated array nor retains a reference to it,
+  so the copy was pure overhead, costing O(nnz(X)) per draw on sparse
+  models. ``fit``, ``partial_fit``, and ``predict`` are unchanged (#265)
 
 **Behavioral changes**
 
 - Seeded agent trajectories under ``UpperConfidenceBound``, ``EXP3A``, and
-  ``EpsilonGreedy`` change: the marginal path consumes different amounts of
-  randomness than joint sampling. Per-row marginals are identical (verified
-  by KS tests) and decisions converge to the same choices as ``samples``
-  grows, but for arms sharing one model the per-arm Monte Carlo estimates
-  no longer share weight draws, so finite-sample selection noise among
-  near-tied arms increases; raise ``samples`` to compensate (marginal draws
-  are much cheaper per draw), or opt the policy out with
-  ``marginal_ok = False`` (#258)
+  ``EpsilonGreedy`` change: the marginal path consumes different amounts
+  of randomness than joint sampling. Per-row marginals are identical
+  (verified by KS tests) and decisions converge to the same choices as
+  ``samples`` grows, but for arms sharing one model the per-arm Monte
+  Carlo estimates no longer share weight draws, so finite-sample
+  selection noise among near-tied arms increases; raise ``samples`` to
+  compensate (marginal draws are much cheaper per draw), or opt the
+  policy out with ``marginal_ok = False`` (#258)
 
-- Seeded ``sample`` trajectories change wherever a reduction applies, since
-  the row and column routes consume ``n_rows`` and :math:`|U|` normals per
+- Seeded ``sample`` trajectories change wherever a reduction applies: the
+  row and column routes consume ``n_rows`` and :math:`|U|` normals per
   draw rather than one per feature. The draws are exact and jointly
-  distributed either way, and agreement with the weight-space path is
-  verified by KS tests per row. Thompson sampling is unaffected: at
-  ``size = 1`` no reduction can win, so none is taken and the output is
-  bit-for-bit identical (enforced by a test) (#263, #266)
+  distributed either way (verified by per-row KS tests). Thompson sampling (``size = 1``) never reduces and
+  is bit-for-bit unchanged (#269)
 
 1.4.0 (2026-07-31)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -43,7 +43,7 @@ Unreleased
   groups are drawn jointly within and independently across groups, which no
   other route can produce, so it stays an explicit request rather than a
   cost decision. Full-mode draws need no request: ``sample`` reduces through
-  this route on its own whenever it is cheapest (see below) (#263)
+  this route on its own whenever it is cheapest (see below) (#269)
 
 - ``sample_marginal`` on ``NormalRegressor``, ``NormalInverseGammaRegressor``,
   and ``BayesianGLM``: iid draws from each prediction row's exact marginal
@@ -96,7 +96,7 @@ Unreleased
   (:math:`p` in {100, 1000}, ``n_rows`` in {1, 10, 32, 96, 320}, ``size``
   in {1, 100, 500, 1000}): no regressions, and speedups to 45.9x. Sparse
   gains reach 860x (:math:`p` = 100,000, one row, ``size`` = 1000: 6.0 s to
-  7.0 ms) (#263)
+  7.0 ms) (#269)
 
 - Every step of the reward-space path after the half-solve is taken from
   ``scipy.linalg`` rather than ``numpy`` (``dgeqrf`` for the QR, ``dgemm``
@@ -106,7 +106,7 @@ Unreleased
   both. On a 28-core box that cost more than every flop on the path: a
   100x100 QR took 81 ms through ``numpy.linalg.qr`` and 0.9 ms through
   ``dgeqrf``. Reward-space sampling is up to 102x faster than before this
-  routing (#263)
+  routing (#269)
 
 - ``UpperConfidenceBound``, ``EXP3A``, and ``EpsilonGreedy`` now draw
   through the marginal path (they consume only per-arm, per-context
@@ -146,7 +146,7 @@ Unreleased
   additionally drops the ``size``-proportional weight-space allocation,
   which at that width exhausted memory beyond roughly 2,600 draws. It also
   serves ``sample_marginal``, where it is taken when :math:`|U|` beats the
-  row count (#266)
+  row count (#269)
 
 - ``sample`` and ``sample_marginal`` no longer copy ``X`` while validating
   it. Neither mutates the validated array nor retains a reference to it, so
@@ -158,7 +158,7 @@ Unreleased
   triangular factor instead. Sparse right-hand sides are unchanged. This
   also settles a discrepancy between the backends: SuperLU returned a
   1-D result for a single-column 2-D input, where CHOLMOD preserved the
-  column; both now preserve it (#266)
+  column; both now preserve it (#269)
 
 **Behavioral changes**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -61,8 +61,8 @@ Unreleased
   -- 13x to 17x the Cholesky that preceded it, and the largest single term
   in a pull-and-update round -- to save nothing, since solving against
   ``U`` costs the same per draw as multiplying by the inverse.
-  ``DenseFactor.colorize`` now calls ``dtrsm``, which also keeps the draw
-  inside scipy's BLAS pool. A dense ``size = 1`` pull plus update at
+  ``DenseFactor``'s draw (``sample_at``, below) now calls ``dtrsm``, which
+  also keeps the draw inside scipy's BLAS pool. A dense ``size = 1`` pull plus update at
   :math:`d` = 1,000 falls from 106 ms to 11 ms. ``trace_inv`` genuinely
   needs the inverse and still builds it lazily, now through ``dtrtri``
   rather than a solve against a dense identity (#269)
@@ -161,25 +161,34 @@ Unreleased
   arms 854 ms to 87 ms and over ten stacked contexts 8.5 s to 0.8 s
   (#269)
 
-- ``half_solve`` takes a sparse right-hand side and returns it compact,
+- ``half_solve`` takes a sparse right-hand side and returns it split,
   and the marginal, reward-space and row-side joint paths hand it one.
-  Every caller reads a half-solve only through the Gram ``Bᵀ B``, and
-  for a sparse operand the rows at never-observed features it does not
-  touch are exactly zero -- so a partitioned factor now returns the
-  block rows plus one row per distinct never-observed feature touched,
-  ``(n_factored + t, k)``, with the same Gram, and never forms the
-  ``(n_features, k)`` operand or result those paths used to densify per
-  block: ``Θ(n_rows · n_features)`` on the marginal path became
-  ``Θ(n_rows · n_factored)``. ``PrecisionFactor.n_factored`` -- the
-  features the factor actually factors, all of them for a dense factor
-  -- is the unit every scratch bound and route gate on those paths now
-  uses in place of ``n_features``, so at :math:`2^{20}` features with 26k
-  observed the marginal path takes 80 rows per block instead of 2, and
-  the gates price the per-row path at what it costs. On the production
-  model, ``sample_marginal(size=1)`` over 96 arms goes from 1.7 s to
-  90 ms and over ten stacked contexts from 17.3 s to 0.97 s;
-  ``sample_reward_space(size=1)`` over 96 arms from 8.3 s to 0.13 s
-  (#269)
+  A partitioned factor returns a ``SparseHalfSolve``: the dense
+  ``(n_factored, k)`` half-solve at the features it factors, and the
+  never-observed part sparse, one row per distinct never-observed
+  feature the operand touches, no denser than the operand's own entries
+  there. The two Grams add to ``Bᵀ B``, and callers use them as they
+  come: the marginal path sums the sparse part's squared column norms in
+  ``O(nnz)``, and the reward-space and row-side paths keep it as a
+  sparse map from one normal per never-observed feature (per block, when
+  blocked) to the rows touching it -- a never-observed feature is a
+  scalar with variance ``1/Λ_jj``, and it stays one, never a dense row
+  of the QR. So neither the ``(n_features, k)`` operand those paths used
+  to densify per block nor a ``(t, k)`` block for the ``t`` never-observed
+  features touched is ever formed: ``Θ(n_rows · n_features)`` on the
+  marginal path became ``Θ(n_rows · n_factored + nnz(X))``, whatever the
+  rows touch. ``PrecisionFactor.n_factored`` -- the features the factor
+  actually factors, all of them for a dense factor -- is the unit every
+  scratch bound and route gate on those paths now uses in place of
+  ``n_features``, so at :math:`2^{20}` features with 26k observed the
+  marginal path takes 80 rows per block instead of 2, and the gates
+  price the per-row path at what it costs. On the production model,
+  ``sample_marginal(size=1)`` over 96 arms goes from 1.7 s to 90 ms and
+  over ten stacked contexts from 17.3 s to 0.97 s;
+  ``sample_reward_space(size=1)`` over 96 arms from 8.3 s to 0.13 s. On
+  a cold model (20 of 200k features observed) ``sample_marginal`` over
+  3,000 rows touching 72k never-observed features runs in 28 ms at a
+  9 MB peak where the densified block took 0.85 s and 3.5 GB (#269)
 
 - Scaling is a field on every precision factor, not a wrapper.
   ``ScaledSparseFactor`` is removed; ``CholmodSparseFactor``,
@@ -315,13 +324,18 @@ Unreleased
   row and column routes consume ``n_rows`` and :math:`|U|` normals per
   draw rather than one per feature. The draws are exact and jointly
   distributed either way (verified by per-row KS tests). Thompson sampling
-  (``size = 1``) never reduces, and on sparse models is bit-for-bit
-  unchanged (#269)
+  (``size = 1``) never reduces; on a sparse model whose every feature has
+  been observed it is bit-for-bit unchanged, but once some feature has
+  never been observed the partitioned factor draws one normal per block
+  feature plus one per distinct never-observed feature the query touches
+  (see ``sample_at`` above) rather than one per feature, so seeded
+  ``size = 1`` draws differ from earlier releases there too (#269)
 
 - Dense seeded draws change in the last bits, Thompson sampling included:
-  ``colorize`` solves against ``U`` instead of multiplying by an explicit
-  ``U^{-1}``, the same operation in exact arithmetic but a different
-  rounding order (the two agree to ~2e-16). No distribution changes (#269)
+  the dense factor's draw solves against ``U`` instead of multiplying by
+  an explicit ``U^{-1}``, the same operation in exact arithmetic but a
+  different rounding order (the two agree to ~2e-16). No distribution
+  changes (#269)
 
 1.4.0 (2026-07-31)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -76,7 +76,8 @@ Unreleased
   since :math:`X = X_U E_U^T`). The choice is
   ``min(size, n_rows, |U|)``, three known integers with no calibration
   constants; at ``size = 1`` nothing beats weight space, so Thompson
-  sampling is bit-for-bit unchanged. Over 36 dense shapes (:math:`p` in
+  sampling still draws there (the entry below changes how cheaply that
+  route runs, not which route is chosen). Over 36 dense shapes (:math:`p` in
   {100, 1000}, ``n_rows`` up to 320, ``size`` up to 1000): no regressions,
   speedups to 45.9x. Sparse: :math:`p` = 100,000, one row, ``size`` = 1000
   goes from 6.0 s to 7.0 ms; a :math:`2^{20}`-feature agent with 96 arms
@@ -95,6 +96,127 @@ Unreleased
   deliberately: tightening it would need a fitted constant, and dense
   cost models are dependent on a BLAS threading configuration the
   library cannot observe.
+
+- Sparse factors factor only the features some observation has touched.
+  ``Λ = αI + Σ x_t x_tᵀ`` puts an off-diagonal entry between two
+  features only when one observation touched both, so a feature no
+  observation has touched holds nothing but its diagonal -- exactly --
+  and ``Λ`` is block diagonal between those features and the rest.
+  Their posterior is an independent scalar with variance ``1/Λ_jj``.
+  ``create_sparse_factor`` now detects them from the stored pattern
+  (both sides: the column's own length and how many entries anywhere
+  reference its row, so triangular storage cannot fool it) and hands
+  CHOLMOD or SuperLU only the observed block; every factor operation
+  scatters its result back across the split. Nothing above the factor
+  changes, and when nothing is trivial the block is the whole matrix,
+  as before. On a production model hashing into :math:`2^{20}` features
+  of which 26,119 had been observed (97.5% trivial), factorization went
+  from 2.9 s to 0.39 s and a 32-row ``partial_fit`` from 3.1 s to
+  0.43 s; ``sample(size=1)`` over 96 arms from 27.7 ms to 13.8 ms,
+  ``sample(size=8)`` 253 ms to 97 ms, ``sample_reward_space(size=1)``
+  8.0 s to 2.3 s. The posterior is unchanged to rounding: the support
+  covariance over 49 production features agrees to 9e-16 with the
+  unpartitioned factor (#269)
+
+- The precision factors draw their own weight-space normals.
+  ``sample_at(features, size, rng)`` replaces ``colorize`` and
+  ``colorize_at`` on every factor, dense and sparse: zero-mean draws of
+  ``w ~ N(0, Λ⁻¹)`` at the features asked for, and the factor decides how
+  many normals that takes. A partitioned sparse factor draws one per
+  block feature plus one per *distinct* never-observed feature in the
+  query, never one per never-observed feature it was not asked about;
+  a dense factor, or a sparse one with nothing trivial, draws them all,
+  bitwise as before. A repeated feature repeats its draw, and callers
+  read the result through the design matrix, so rows touching one
+  feature share it: the joint law of ``Xw``, enforced by the interface
+  rather than by care. Every ``sample`` now falls back to one
+  weight-space path for dense and sparse ``X`` alike, and the internal
+  ``multivariate_normal_sample_from_precision``,
+  ``multivariate_t_sample_from_precision`` and the
+  ``..._from_sparse_precision`` alias are removed with the branches
+  they served. On the production model above, ``sample(size=1)`` over
+  96 arms goes from 13.8 ms to 3.2 ms and ``sample(size=8)`` from
+  97 ms to 8.3 ms; end to end from the branch tip, ``sample(size=1)``
+  is 28.1 ms to 3.2 ms (#269)
+
+- The support-covariance route hands the factor a sparse right-hand
+  side, and the sparse factors solve a sparse right-hand side at their
+  block rows only. ``E_U`` is ``|U|`` ones; building it as a dense
+  ``(n_features, k)`` block, and scattering a dense ``(n_features, k)``
+  result back to read ``|U|`` rows of it, cost the route
+  ``O(n_features · |U|)`` however small the observed block -- so once
+  weight-space solves ran on the block, the route was mispriced by the
+  block-to-matrix ratio wherever its gate fired. Neither backend is
+  handed the sparse operand itself: its entries are classified in
+  ``O(nnz log n)``, the observed rows densified (``m x k``) for one
+  BLAS-3 solve, and the result assembled straight into CSC. That also
+  closes a correctness hole -- CHOLMOD's own sparse solve reads the
+  operand's index arrays with the factor's integer type, and an
+  int64-indexed operand (what scipy returns from row-indexing a CSC)
+  against an int32 factor gives the wrong answer silently -- and gives
+  SuperLU a real sparse-RHS solve, where it re-factorized the whole
+  matrix through ``spsolve`` on every call. On the production model:
+  ``support_covariance`` over 49 features 398 ms to 71 ms, over 489
+  features 4.0 s to 0.7 s; ``sample(size=500)`` over one context of 96
+  arms 854 ms to 87 ms and over ten stacked contexts 8.5 s to 0.8 s
+  (#269)
+
+- ``half_solve`` takes a sparse right-hand side and returns it compact,
+  and the marginal, reward-space and row-side joint paths hand it one.
+  Every caller reads a half-solve only through the Gram ``Bᵀ B``, and
+  for a sparse operand the rows at never-observed features it does not
+  touch are exactly zero -- so a partitioned factor now returns the
+  block rows plus one row per distinct never-observed feature touched,
+  ``(n_factored + t, k)``, with the same Gram, and never forms the
+  ``(n_features, k)`` operand or result those paths used to densify per
+  block: ``Θ(n_rows · n_features)`` on the marginal path became
+  ``Θ(n_rows · n_factored)``. ``PrecisionFactor.n_factored`` -- the
+  features the factor actually factors, all of them for a dense factor
+  -- is the unit every scratch bound and route gate on those paths now
+  uses in place of ``n_features``, so at :math:`2^{20}` features with 26k
+  observed the marginal path takes 80 rows per block instead of 2, and
+  the gates price the per-row path at what it costs. On the production
+  model, ``sample_marginal(size=1)`` over 96 arms goes from 1.7 s to
+  90 ms and over ten stacked contexts from 17.3 s to 0.97 s;
+  ``sample_reward_space(size=1)`` over 96 arms from 8.3 s to 0.13 s
+  (#269)
+
+- Scaling is a field on every precision factor, not a wrapper.
+  ``ScaledSparseFactor`` is removed; ``CholmodSparseFactor``,
+  ``SuperLUSparseFactor`` and ``DenseFactor`` carry ``_scale``, and
+  ``scale_factor`` returns a shallow copy with the scalar composed in,
+  for any of the three. ``decay`` scales the cached factor on dense
+  models too, where it used to discard it and refactorize at the next
+  pull -- :math:`O(d^3)` per decay -- and the Normal-Inverse-Gamma
+  ``shape_`` composes ``a/b`` into the cached factor instead of building
+  a scaled copy of the dense triangle by hand; a dense ``decay`` plus
+  pull at :math:`d` = 1,000 goes from 14.7 ms to 1.9 ms. Dense NIG draws
+  now differ from before at rounding (the scale rides in ``dtrsm``'s
+  ``alpha`` rather than in a rescaled triangle); everything else on the
+  dense side is bitwise. ``refactorize`` yields a factor of the new
+  matrix itself, scale reset, and invalidates any scaled views of the
+  same factorization, as the wrapper's did (#269)
+
+- A sparse weight-space ``sample`` never materializes the weight vector.
+  The draw :math:`w = \hat{w} + Mz` is read only through ``X``, so the
+  passes that followed the triangular solve (undoing the factor's
+  fill-reducing permutation, a scaled factor's rescale, adding
+  :math:`\hat{w}`, and the CSC product's own sweep over all :math:`p`
+  columns) spent :math:`O(\text{size} \cdot p)` on entries no prediction
+  row touches. They now run on the :math:`|U|` columns ``X`` does touch,
+  leaving one :math:`O(p)` scan for the support and
+  :math:`O(\mathrm{nnz}(X))` arithmetic; only the normals and the solve
+  stay proportional to :math:`p`, and neither is avoidable in weight
+  space. At :math:`p = 2^{20}` with 96 arms over a 49-column support,
+  ``NormalInverseGammaRegressor.sample`` at ``size = 1`` falls from
+  27.9 ms to 22.7 ms, of which 20.4 ms is now the normals plus the one
+  solve. The same reduction serves ``NormalRegressor`` and
+  ``BayesianGLM``, and the whole weight-space regime rather than
+  ``size = 1`` alone (1.33x at ``size = 8``). Results agree with the
+  previous path to 3e-16 rather than bitwise, since the per-draw scalars
+  are applied once to the reduced draw instead of elementwise to
+  :math:`p` entries. A dense ``X`` against a sparse model reads every
+  column and is left on the old path, unchanged (#269)
 
 - The reward-space, support-covariance, weight-space, and dense sampling
   paths are ``scipy.linalg`` throughout (``dgeqrf``, ``dgemm``,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,12 +34,10 @@ Unreleased
 
 - ``sample_reward_space`` on ``NormalRegressor``,
   ``NormalInverseGammaRegressor``, and ``BayesianGLM``: joint draws from
-  the exact posterior predictive, factored in reward space (one triangular
-  half-solve per prediction row against the cached precision factor, then
-  a QR), so per-draw cost is independent of the feature count.
-  Distributionally identical to ``sample``; with ``block_size=k``,
-  consecutive groups of ``k`` rows are drawn jointly within and
-  independently across groups (#269)
+  the exact posterior predictive, factored in reward space so per-draw
+  cost is independent of the feature count. Distributionally identical
+  to ``sample``; with ``block_size=k``, consecutive groups of ``k`` rows
+  are drawn jointly within and independently across groups (#269)
 
 - ``sample_marginal`` on ``NormalRegressor``, ``NormalInverseGammaRegressor``,
   and ``BayesianGLM``: iid draws from each prediction row's exact marginal
@@ -55,225 +53,28 @@ Unreleased
 
 **Performance**
 
-- Dense sampling no longer forms an explicit :math:`U^{-1}`. The precision
-  factor is rebuilt after every ``partial_fit``, so materializing the
-  inverse charged an :math:`O(d^3)` triangular inversion to every update
-  -- 13x to 17x the Cholesky that preceded it, and the largest single term
-  in a pull-and-update round -- to save nothing, since solving against
-  ``U`` costs the same per draw as multiplying by the inverse.
-  ``DenseFactor``'s draw (``sample_at``, below) now calls ``dtrsm``, which
-  also keeps the draw inside scipy's BLAS pool. A dense ``size = 1`` pull plus update at
-  :math:`d` = 1,000 falls from 106 ms to 11 ms. ``trace_inv`` genuinely
-  needs the inverse and still builds it lazily, now through ``dtrtri``
-  rather than a solve against a dense identity (#269)
-
-- Joint ``sample`` draws reduce through whichever exact route is cheapest.
-  :math:`\operatorname{Cov}(Xw) = X \Lambda^{-1} X^T` has a square root
-  on each side: weight space costs ``size`` solves against the cached
-  factor, the row side ``n_rows`` solves and an ``n_rows x n_rows`` QR,
-  and, for sparse ``X`` touching ``|U|`` columns, the column side ``|U|``
-  solves and the ``|U| x |U|`` block of :math:`\Lambda^{-1}` (an identity,
-  since :math:`X = X_U E_U^T`). The choice is
-  ``min(size, n_rows, |U|)``, three known integers with no calibration
-  constants; at ``size = 1`` nothing beats weight space, so Thompson
-  sampling still draws there (the entry below changes how cheaply that
-  route runs, not which route is chosen). Over 36 dense shapes (:math:`p` in
-  {100, 1000}, ``n_rows`` up to 320, ``size`` up to 1000): no regressions,
-  speedups to 45.9x. Sparse: :math:`p` = 100,000, one row, ``size`` = 1000
-  goes from 6.0 s to 7.0 ms; a :math:`2^{20}`-feature agent with 96 arms
-  over a 49-column support draws ``size=500`` in 0.99 s instead of 31.5 s,
-  without the ``size``-proportional weight-space allocation that ran out
-  of memory beyond ~2,600 draws. The column side also serves
-  ``sample_marginal`` when :math:`|U|` beats the row count (#269)
-
-  Those dense figures were measured before the BLAS thread-pool fixes
-  below, which cut the weight-space side by up to 8.9x and so narrowed
-  the row side's dense margin; the swept shapes stay wins, but past them
-  the ``2 n_rows <= size`` guard is now slightly loose. At
-  :math:`p` = 1,000 with 448 rows and ``size`` = 900 the row side is
-  taken and runs 0.76x to 0.81x, the crossover there having moved from
-  ``2 n_rows`` to roughly ``4 n_rows``. The guard is left alone
-  deliberately: tightening it would need a fitted constant, and dense
-  cost models are dependent on a BLAS threading configuration the
-  library cannot observe.
-
-- Sparse factors factor only the features some observation has touched.
-  ``Λ = αI + Σ x_t x_tᵀ`` puts an off-diagonal entry between two
-  features only when one observation touched both, so a feature no
-  observation has touched holds nothing but its diagonal -- exactly --
-  and ``Λ`` is block diagonal between those features and the rest.
-  Their posterior is an independent scalar with variance ``1/Λ_jj``.
-  ``create_sparse_factor`` now detects them from the stored pattern
-  (both sides: the column's own length and how many entries anywhere
-  reference its row, so triangular storage cannot fool it) and hands
-  CHOLMOD or SuperLU only the observed block; every factor operation
-  scatters its result back across the split. Nothing above the factor
-  changes, and when nothing is trivial the block is the whole matrix,
-  as before. On a production model hashing into :math:`2^{20}` features
-  of which 26,119 had been observed (97.5% trivial), factorization went
-  from 2.9 s to 0.39 s and a 32-row ``partial_fit`` from 3.1 s to
-  0.43 s; ``sample(size=1)`` over 96 arms from 27.7 ms to 13.8 ms,
-  ``sample(size=8)`` 253 ms to 97 ms, ``sample_reward_space(size=1)``
-  8.0 s to 2.3 s. The posterior is unchanged to rounding: the support
-  covariance over 49 production features agrees to 9e-16 with the
-  unpartitioned factor (#269)
-
-- The precision factors draw their own weight-space normals.
-  ``sample_at(features, size, rng)`` replaces ``colorize`` and
-  ``colorize_at`` on every factor, dense and sparse: zero-mean draws of
-  ``w ~ N(0, Λ⁻¹)`` at the features asked for, and the factor decides how
-  many normals that takes. A partitioned sparse factor draws one per
-  block feature plus one per *distinct* never-observed feature in the
-  query, never one per never-observed feature it was not asked about;
-  a dense factor, or a sparse one with nothing trivial, draws them all,
-  bitwise as before. A repeated feature repeats its draw, and callers
-  read the result through the design matrix, so rows touching one
-  feature share it: the joint law of ``Xw``, enforced by the interface
-  rather than by care. Every ``sample`` now falls back to one
-  weight-space path for dense and sparse ``X`` alike, and the internal
-  ``multivariate_normal_sample_from_precision``,
-  ``multivariate_t_sample_from_precision`` and the
-  ``..._from_sparse_precision`` alias are removed with the branches
-  they served. On the production model above, ``sample(size=1)`` over
-  96 arms goes from 13.8 ms to 3.2 ms and ``sample(size=8)`` from
-  97 ms to 8.3 ms; end to end from the branch tip, ``sample(size=1)``
-  is 28.1 ms to 3.2 ms (#269)
-
-- The support-covariance route hands the factor a sparse right-hand
-  side, and the sparse factors solve a sparse right-hand side at their
-  block rows only. ``E_U`` is ``|U|`` ones; building it as a dense
-  ``(n_features, k)`` block, and scattering a dense ``(n_features, k)``
-  result back to read ``|U|`` rows of it, cost the route
-  ``O(n_features · |U|)`` however small the observed block -- so once
-  weight-space solves ran on the block, the route was mispriced by the
-  block-to-matrix ratio wherever its gate fired. Neither backend is
-  handed the sparse operand itself: its entries are classified in
-  ``O(nnz log n)``, the observed rows densified (``m x k``) for one
-  BLAS-3 solve, and the result assembled straight into CSC. That also
-  closes a correctness hole -- CHOLMOD's own sparse solve reads the
-  operand's index arrays with the factor's integer type, and an
-  int64-indexed operand (what scipy returns from row-indexing a CSC)
-  against an int32 factor gives the wrong answer silently -- and gives
-  SuperLU a real sparse-RHS solve, where it re-factorized the whole
-  matrix through ``spsolve`` on every call. On the production model:
-  ``support_covariance`` over 49 features 398 ms to 71 ms, over 489
-  features 4.0 s to 0.7 s; ``sample(size=500)`` over one context of 96
-  arms 854 ms to 87 ms and over ten stacked contexts 8.5 s to 0.8 s
-  (#269)
-
-- ``half_solve`` takes a sparse right-hand side and returns it split,
-  and the marginal, reward-space and row-side joint paths hand it one.
-  A partitioned factor returns a ``SparseHalfSolve``: the dense
-  ``(n_factored, k)`` half-solve at the features it factors, and the
-  never-observed part sparse, one row per distinct never-observed
-  feature the operand touches, no denser than the operand's own entries
-  there. The two Grams add to ``Bᵀ B``, and callers use them as they
-  come: the marginal path sums the sparse part's squared column norms in
-  ``O(nnz)``, and the reward-space and row-side paths keep it as a
-  sparse map from one normal per never-observed feature (per block, when
-  blocked) to the rows touching it -- a never-observed feature is a
-  scalar with variance ``1/Λ_jj``, and it stays one, never a dense row
-  of the QR. So neither the ``(n_features, k)`` operand those paths used
-  to densify per block nor a ``(t, k)`` block for the ``t`` never-observed
-  features touched is ever formed: ``Θ(n_rows · n_features)`` on the
-  marginal path became ``Θ(n_rows · n_factored + nnz(X))``, whatever the
-  rows touch. ``PrecisionFactor.n_factored`` -- the features the factor
-  actually factors, all of them for a dense factor -- is the unit every
-  scratch bound and route gate on those paths now uses in place of
-  ``n_features``, so at :math:`2^{20}` features with 26k observed the
-  marginal path takes 80 rows per block instead of 2, and the gates
-  price the per-row path at what it costs. On the production model,
-  ``sample_marginal(size=1)`` over 96 arms goes from 1.7 s to 90 ms and
-  over ten stacked contexts from 17.3 s to 0.97 s;
-  ``sample_reward_space(size=1)`` over 96 arms from 8.3 s to 0.13 s. On
-  a cold model (20 of 200k features observed) ``sample_marginal`` over
-  3,000 rows touching 72k never-observed features runs in 28 ms at a
-  9 MB peak where the densified block took 0.85 s and 3.5 GB (#269)
-
-- Scaling is a field on every precision factor, not a wrapper.
-  ``ScaledSparseFactor`` is removed; ``CholmodSparseFactor``,
-  ``SuperLUSparseFactor`` and ``DenseFactor`` carry ``_scale``, and
-  ``scale_factor`` returns a shallow copy with the scalar composed in,
-  for any of the three. ``decay`` scales the cached factor on dense
-  models too, where it used to discard it and refactorize at the next
-  pull -- :math:`O(d^3)` per decay -- and the Normal-Inverse-Gamma
-  ``shape_`` composes ``a/b`` into the cached factor instead of building
-  a scaled copy of the dense triangle by hand; a dense ``decay`` plus
-  pull at :math:`d` = 1,000 goes from 14.7 ms to 1.9 ms. Dense NIG draws
-  now differ from before at rounding (the scale rides in ``dtrsm``'s
-  ``alpha`` rather than in a rescaled triangle); everything else on the
-  dense side is bitwise. ``refactorize`` yields a factor of the new
-  matrix itself, scale reset, and invalidates any scaled views of the
-  same factorization, as the wrapper's did (#269)
-
-- A sparse weight-space ``sample`` never materializes the weight vector.
-  The draw :math:`w = \hat{w} + Mz` is read only through ``X``, so the
-  passes that followed the triangular solve (undoing the factor's
-  fill-reducing permutation, a scaled factor's rescale, adding
-  :math:`\hat{w}`, and the CSC product's own sweep over all :math:`p`
-  columns) spent :math:`O(\text{size} \cdot p)` on entries no prediction
-  row touches. They now run on the :math:`|U|` columns ``X`` does touch,
-  leaving one :math:`O(p)` scan for the support and
-  :math:`O(\mathrm{nnz}(X))` arithmetic; only the normals and the solve
-  stay proportional to :math:`p`, and neither is avoidable in weight
-  space. At :math:`p = 2^{20}` with 96 arms over a 49-column support,
-  ``NormalInverseGammaRegressor.sample`` at ``size = 1`` falls from
-  27.9 ms to 22.7 ms, of which 20.4 ms is now the normals plus the one
-  solve. The same reduction serves ``NormalRegressor`` and
-  ``BayesianGLM``, and the whole weight-space regime rather than
-  ``size = 1`` alone (1.33x at ``size = 8``). Results agree with the
-  previous path to 3e-16 rather than bitwise, since the per-draw scalars
-  are applied once to the reduced draw instead of elementwise to
-  :math:`p` entries. A dense ``X`` against a sparse model reads every
-  column and is left on the old path, unchanged (#269)
-
-- The reward-space, support-covariance, weight-space, and dense sampling
-  paths are ``scipy.linalg`` throughout (``dgeqrf``, ``dgemm``,
-  ``dgemv``, ``dtrsm``, ``dpotrf``). ``numpy`` and ``scipy`` bind
-  separate copies of OpenBLAS with separate thread pools, and
-  alternating between them within one call parks and unparks both: on a
-  28-core box a 100x100 QR took 81 ms through ``numpy.linalg.qr`` and
-  0.9 ms through ``dgeqrf``. The last two crossings to go were the
-  weight-space tail ``draws @ X.T``, which followed the triangular solve
-  that produced ``draws``, and the predictive mean ``X @ coef`` ahead of
-  the reduced draw. Routing both through ``dgemm``/``dgemv`` took a
-  dense ``sample`` at :math:`d` = 1,000 with 320 rows and ``size`` = 100
-  from 40.0 ms to 4.5 ms. Operands are passed in whichever orientation
-  they already hold, since a C-contiguous array's transpose is
-  Fortran-contiguous and the naive spelling would copy both (#269)
-
-- ``SuperLUSparseFactor.solve`` goes through the cached triangular factor
-  for a dense right-hand side instead of refactorizing on every call, and
-  now preserves the column of a single-column 2-D input, as CHOLMOD does
-  (#269)
-
-- Every dense right-hand side handed to a sparse factor is now
-  Fortran-ordered. CHOLMOD's dense format is column-major, so a C-ordered
-  block is copied before the solve begins -- and on the
-  support-covariance route that block is ``(n_features, |U|)``, large
-  enough that the copy outweighed the solve. At :math:`p` = 100,000 with
-  96 rows over a 49-column support, ``sample`` at ``size`` = 100 goes
-  from 19.5 ms to 9.8 ms and ``sample_marginal`` at ``size`` = 10 from
-  19.8 ms to 9.6 ms (#269)
-
-- The sparse factors no longer precompute state only ``colorize`` needs,
-  which every ``fit``/``partial_fit`` was paying for and neither uses.
-  Sparse ``partial_fit`` at :math:`p` = 100,000 falls from 13.0 ms to
-  10.0 ms under CHOLMOD (#269)
-
-- ``CholmodSparseFactor`` inverts the fill-reducing permutation by
-  scattering rather than sorting, :math:`O(p)` instead of
-  :math:`O(p \log p)`. It is rebuilt with the factor, so a Thompson pull
-  pays it every round: a ``sample(size=1)`` and ``partial_fit`` round at
-  :math:`p` = 100,000 falls from 11.9 ms to 11.1 ms (#269)
-
-- ``SuperLUSparseFactor`` retains its decomposition, so ``solve`` runs
-  both triangular sweeps in one ``gstrs`` call instead of two trips
-  through ``spsolve_triangular``; the symmetric ``L`` that sampling needs
-  is derived from it on demand. At :math:`p` = 100,000, ``sample`` and
-  ``sample_marginal`` over a 49-column support run 4.3x faster and
-  ``partial_fit`` 1.8x. The factor holds ``L`` and ``U`` rather than one
-  folded ``L``, costing roughly one extra ``nnz(L)`` when sampling (#269)
+- A number of performance updates to posterior sampling on
+  ``NormalRegressor``, ``NormalInverseGammaRegressor`` and ``BayesianGLM``,
+  none of which changes a distribution. Joint ``sample`` draws go through
+  the cheapest exact route for the call: weight space, the row-side
+  factor behind ``sample_reward_space``, or, for a sparse ``X``, a
+  covariance over the columns it touches. Sparse precision factors
+  factor only the features some observation has touched and carry the
+  rest as a diagonal, so factorization, updates and every sampling
+  path are sized by that block rather than by ``n_features``, and
+  memory no longer grows with the never-observed features a query
+  touches. The dense factor no longer materializes :math:`U^{-1}` on
+  every update, scaling is a field on every factor rather than a
+  wrapper, and the sampling paths keep to one BLAS thread pool and stop
+  copying ``X`` and their BLAS operands. Expected gains: on a sparse
+  model hashing into :math:`2^{20}` features of which ~26k had been
+  observed, factorization and a 32-row ``partial_fit`` about 5x faster,
+  Thompson ``sample`` over 96 arms about 4x (26 ms to 7 ms),
+  ``sample(size=8)`` about 30x, ``sample(size=500)`` from 37 s to under
+  0.1 s, and ``sample_marginal(size=500)`` about 20x (2.3 s to 0.1 s
+  over 96 arms, 22 s to 1 s over 960 rows); on dense models, ``size = 1``
+  pull-plus-update at :math:`d` = 1,000 about 10x, and large-``size``
+  joint draws up to ~45x on the shapes swept (#269)
 
 - ``UpperConfidenceBound``, ``EXP3A``, and ``EpsilonGreedy`` now draw
   through the marginal path (they consume only per-arm, per-context
@@ -305,9 +106,6 @@ Unreleased
   so the copy was pure overhead, costing O(nnz(X)) per draw on sparse
   models. ``fit`` and ``partial_fit`` are unchanged (#265)
 
-- ``sample_reward_space``, ``predict``, and ``predict_proba`` likewise no
-  longer copy ``X``: they only read it (#269)
-
 **Behavioral changes**
 
 - Seeded agent trajectories under ``UpperConfidenceBound``, ``EXP3A``, and
@@ -320,22 +118,15 @@ Unreleased
   compensate (marginal draws are much cheaper per draw), or opt the
   policy out with ``marginal_ok = False`` (#258)
 
-- Seeded ``sample`` trajectories change wherever a reduction applies: the
-  row and column routes consume ``n_rows`` and :math:`|U|` normals per
-  draw rather than one per feature. The draws are exact and jointly
-  distributed either way (verified by per-row KS tests). Thompson sampling
-  (``size = 1``) never reduces; on a sparse model whose every feature has
-  been observed it is bit-for-bit unchanged, but once some feature has
-  never been observed the partitioned factor draws one normal per block
-  feature plus one per distinct never-observed feature the query touches
-  (see ``sample_at`` above) rather than one per feature, so seeded
-  ``size = 1`` draws differ from earlier releases there too (#269)
-
-- Dense seeded draws change in the last bits, Thompson sampling included:
-  the dense factor's draw solves against ``U`` instead of multiplying by
-  an explicit ``U^{-1}``, the same operation in exact arithmetic but a
-  different rounding order (the two agree to ~2e-16). No distribution
-  changes (#269)
+- Seeded ``sample`` trajectories change: a reduced draw consumes
+  ``n_rows`` or :math:`|U|` normals rather than one per feature, a
+  partitioned sparse factor draws one normal per observed feature plus
+  one per distinct never-observed feature the query touches, and dense
+  draws solve against ``U`` instead of multiplying by :math:`U^{-1}`,
+  which differs in the last bits. Every distribution is unchanged
+  (verified by per-row KS tests); Thompson sampling (``size = 1``) on a
+  sparse model whose every feature has been observed is bit-for-bit
+  unchanged (#269)
 
 1.4.0 (2026-07-31)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,15 +11,15 @@ Unreleased
   two arms share one. Neither agent gives arms a way to differ in
   features, so arms sharing a learner were statistically
   indistinguishable; worse, the policies on that path sample one arm at a
-  time, which draws a separate weight vector per arm and silently
-  discards the dependence a shared posterior implies. A policy declaring
-  ``marginal_ok = False`` could therefore ask for joint draws and receive
-  independent ones: on arms sharing a learner, measured cross-arm
-  correlation was 0.00 where the true value was 1.00. Sharing one model
-  across arms is ``LipschitzContextualAgent``'s job -- it distinguishes
-  arms with an ``arm_featurizer`` and samples the shared learner once for
-  all of them -- and the error says so. Two distinct ``LearnerPipeline``
-  objects wrapping the same estimator also count as sharing (#267)
+  time, which draws a separate weight vector per arm and silently discards
+  the dependence a shared posterior implies. A policy asking for joint
+  draws could therefore receive independent ones: on arms sharing a
+  learner, measured cross-arm correlation was 0.00 where the true value
+  was 1.00. Sharing one model across arms is
+  ``LipschitzContextualAgent``'s job -- it distinguishes arms with an
+  ``arm_featurizer`` and samples the shared learner once for all of them
+  -- and the error says so. Two distinct ``LearnerPipeline`` objects
+  wrapping the same estimator also count as sharing (#267)
 
 - The batched arm-sampling path is removed: ``batch_sample_arms``,
   ``can_batch_arms``, ``stack_features``, and the ``LearnerWithTransform``
@@ -32,31 +32,94 @@ Unreleased
 
 **New features**
 
+- ``sample_reward_space`` on ``NormalRegressor``,
+  ``NormalInverseGammaRegressor``, and ``BayesianGLM``: joint draws from
+  the exact posterior predictive, computed by QR-factoring ``half_solve``
+  output into a triangular square root of :math:`X \Lambda^{-1} X^T` and
+  drawing directly in reward space -- distributionally identical to
+  ``sample``, but per-draw cost is independent of the feature count
+  (neither :math:`\Lambda^{-1}` nor any covariance is ever formed;
+  rank-deficient ``X`` is exact). With ``block_size=k``, consecutive row
+  groups are drawn jointly within and independently across groups, which no
+  other route can produce, so it stays an explicit request rather than a
+  cost decision. Full-mode draws need no request: ``sample`` reduces through
+  this route on its own whenever it is cheapest (see below) (#263)
+
 - ``sample_marginal`` on ``NormalRegressor``, ``NormalInverseGammaRegressor``,
   and ``BayesianGLM``: iid draws from each prediction row's exact marginal
   posterior predictive, computed with one triangular half-solve per row
   against the cached precision factor (neither :math:`\Lambda^{-1}` nor any
   :math:`n \times n` matrix is ever formed, and per-draw cost is independent
-  of the feature count). ``Arm.sample_marginal``, ``LearnerPipeline.sample_marginal``,
-  and ``batch_sample_arms(..., marginal=True)`` forward to it, falling back
-  to joint ``sample`` for learners without it (or whose class overrides
-  ``sample`` without it). Unlike ``sample`` -- whose
-  rows within one draw share a weight vector -- draws are independent
-  across rows, so it serves per-row statistics only (#258)
+  of the feature count). ``Arm.sample_marginal`` and
+  ``LearnerPipeline.sample_marginal`` forward to it, falling back to joint
+  ``sample`` for learners without it (or whose class overrides ``sample``
+  without it). Unlike ``sample`` -- whose rows within one draw share a
+  weight vector -- draws are independent across rows, so it serves per-row
+  statistics only (#258)
 
 **Performance**
+
+- Joint ``sample`` draws now reduce through whichever exact route is
+  cheapest. :math:`\operatorname{Cov}(Xw) = X \Lambda^{-1} X^T` has rank at
+  most :math:`\min(n_{\text{rows}}, |U|, p)`, and there is a reduction to a
+  small square root on each side, so the three routes differ only in how
+  many triangular solves against the cached factor they cost:
+
+  .. list-table::
+     :header-rows: 1
+
+     * - route
+       - solves
+       - square root
+     * - weight space
+       - ``size``
+       - :math:`p \times p`, cached
+     * - row side
+       - ``n_rows``
+       - :math:`n_{\text{rows}} \times n_{\text{rows}}`
+     * - column side
+       - :math:`|U|`
+       - :math:`|U| \times |U|`
+
+  The choice is therefore :math:`\min(\text{size}, n_{\text{rows}}, |U|)`,
+  three exactly known integers, and the gate holds no calibration
+  constants. Weight space is the one whose square root is *cached* -- it
+  factors :math:`\Lambda`, which does not depend on ``X`` -- so it builds
+  nothing and pays per draw, while the other two refactor on every call.
+  That is why neither can win at small ``size``: there is nothing to
+  amortize. ``size = 1`` therefore always stays on weight space, and
+  Thompson sampling is bit-for-bit unchanged.
+
+  Previously the column side was chosen inside ``sample`` and the row side
+  out at the agent behind a policy flag, so neither could account for what
+  the other would have picked. Measured end-to-end over 36 dense shapes
+  (:math:`p` in {100, 1000}, ``n_rows`` in {1, 10, 32, 96, 320}, ``size``
+  in {1, 100, 500, 1000}): no regressions, and speedups to 45.9x. Sparse
+  gains reach 860x (:math:`p` = 100,000, one row, ``size`` = 1000: 6.0 s to
+  7.0 ms) (#263)
+
+- Every step of the reward-space path after the half-solve is taken from
+  ``scipy.linalg`` rather than ``numpy`` (``dgeqrf`` for the QR, ``dgemm``
+  for the draws, ``dgemv`` for the predictive mean). ``numpy`` and
+  ``scipy`` bind separate copies of OpenBLAS, each with its own thread
+  pool, and alternating between them within one call parks and unparks
+  both. On a 28-core box that cost more than every flop on the path: a
+  100x100 QR took 81 ms through ``numpy.linalg.qr`` and 0.9 ms through
+  ``dgeqrf``. Reward-space sampling is up to 102x faster than before this
+  routing (#263)
 
 - ``UpperConfidenceBound``, ``EXP3A``, and ``EpsilonGreedy`` now draw
   through the marginal path (they consume only per-arm, per-context
   statistics, for which marginal draws are exact), giving large speedups
   for their Monte Carlo estimates, dense and sparse alike.
   ``ThompsonSampling`` and joint ``sample`` are unchanged, byte-for-byte.
-  Custom policies can opt in by setting ``marginal_ok = True`` (declared
-  on ``PolicyProtocol``), and subclasses of the built-in policies can
-  opt out with ``marginal_ok = False``, which their ``__call__`` and the
-  agents both honor. The marginal path is never used for a learner whose
-  class overrides ``sample`` without also overriding ``sample_marginal``,
-  so customized joint sampling is not silently bypassed (#258)
+  Custom policies can opt in by setting ``marginal_ok = True`` (declared on
+  ``PolicyProtocol``), and subclasses of the built-in policies can opt out
+  with ``marginal_ok = False``, which their ``__call__`` and the agents both
+  honor. The marginal path is never used
+  for a learner whose class overrides ``sample`` without also overriding
+  ``sample_marginal``, so customized joint sampling is not silently
+  bypassed (#258)
 
 - The marginal path is likewise never used when a
   ``LipschitzContextualAgent`` carries a user-supplied
@@ -64,30 +127,58 @@ Unreleased
   may combine arms within it (share of total, cannibalization, softmax
   over a slate), which requires the arms of a draw to be jointly
   distributed; iid marginal draws leave such a reward's mean intact but
-  manufacture spread that a quantile-based policy reads as uncertainty.
-  A batch function that maps each ``(arm, context, draw)`` cell
-  independently can opt back into the faster path by carrying a truthy
-  ``elementwise`` attribute. Per-arm ``Arm.reward_function``s are applied
-  one arm at a time and never affect sampling, so the common cases --
-  no reward function, or per-arm functions only -- keep the speedup (#258)
+  manufacture spread that a quantile-based policy reads as uncertainty. A
+  per-arm ``Arm.reward_function`` is applied one arm at a time and never
+  affects sampling, so the common cases -- no reward function, or per-arm
+  functions only -- keep the speedup (#258)
+
+- The column-side reduction above. Writing :math:`U` for the columns a
+  sparse design matrix touches, :math:`X = X_U E_U^T` exactly, so
+  :math:`\operatorname{Cov}(Xw) = X_U (\Lambda^{-1})_{U,U} X_U^T`: the whole
+  predictive law follows from one :math:`|U| \times |U|` block, obtained
+  with :math:`|U|` solves against the cached factor. Every draw after that
+  is dense linear algebra on that small block, never touching the factor
+  again. The reformulation is exact, and the cost carries no dependence on
+  the factor's elimination tree. Dense models never take it, since there
+  :math:`|U|` is the full feature count and there is nothing to reduce. On a
+  production agent (:math:`2^{20}` features, 96 arms over a 49-column
+  support) a ``size=500`` joint draw goes from 31.5 s to 0.99 s, and
+  additionally drops the ``size``-proportional weight-space allocation,
+  which at that width exhausted memory beyond roughly 2,600 draws. It also
+  serves ``sample_marginal``, where it is taken when :math:`|U|` beats the
+  row count (#266)
 
 - ``sample`` and ``sample_marginal`` no longer copy ``X`` while validating
-  it. Neither mutates the validated array nor retains a reference to it,
-  so the copy was pure overhead, costing O(nnz(X)) per draw on sparse
-  models. ``fit``, ``partial_fit``, and ``predict`` are unchanged (#265)
+  it. Neither mutates the validated array nor retains a reference to it, so
+  the copy was pure overhead, costing O(nnz(X)) per draw on sparse models.
+  ``fit``, ``partial_fit``, and ``predict`` are unchanged (#265)
+
+- ``SuperLUSparseFactor.solve`` no longer refactorizes the precision on
+  every call for a dense right-hand side, going through the cached
+  triangular factor instead. Sparse right-hand sides are unchanged. This
+  also settles a discrepancy between the backends: SuperLU returned a
+  1-D result for a single-column 2-D input, where CHOLMOD preserved the
+  column; both now preserve it (#266)
 
 **Behavioral changes**
 
 - Seeded agent trajectories under ``UpperConfidenceBound``, ``EXP3A``, and
-  ``EpsilonGreedy`` change: the marginal path consumes different amounts
-  of randomness than joint sampling. Per-row marginals are identical
-  (verified by KS tests) and decisions converge to the same choices as
-  ``samples`` grows, but for arms sharing one model the per-arm Monte
-  Carlo estimates no longer share weight draws, so finite-sample
-  selection noise among near-tied arms increases; raise ``samples`` to
-  compensate (marginal draws are much cheaper per draw), or opt the
-  policy out with ``marginal_ok = False``.
-  ``sample`` itself is bit-for-bit identical to previous versions (#258)
+  ``EpsilonGreedy`` change: the marginal path consumes different amounts of
+  randomness than joint sampling. Per-row marginals are identical (verified
+  by KS tests) and decisions converge to the same choices as ``samples``
+  grows, but for arms sharing one model the per-arm Monte Carlo estimates
+  no longer share weight draws, so finite-sample selection noise among
+  near-tied arms increases; raise ``samples`` to compensate (marginal draws
+  are much cheaper per draw), or opt the policy out with
+  ``marginal_ok = False`` (#258)
+
+- Seeded ``sample`` trajectories change wherever a reduction applies, since
+  the row and column routes consume ``n_rows`` and :math:`|U|` normals per
+  draw rather than one per feature. The draws are exact and jointly
+  distributed either way, and agreement with the weight-space path is
+  verified by KS tests per row. Thompson sampling is unaffected: at
+  ``size = 1`` no reduction can win, so none is taken and the output is
+  bit-for-bit identical (enforced by a test) (#263, #266)
 
 1.4.0 (2026-07-31)
 ------------------

--- a/src/bayesianbandits/_blas_helpers.py
+++ b/src/bayesianbandits/_blas_helpers.py
@@ -2,14 +2,26 @@
 
 from __future__ import annotations
 
-from typing import Any, Union
+from typing import Any, Union, cast
 
 import numpy as np
 from numpy.typing import NDArray
-from scipy.linalg.blas import dgemv, dsymv, dsyrk  # type: ignore[attr-defined]
+from scipy.linalg.blas import dgemm, dgemv, dsymv, dsyrk  # type: ignore[attr-defined]
+from scipy.linalg.lapack import dgeqrf, dgeqrf_lwork  # type: ignore[attr-defined]
 from scipy.sparse import csc_array
 
-__all__ = ["dgemv", "dsymv", "dsyrk", "update_precision_dense", "compute_eta_dense"]
+__all__ = [
+    "dgemm",
+    "dgemv",
+    "dsymv",
+    "dsyrk",
+    "update_precision_dense",
+    "compute_eta_dense",
+    "lower_predictive_sqrt",
+    "dense_matvec",
+    "standard_normal_f",
+    "affine_lower_factor",
+]
 
 _Array = Union[NDArray[Any], csc_array]
 
@@ -45,3 +57,81 @@ def compute_eta_dense(
     """
     eta = dsymv(prior_decay, cov_inv, coef)
     return dgemv(alpha, X, y_weighted, trans=1, beta=1.0, y=eta, overwrite_y=True)
+
+
+def lower_predictive_sqrt(B: NDArray[np.float64], n_rows: int) -> NDArray[np.float64]:
+    """Lower-triangular ``L`` of shape ``(n_rows, n_rows)`` with ``L Lᵀ = Bᵀ B``.
+
+    ``B`` has shape ``(n_features, n_rows)`` and is **overwritten**.
+
+    Takes the ``R`` factor of ``B``'s QR: ``Rᵀ R = Bᵀ B`` exactly, with
+    no need for ``Bᵀ B`` to be formed and no loss of the conditioning
+    that squaring it would cost.  ``R`` is padded with zero rows when
+    ``B`` has fewer rows than columns, which is what makes the result
+    exact for rank-deficient input (repeated prediction rows) where a
+    Cholesky of the explicit covariance would fail.
+
+    Calls ``dgeqrf`` directly rather than ``numpy.linalg.qr``.  The two
+    compute the same factor, but numpy and scipy bind *separate* copies
+    of OpenBLAS, each with its own thread pool; alternating between them
+    within one call parks and unparks both pools and dominates the
+    runtime at every size we measured.  Every routine on this path is
+    therefore taken from ``scipy.linalg``, so a caller that reaches here
+    through a ``scipy`` triangular solve stays inside one pool.
+    """
+    lwork = int(dgeqrf_lwork(B.shape[0], B.shape[1])[0])
+    qr, _tau, _work, _info = dgeqrf(B, lwork=lwork, overwrite_a=True)
+    R = np.triu(qr[: min(qr.shape)])
+    if R.shape[0] < n_rows:  # more prediction rows than features
+        R = np.vstack([R, np.zeros((n_rows - R.shape[0], n_rows))])
+    # Sign-flipping rows of R leaves Rᵀ R unchanged, so this only
+    # canonicalizes the factor to a non-negative diagonal.
+    signs = np.where(np.diagonal(R) < 0.0, -1.0, 1.0)
+    return cast(NDArray[np.float64], np.asfortranarray(R.T * signs, dtype=np.float64))
+
+
+def dense_matvec(A: NDArray[Any], x: NDArray[Any]) -> NDArray[np.float64]:
+    """``A @ x`` for dense ``A``, through ``dgemv`` rather than ``numpy``.
+
+    Trivial in flops, but it is the one ``numpy`` BLAS call left on the
+    reward-space path, and a single round trip out of ``scipy``'s thread
+    pool costs far more than the product itself (see
+    :func:`lower_predictive_sqrt`).
+
+    ``dgemv`` wants Fortran order.  A C-contiguous ``A`` is passed as its
+    transpose with ``trans=1``, which is the same memory read the other
+    way round, so neither layout is copied.
+    """
+    A2 = np.asarray(A, dtype=np.float64)
+    x1 = np.asarray(x, dtype=np.float64).ravel()
+    if A2.flags.c_contiguous and not A2.flags.f_contiguous:
+        return cast(NDArray[np.float64], dgemv(1.0, A2.T, x1, trans=1))
+    return cast(NDArray[np.float64], dgemv(1.0, A2, x1))
+
+
+def standard_normal_f(
+    rng: np.random.Generator, size: int, n_rows: int
+) -> NDArray[np.float64]:
+    """``(size, n_rows)`` standard normals in **Fortran** order.
+
+    Drawing the transpose and viewing it back costs nothing and lets
+    ``affine_lower_factor`` hand the buffer to ``dgemm`` without a copy.
+    """
+    return cast(NDArray[np.float64], rng.standard_normal((n_rows, size)).T)
+
+
+def affine_lower_factor(
+    mean: NDArray[np.float64], z: NDArray[np.float64], L: NDArray[np.float64]
+) -> NDArray[np.float64]:
+    """``mean + z @ Lᵀ`` in one ``dgemm``, accumulating onto the mean.
+
+    ``z`` should come from :func:`standard_normal_f` and ``L`` from
+    :func:`lower_predictive_sqrt` so that both are already F-contiguous
+    and ``dgemm`` runs without copying either operand.
+    """
+    out = np.empty((z.shape[0], L.shape[0]), dtype=np.float64, order="F")
+    out[:] = mean
+    return cast(
+        NDArray[np.float64],
+        dgemm(1.0, z, L, trans_b=1, beta=1.0, c=out, overwrite_c=True),
+    )

--- a/src/bayesianbandits/_blas_helpers.py
+++ b/src/bayesianbandits/_blas_helpers.py
@@ -140,6 +140,9 @@ def affine_lower_factor(
     :func:`standard_normal_f` and ``L`` from :func:`lower_predictive_sqrt`
     are both F-contiguous, so neither operand is copied."""
     out = np.empty((z.shape[0], L.shape[0]), dtype=np.float64, order="F")
+    if out.shape[0] == 0:
+        # f2py rejects a zero-row ``c``; nothing to draw anyway
+        return out
     out[:] = mean
     return cast(
         NDArray[np.float64],

--- a/src/bayesianbandits/_blas_helpers.py
+++ b/src/bayesianbandits/_blas_helpers.py
@@ -11,7 +11,6 @@ from scipy.linalg.lapack import dgeqrf, dgeqrf_lwork  # type: ignore[attr-define
 from scipy.sparse import csc_array
 
 __all__ = [
-    "dgemm",
     "dgemv",
     "dsymv",
     "dsyrk",

--- a/src/bayesianbandits/_blas_helpers.py
+++ b/src/bayesianbandits/_blas_helpers.py
@@ -64,20 +64,15 @@ def lower_predictive_sqrt(B: NDArray[np.float64], n_rows: int) -> NDArray[np.flo
 
     ``B`` has shape ``(n_features, n_rows)`` and is **overwritten**.
 
-    Takes the ``R`` factor of ``B``'s QR: ``Rᵀ R = Bᵀ B`` exactly, with
-    no need for ``Bᵀ B`` to be formed and no loss of the conditioning
-    that squaring it would cost.  ``R`` is padded with zero rows when
-    ``B`` has fewer rows than columns, which is what makes the result
-    exact for rank-deficient input (repeated prediction rows) where a
-    Cholesky of the explicit covariance would fail.
+    ``L`` is the transposed ``R`` of ``B``'s QR, zero-padded when ``B``
+    has fewer rows than columns, so it is exact for rank-deficient input
+    (repeated prediction rows) where a Cholesky of ``Bᵀ B`` would fail.
 
-    Calls ``dgeqrf`` directly rather than ``numpy.linalg.qr``.  The two
-    compute the same factor, but numpy and scipy bind *separate* copies
-    of OpenBLAS, each with its own thread pool; alternating between them
-    within one call parks and unparks both pools and dominates the
-    runtime at every size we measured.  Every routine on this path is
-    therefore taken from ``scipy.linalg``, so a caller that reaches here
-    through a ``scipy`` triangular solve stays inside one pool.
+    Calls ``dgeqrf`` rather than ``numpy.linalg.qr``: numpy and scipy
+    bind separate copies of OpenBLAS with separate thread pools, and
+    alternating between them within one call parks and unparks both,
+    which dominates the runtime. Every routine on this path is therefore
+    taken from ``scipy.linalg``.
     """
     lwork = int(dgeqrf_lwork(B.shape[0], B.shape[1])[0])
     qr, _tau, _work, _info = dgeqrf(B, lwork=lwork, overwrite_a=True)
@@ -91,16 +86,10 @@ def lower_predictive_sqrt(B: NDArray[np.float64], n_rows: int) -> NDArray[np.flo
 
 
 def dense_matvec(A: NDArray[Any], x: NDArray[Any]) -> NDArray[np.float64]:
-    """``A @ x`` for dense ``A``, through ``dgemv`` rather than ``numpy``.
-
-    Trivial in flops, but it is the one ``numpy`` BLAS call left on the
-    reward-space path, and a single round trip out of ``scipy``'s thread
-    pool costs far more than the product itself (see
-    :func:`lower_predictive_sqrt`).
-
-    ``dgemv`` wants Fortran order.  A C-contiguous ``A`` is passed as its
-    transpose with ``trans=1``, which is the same memory read the other
-    way round, so neither layout is copied.
+    """``A @ x`` for dense ``A`` through ``dgemv``, so the reward-space
+    path never leaves scipy's BLAS pool (see :func:`lower_predictive_sqrt`).
+    A C-contiguous ``A`` is passed as its transpose with ``trans=1``, so
+    neither layout is copied.
     """
     A2 = np.asarray(A, dtype=np.float64)
     x1 = np.asarray(x, dtype=np.float64).ravel()
@@ -112,23 +101,17 @@ def dense_matvec(A: NDArray[Any], x: NDArray[Any]) -> NDArray[np.float64]:
 def standard_normal_f(
     rng: np.random.Generator, size: int, n_rows: int
 ) -> NDArray[np.float64]:
-    """``(size, n_rows)`` standard normals in **Fortran** order.
-
-    Drawing the transpose and viewing it back costs nothing and lets
-    ``affine_lower_factor`` hand the buffer to ``dgemm`` without a copy.
-    """
+    """``(size, n_rows)`` standard normals in Fortran order, so
+    :func:`affine_lower_factor` can hand them to ``dgemm`` uncopied."""
     return cast(NDArray[np.float64], rng.standard_normal((n_rows, size)).T)
 
 
 def affine_lower_factor(
     mean: NDArray[np.float64], z: NDArray[np.float64], L: NDArray[np.float64]
 ) -> NDArray[np.float64]:
-    """``mean + z @ Lᵀ`` in one ``dgemm``, accumulating onto the mean.
-
-    ``z`` should come from :func:`standard_normal_f` and ``L`` from
-    :func:`lower_predictive_sqrt` so that both are already F-contiguous
-    and ``dgemm`` runs without copying either operand.
-    """
+    """``mean + z @ Lᵀ`` in one ``dgemm``. ``z`` from
+    :func:`standard_normal_f` and ``L`` from :func:`lower_predictive_sqrt`
+    are both F-contiguous, so neither operand is copied."""
     out = np.empty((z.shape[0], L.shape[0]), dtype=np.float64, order="F")
     out[:] = mean
     return cast(

--- a/src/bayesianbandits/_blas_helpers.py
+++ b/src/bayesianbandits/_blas_helpers.py
@@ -19,6 +19,7 @@ __all__ = [
     "compute_eta_dense",
     "lower_predictive_sqrt",
     "dense_matvec",
+    "dense_matmul_bt",
     "standard_normal_f",
     "affine_lower_factor",
 ]
@@ -96,6 +97,32 @@ def dense_matvec(A: NDArray[Any], x: NDArray[Any]) -> NDArray[np.float64]:
     if A2.flags.c_contiguous and not A2.flags.f_contiguous:
         return cast(NDArray[np.float64], dgemv(1.0, A2.T, x1, trans=1))
     return cast(NDArray[np.float64], dgemv(1.0, A2, x1))
+
+
+def dense_matmul_bt(A: NDArray[Any], B: NDArray[Any]) -> NDArray[np.float64]:
+    """``A @ B.T`` for dense ``A`` (m, k) and ``B`` (n, k) through ``dgemm``,
+    so the weight-space draw never leaves scipy's BLAS pool (see
+    :func:`lower_predictive_sqrt`).
+
+    ``dgemm`` wants Fortran-ordered operands, and a C-contiguous array's
+    transpose is Fortran-contiguous, so each operand is handed over in
+    whichever orientation it already has and the transposition is
+    expressed through ``trans_a``/``trans_b`` instead of a copy.  The
+    obvious ``dgemm(1.0, A, B, trans_b=1)`` is arithmetically identical
+    but copies both operands when they are C-ordered, which is the cost
+    this exists to avoid.
+    """
+    A2 = np.asarray(A, dtype=np.float64)
+    B2 = np.asarray(B, dtype=np.float64)
+    if A2.flags.c_contiguous and not A2.flags.f_contiguous:
+        a, trans_a = A2.T, 1
+    else:
+        a, trans_a = A2, 0
+    if B2.flags.c_contiguous and not B2.flags.f_contiguous:
+        b, trans_b = B2.T, 0
+    else:
+        b, trans_b = B2, 1
+    return cast(NDArray[np.float64], dgemm(1.0, a, b, trans_a=trans_a, trans_b=trans_b))
 
 
 def standard_normal_f(

--- a/src/bayesianbandits/_empirical_bayes.py
+++ b/src/bayesianbandits/_empirical_bayes.py
@@ -20,9 +20,7 @@ from scipy.special import digamma, gammaln, polygamma
 
 from ._blas_helpers import dsymv
 from ._sparse_bayesian_linear_regression import (
-    DenseFactor,
     PrecisionFactor,
-    SparseFactor,
 )
 
 _LOG_2PI = math.log(2.0 * math.pi)
@@ -38,61 +36,6 @@ _LOG_2PI = math.log(2.0 * math.pi)
 # produce such ill-conditioning.  Once enough data arrives (n ≥ p),
 # the updates become well-behaved and start flowing normally.
 _MAX_BETA_ALPHA_RATIO = 1e10
-
-
-def _takahashi_diagonal(L_csc: csc_array) -> NDArray[np.float64]:
-    """Compute diag((LL')⁻¹) via Takahashi recursion (selected inversion).
-
-    Given a lower triangular CSC matrix L where LL' = A, computes the
-    diagonal of A⁻¹ exactly using backward recursion through L's sparsity
-    structure.  Cost is O(Σⱼ nⱼ²) where nⱼ is the number of sub-diagonal
-    entries in column j — the same order as the Cholesky factorization
-    itself.
-
-    Delegates to a Cython implementation for performance.
-
-    Parameters
-    ----------
-    L_csc : csc_array
-        Lower triangular Cholesky factor in CSC format.
-
-    Returns
-    -------
-    NDArray[np.float64]
-        Diagonal of (LL')⁻¹, length p.
-
-    References
-    ----------
-    .. [1] Takahashi, K., Fagan, J., & Chin, M.-S. (1973). "Formation of
-       a sparse bus impedance matrix and its application to short circuit
-       study." 8th PICA Conference Proceedings.
-    """
-    from ._takahashi import takahashi_diagonal as _cy_impl
-
-    p = cast(tuple[int, int], L_csc.shape)[0]
-    if not L_csc.has_sorted_indices:
-        L_csc = L_csc.copy()
-        L_csc.sort_indices()
-    return _cy_impl(
-        L_csc.data,
-        L_csc.indices.astype(np.int32),
-        L_csc.indptr.astype(np.int32),
-        p,
-    )
-
-
-def _takahashi_trace(factor: SparseFactor) -> float:
-    """Compute tr(Λ⁻¹) exactly via Takahashi recursion.
-
-    Extracts the Cholesky factor L from the SparseFactor, runs Takahashi
-    diagonal recursion, and returns sum(diag((LL')⁻¹)).
-
-    The trace is permutation-invariant, so the result is correct regardless
-    of fill-reducing permutation order.
-    """
-    L = factor.get_L_csc()
-    Z_diag = _takahashi_diagonal(L)
-    return float(np.sum(Z_diag))
 
 
 def _diagonal_trace_approx(
@@ -122,26 +65,15 @@ def _factorization_stats(
     ----------
     precision : dense or sparse matrix
     factor : pre-computed factorization (DenseFactor or SparseFactor)
-    trace_method : ``"auto"`` uses Takahashi recursion for sparse and
-        Cholesky for dense.  ``"diagonal"`` uses the fast O(p)
-        approximation tr(Λ⁻¹) ≈ Σ 1/Λᵢᵢ.
+    trace_method : ``"auto"`` takes the exact trace from the factor
+        (Takahashi recursion for sparse, the Cholesky inverse for
+        dense).  ``"diagonal"`` uses the fast O(p) approximation
+        tr(Λ⁻¹) ≈ Σ 1/Λᵢᵢ, the one case that reads the precision matrix
+        rather than the factorization of it.
     """
     if trace_method == "diagonal":
-        tr_inv = _diagonal_trace_approx(precision)
-        if isinstance(factor, DenseFactor):
-            ld = factor.logdet()
-        else:
-            ld = factor.logdet()
-        return ld, tr_inv
-
-    # trace_method == "auto" (default)
-    if isinstance(factor, DenseFactor):
-        ld = factor.logdet()
-        tr_inv = factor.trace_inv()
-    else:
-        ld = factor.logdet()
-        tr_inv = _takahashi_trace(factor)
-    return ld, tr_inv
+        return factor.logdet(), _diagonal_trace_approx(precision)
+    return factor.logdet(), factor.trace_inv()
 
 
 def accumulate_sufficient_stats(

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -936,7 +936,7 @@ def _predictive_mean(
     """
     if issparse(X):
         return np.asarray(X @ coef, dtype=np.float64).ravel()
-    return dense_matvec(X, coef)
+    return dense_matvec(cast(NDArray[Any], X), coef)
 
 
 def _weight_space_rows(
@@ -1199,14 +1199,16 @@ class _RewardSpacePredictiveMixin:
     contract."""
 
     if TYPE_CHECKING:
-        coef_: NDArray[np.float64]
-        cov_inv_: Union[NDArray[np.float64], csc_array]
+        # ``Any`` where the concrete classes assign a wider set of array
+        # types than one annotation covers, or define the name as a
+        # ``cached_property``; a narrower stub here would only make the
+        # subclasses' own assignments type errors.
+        coef_: Any
+        cov_inv_: Any
         n_features_: int
         sparse: bool
         random_state_: np.random.Generator
-
-        @property
-        def _precision_factor(self) -> PrecisionFactor: ...
+        _precision_factor: Any
 
         def _initialize_prior(self, X: Union[NDArray[Any], csc_array]) -> None: ...
 

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -829,10 +829,9 @@ def _marginal_predictive_sd(
     A sparse ``X`` is densified for the solve in row blocks, keeping the
     dense scratch bounded regardless of the number of prediction rows.
 
-    When ``X`` is sparse and touches fewer distinct columns than it has
-    rows, the support-covariance route is exact and cheaper -- it pays
-    one solve per distinct column instead of one per row -- so it is
-    used instead. See :mod:`bayesianbandits._support_covariance`.
+    A sparse ``X`` touching fewer distinct columns than it has rows
+    goes through :mod:`bayesianbandits._support_covariance` instead: one
+    solve per distinct column rather than one per row, exactly.
     """
     # Dispatch on the actual type of X: sparse models accept dense X too
     # (check_array's accept_sparse only *permits* sparse input)
@@ -878,53 +877,24 @@ def _validated_marginal_mean_sd(
 
 
 def _reward_space_is_cheaper(
-    n: int,
-    d: int,
-    size: int,
-    sparse: bool,
-    precision_nnz: int,
-    block_size: Optional[int] = None,
+    n: int, d: int, size: int, sparse: bool, precision_nnz: int
 ) -> bool:
-    """Is reward-space sampling cheaper than weight-space for this call?
+    """Is the row-side reduction cheaper than weight space for this call?
 
-    Weight-space draws ``size`` weight vectors from the ``d``-dimensional
-    posterior and projects them through ``X``.  Reward-space computes an
-    exact square root of the predictive covariance
-    :math:`X \\Lambda^{-1} X^T` once (``n`` triangular half-solves plus a
-    QR) and draws directly in reward space, so its per-draw cost is
-    independent of ``d``.
-
-    The decision rests on the one quantity both paths pay in the same
-    currency: **triangular solves against the cached factor**.
-    Reward-space performs ``n`` of them, weight-space ``size``.  Both are
-    exactly known integers, so comparing them needs no calibration.
-    Requiring ``2n <= size`` rather than ``n < size`` leaves the other
-    half of the weight-space solve budget to cover reward-space's
-    remaining work, which the guards below then check fits.
-
-    With ``k`` rows per QR block (``k = n`` in full mode), that remaining
-    work is ``n·k·d`` for the QR and ``n·k·size`` for the draws:
-
-    - Dense.  Weight-space spends ``d²·size`` colorizing, so the draw
-      term fits when ``2·n·k <= d²``.  This is what stops the path being
-      taken at ``n ≈ d``, where the two do the same work but
-      reward-space does it in many small, latency-bound calls rather
-      than one large one.  ``n <= d`` additionally keeps reward-space's
-      ``n·size`` normals under weight-space's ``d·size``.
-    - Sparse.  A solve costs ``nnz``, not ``d²``, so the draw term fits
-      when ``2·n·k <= nnz``.  Sparse also densifies a ``(d, k)`` scratch
-      for the half-solves, which is the only allocation here that can
-      exceed the factor itself, so it is held to the same element budget
-      the marginal path uses.  That budget, not the cost model, is what
-      declines large ``n`` at high ``d``; ``block_size`` is the way to
-      take those calls.
+    Both pay in triangular solves against the cached factor: ``n`` for
+    the row side, ``size`` for weight space. Requiring ``2n <= size``
+    leaves the other half of the weight-space budget to cover the row
+    side's QR (``n²·d``) and draws (``n²·size``), which the remaining
+    guards check against what weight space spends per solve: ``d²``
+    dense, ``nnz`` sparse. Dense also needs ``n <= d`` (fewer normals per
+    draw); sparse also caps the ``(d, n)`` half-solve scratch at the
+    marginal path's element budget.
     """
-    k = n if block_size is None else block_size
     if 2 * n > size:
         return False
     if sparse:
-        return k * d <= _MARGINAL_SD_BLOCK_ELEMS and 2 * n * k <= precision_nnz
-    return n <= d and 2 * n * k <= d * d
+        return n * d <= _MARGINAL_SD_BLOCK_ELEMS and 2 * n * n <= precision_nnz
+    return n <= d and 2 * n * n <= d * d
 
 
 class _RowSpaceDraw:
@@ -953,11 +923,8 @@ def build_joint_reduction(
 ) -> Optional[Any]:
     """Cheapest exact reduction of ``Cov(Xw)``, or ``None`` for weight space.
 
-    ``Cov(Xw) = X \\Lambda^{-1} X^T`` has rank at most
-    ``min(n_rows, |U|, n_features)``, and there is a reduction to a
-    square root on each side.  All three routes are exact and give the
-    same distribution; they differ only in how many triangular solves
-    against the cached factor they cost:
+    All three routes give the same distribution and differ only in how
+    many triangular solves against the cached factor they cost:
 
     ==================  ===================  =========================
     route               solves               square root
@@ -967,24 +934,11 @@ def build_joint_reduction(
     column side         ``|U|``              ``|U| x |U|``
     ==================  ===================  =========================
 
-    So the choice is just ``min(size, n_rows, |U|)``, three exactly
-    known integers.  Weight space is the one whose square root is
-    *cached* -- it factors :math:`\\Lambda`, which does not depend on
-    ``X`` -- so it needs no build at all and simply pays per draw. The
-    other two must refactor on every call, which is why neither can win
-    at small ``size``: there is nothing to amortize.
-
-    Passing ``min(size, n_rows)`` as the column-side budget is what
-    makes this one comparison rather than two: the column route already
-    declines unless ``|U|`` beats its budget, so handing it the row
-    route's cost lets it fire only when it is the cheapest of the three.
-
-    A dense model has no column-side route -- ``|U|`` is every feature,
-    so there is nothing to reduce -- but the row side still applies, and
-    :func:`_reward_space_is_cheaper` carries the extra guards a dense
-    model needs: weight space there does no solve at all, multiplying by
-    a cached inverse factor instead, so the row side must also fit its
-    draw term under that.
+    So the choice is ``min(size, n_rows, |U|)``. Weight space's square
+    root is cached, so it never loses at small ``size``. The column
+    side's budget is ``min(size, n_rows)`` so that it fires only when it
+    is the cheapest of the three; it is unavailable for dense ``X``,
+    where ``|U|`` is every feature.
     """
     n_rows = cast("tuple[int, int]", X.shape)[0]
     row_ok = _reward_space_is_cheaper(n_rows, n_features, size, sparse, precision_nnz)
@@ -1012,28 +966,16 @@ def _predictive_cholesky_from_factor(
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
     """Predictive mean and lower-triangular square root(s) of :math:`X \\Lambda^{-1} X^T`.
 
-    Computes ``B = factor.half_solve(X.T)`` -- one triangular solve per
-    prediction row against the cached factor, so ``B.T @ B`` equals the
-    predictive covariance without :math:`\\Lambda^{-1}` or the covariance
-    itself ever being formed -- and takes the ``R`` factor of its QR
-    decomposition: ``R.T @ R = B.T @ B``, making ``R.T`` an exact lower
-    triangular square root even when ``X`` has linearly dependent rows
-    (e.g. repeated contexts) -- unlike a Cholesky of the explicit
-    covariance, which would need regularization there and would square
-    the condition number.
+    ``B = factor.half_solve(X.T)`` satisfies ``B.T @ B = X Λ⁻¹ Xᵀ``, so
+    the ``R`` of its QR is an exact square root even for linearly
+    dependent rows, where a Cholesky of the explicit covariance would
+    fail (see :func:`lower_predictive_sqrt`).
 
-    With ``block_size=k``, rows are treated as consecutive groups of
-    ``k`` and the QR is batched per group, returning one ``(k, k)``
-    factor per group with shape ``(n_blocks, k, k)``: exact joint
-    structure within each group, none across groups. This is the shape
-    a caller wants when rows group into independent decision units
-    (e.g. one block of arm rows per context). Blocked mode processes
-    rows in chunks so the dense half-solve scratch stays within the
-    same ``_MARGINAL_SD_BLOCK_ELEMS`` budget ``_marginal_predictive_sd``
-    uses, regardless of the total row count. Full mode has no such cap:
-    a sparse ``X`` is densified transposed all at once, so the scratch
-    is a dense ``(n_features, n_rows)`` array -- pass ``block_size`` to
-    bound memory when both dimensions are large.
+    With ``block_size=k``, one ``(k, k)`` factor is returned per
+    consecutive group of ``k`` rows, shape ``(n_blocks, k, k)``: joint
+    within a group, nothing across groups. Blocked mode chunks the dense
+    half-solve scratch under ``_MARGINAL_SD_BLOCK_ELEMS``; full mode
+    densifies a sparse ``X`` all at once, ``(n_features, n_rows)``.
     """
 
     def half_solve_rows(rows: slice) -> NDArray[np.float64]:
@@ -1079,10 +1021,8 @@ def _predictive_cholesky_from_factor(
         B = half_solve_rows(slice(start * block_size, stop * block_size))
         B = B.reshape(-1, (stop - start) * block_size)
         blocks = B.reshape(B.shape[0], stop - start, block_size).transpose(1, 0, 2)
-        # One factorization per block rather than numpy's batched QR: the
-        # batched call is a single trip into numpy's OpenBLAS, and the
-        # round trip out of scipy's costs more than this loop does. See
-        # ``lower_predictive_sqrt``.
+        # Per-block dgeqrf rather than numpy's batched QR, which would
+        # leave scipy's BLAS pool; see ``lower_predictive_sqrt``.
         for offset, block in enumerate(blocks):
             L[start + offset] = lower_predictive_sqrt(block, block_size)
     return mean, L
@@ -1091,13 +1031,10 @@ def _predictive_cholesky_from_factor(
 def _blocked_colorize(
     L: NDArray[np.float64], z: NDArray[np.floating[Any]]
 ) -> NDArray[np.float64]:
-    """Apply per-block lower factors: ``(L_b @ z_{s,b})`` for every draw.
+    """``L_b @ z_{s,b}`` for every block ``b`` and draw ``s``.
 
-    ``L`` has shape ``(n_blocks, k, k)``, ``z`` has shape
-    ``(n_blocks, size, k)``; returns shape ``(size, n_blocks * k)``. The
-    result is written straight into a C-order ``(size, n_blocks, k)``
-    array, so neither the draw tensor nor the result is copied through
-    a transposed intermediate.
+    ``L``: ``(n_blocks, k, k)``; ``z``: ``(n_blocks, size, k)``; returns
+    ``(size, n_blocks * k)``, written directly in C order.
     """
     n_blocks, size, k = z.shape
     out = np.empty((size, n_blocks, k))
@@ -1107,13 +1044,9 @@ def _blocked_colorize(
 
 
 class _RewardSpacePredictiveMixin:
-    """Reward-space sampling support shared by the conjugate linear models.
-
-    Hosts the predictive-Cholesky construction, the flop-model gate, and
-    the shared ``sample``/``sample_reward_space`` validation preamble
-    over the ``coef_``/``_precision_factor``/``sparse`` contract that
-    :class:`NormalRegressor` and :class:`BayesianGLM` share.
-    """
+    """Reward-space sampling shared by :class:`NormalRegressor` and
+    :class:`BayesianGLM`, over their common ``coef_`` /
+    ``_precision_factor`` / ``sparse`` contract."""
 
     if TYPE_CHECKING:
         coef_: NDArray[np.float64]
@@ -1129,20 +1062,17 @@ class _RewardSpacePredictiveMixin:
     def _predictive_cholesky(
         self, X: Union[NDArray[Any], csc_array], block_size: Optional[int] = None
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        """Predictive mean and lower square root(s) of the linear
-        predictor's covariance :math:`X \\Lambda^{-1} X^T`. Assumes ``X``
-        is already validated and the model is fitted (or the prior
-        initialized). For the NIG subclass this is the *unscaled* factor:
-        the ``b/a`` scaling is applied by ``sample_reward_space``."""
+        """Predictive mean and lower square root(s) of
+        :math:`X \\Lambda^{-1} X^T` for validated ``X``. Unscaled for the
+        NIG subclass: ``sample_reward_space`` applies ``b/a`` itself."""
         return _predictive_cholesky_from_factor(
             self._precision_factor, self.coef_, X, block_size
         )
 
     @property
     def _precision_nnz(self) -> int:
-        """Stored entries in the precision, the per-solve cost proxy for
-        a sparse model. Zero for a dense one, where a solve costs
-        ``d^2`` regardless."""
+        """Per-solve cost proxy: stored precision entries for a sparse
+        model, zero for a dense one."""
         return cast(csc_array, self.cov_inv_).nnz if self.sparse else 0
 
     def _validated_for_sampling(
@@ -1593,11 +1523,8 @@ scipy.sparse.csc_array
             X, copy=False, ensure_2d=True, accept_sparse="csc" if self.sparse else False
         )
 
-        # Exact joint draws through whichever reduction of the
-        # predictive covariance is cheapest here: one solve per draw
-        # (weight space), one per prediction row, or one per distinct
-        # column X touches. Same distribution, different consumption of
-        # the random stream.
+        # Exact joint draws through the cheapest reduction of Cov(Xw);
+        # same distribution as weight space, different random stream.
         support_draw = build_joint_reduction(
             self._precision_factor,
             X_sample,
@@ -1682,35 +1609,24 @@ scipy.sparse.csc_array
         :math:`X w \\sim \\mathcal{N}(X \\hat{w}, X \\Lambda^{-1} X^T)`
         -- but computed by factoring the ``n``-row predictive covariance
         once (one triangular half-solve per prediction row against the
-        cached precision factor, then a QR) and drawing directly in
-        reward space. Per-draw cost is then independent of the number of
-        features, so this is much cheaper than ``sample`` when ``size``
-        is large relative to the number of rows, and much more expensive
-        in the opposite regime. Neither :math:`\\Lambda^{-1}` nor the
-        covariance is ever formed, and linearly dependent rows (e.g.
-        repeated contexts) are represented exactly. Note that without
-        ``block_size``, a sparse model densifies the transposed
-        prediction rows all at once -- a dense
-        ``(n_features, n_samples)`` scratch array -- so pass
-        ``block_size`` to bound memory when both dimensions are large.
+        cached precision factor, then a QR) and drawing in reward space,
+        so per-draw cost is independent of the number of features:
+        cheaper than ``sample`` when ``size`` is large relative to the
+        number of rows, more expensive otherwise. Linearly dependent
+        rows (e.g. repeated contexts) are represented exactly. A sparse
+        model densifies the transposed rows, ``(n_features, n_samples)``,
+        unless ``block_size`` is given.
 
-        With ``block_size=k``, consecutive groups of ``k`` rows are
-        factored and drawn independently: draws are joint within each
-        group and independent across groups (unlike ``sample``, where
-        all rows of one draw share a weight vector). Use this when rows
-        group into independent decision units -- e.g. one block of arm
-        rows per context -- and no cross-group statistic is consumed;
-        the per-group joint distribution is exact.
+        With ``block_size=k``, consecutive groups of ``k`` rows are drawn
+        jointly within the group and independently across groups (unlike
+        ``sample``, where all rows of a draw share a weight vector). Use
+        this when rows group into independent decision units, e.g. one
+        block of arm rows per context.
 
         If the model has not been fitted, samples are drawn from the
-        prior predictive distribution.
-
-        .. note::
-
-           Only the sampling *distribution* is guaranteed to match
-           ``sample``, not the bitstream: the two methods consume
-           different amounts of randomness, so the same seed yields
-           different (equally distributed) realizations.
+        prior predictive distribution. Only the distribution matches
+        ``sample``, not the bitstream: the same seed yields different
+        realizations.
 
         Parameters
         ----------
@@ -2161,10 +2077,8 @@ scipy.sparse.csc_array
         )
         df = 2 * self.a_
 
-        # Exact joint draws via the support covariance, built from
-        # ``shape_`` so S already carries the (b/a) factor. The
-        # chi-square mixing is a per-draw scalar, so it commutes with
-        # the linear map and the reduction stays exact.
+        # ``shape_`` carries the (b/a) factor; the chi-square mixing is
+        # a per-draw scalar, so the reduction stays exact.
         support_draw = build_joint_reduction(
             self.shape_,
             X_sample,
@@ -2258,16 +2172,12 @@ scipy.sparse.csc_array
         multivariate t with :math:`2 a_n` degrees of freedom, location
         :math:`X \\mu_n`, and shape :math:`(b_n / a_n) X \\Lambda_n^{-1} X^T`
         -- but drawn via the exact square root of the shape matrix, with
-        one shared chi-square mixing variable per draw. See
-        :meth:`NormalRegressor.sample_reward_space` for the cost model
-        and the bitstream caveat.
+        one chi-square mixing variable per draw. See
+        :meth:`NormalRegressor.sample_reward_space` for the cost model.
 
-        With ``block_size=k``, consecutive groups of ``k`` rows are
-        drawn independently, each with its own chi-square mixing
-        variable per draw: every group's joint t distribution is exact,
-        and groups are fully independent (whereas ``sample`` shares one
-        noise-scale draw across all rows). Use only when no cross-group
-        statistic is consumed.
+        With ``block_size=k``, each group of ``k`` rows gets its own
+        chi-square per draw: joint t within a group, independent across
+        groups.
 
         Parameters
         ----------
@@ -2298,10 +2208,8 @@ scipy.sparse.csc_array
             z = standard_normal_f(self.random_state_, size, mean.shape[0])
             g = self.random_state_.chisquare(df, size=size)
             # t draw: location + sqrt(df/g) · (shape-chol @ z), with the
-            # (b/a) shape scaling (shape cov = (b/a) · X Λ⁻¹ Xᵀ) folded
-            # into the per-draw scale. Scaling the draws rather than the
-            # product is equivalent (both scale whole rows) and lets the
-            # mean be accumulated inside the same GEMM.
+            # (b/a) shape scaling folded into the per-draw scale so the
+            # mean accumulates inside the same GEMM.
             scale = np.sqrt((self.b_ / self.a_) * df / g)
             z *= scale[:, np.newaxis]
             return affine_lower_factor(mean, z, L)
@@ -2910,9 +2818,7 @@ scipy.sparse.csc_array
             X, copy=False, ensure_2d=True, accept_sparse="csc" if self.sparse else False
         )
 
-        # The support covariance gives the linear predictor's exact joint
-        # law directly; the inverse link is applied elementwise either
-        # way, so it composes unchanged.
+        # The reduction draws eta; the inverse link is elementwise either way.
         support_draw = build_joint_reduction(
             self._precision_factor,
             X_sample,
@@ -2989,13 +2895,12 @@ scipy.sparse.csc_array
         """
         Sample jointly from the posterior predictive, drawing in eta space.
 
-        Distributionally identical to :meth:`sample` -- draws linear
-        predictors :math:`\\eta \\sim \\mathcal{N}(X \\hat{w},
-        X \\Lambda^{-1} X^T)` and applies the inverse link elementwise
-        -- but the :math:`\\eta` draws come directly from the ``n``-row
-        predictive Gaussian via the exact square root of its covariance.
-        See :meth:`NormalRegressor.sample_reward_space` for the cost
-        model, the ``block_size`` semantics, and the bitstream caveat.
+        Distributionally identical to :meth:`sample` -- draws
+        :math:`\\eta \\sim \\mathcal{N}(X \\hat{w}, X \\Lambda^{-1} X^T)`
+        and applies the inverse link elementwise -- but the :math:`\\eta`
+        draws come from the exact square root of the ``n``-row predictive
+        covariance. See :meth:`NormalRegressor.sample_reward_space` for
+        the cost model and ``block_size``.
 
         Parameters
         ----------

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -817,6 +817,19 @@ def _invalidate_cached_properties(
 _MARGINAL_SD_BLOCK_ELEMS = 2**21
 
 
+def _dense_rows_t(X_rows: Any) -> NDArray[np.float64]:
+    """``X_rows.T`` densified, ``(n_features, rows)`` and F-contiguous.
+
+    Densifying first and transposing the result costs one pass over the
+    row-major block; transposing the sparse matrix first (``X.T.toarray()``)
+    lands on the same layout by way of a CSR-to-CSC conversion of the
+    whole block. F-contiguous either way, which is what the sparse
+    factors' solvers want -- CHOLMOD's dense format is column-major, and
+    a C-ordered right-hand side is copied before the solve.
+    """
+    return cast(NDArray[np.float64], np.asarray(X_rows.toarray(), dtype=np.float64).T)
+
+
 def _marginal_predictive_sd(
     factor: PrecisionFactor, X: Union[NDArray[Any], csc_array]
 ) -> NDArray[np.float64]:
@@ -852,7 +865,7 @@ def _marginal_predictive_sd(
     var = np.empty(n_rows, dtype=np.float64)
     for start in range(0, n_rows, block):
         stop = min(n_rows, start + block)
-        rhs = np.asarray(X_rows[start:stop].T.toarray(), dtype=np.float64)
+        rhs = _dense_rows_t(X_rows[start:stop])
         B = np.asarray(factor.half_solve(rhs), dtype=np.float64)
         var[start:stop] = np.einsum("ij,ij->j", B, B)
     return cast(NDArray[np.float64], np.sqrt(var))
@@ -1026,7 +1039,7 @@ def _predictive_cholesky_from_factor(
         # (check_array's accept_sparse only *permits* sparse input)
         X_rows = X_row_sliceable[rows]
         if issparse(X_rows):
-            rhs = np.asarray(X_rows.T.toarray(), dtype=np.float64)
+            rhs = _dense_rows_t(X_rows)
         else:
             rhs = np.asarray(X_rows, dtype=np.float64).T
         return np.asarray(factor.half_solve(rhs), dtype=np.float64)

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -1194,20 +1194,45 @@ def _blocked_colorize(
 
 
 class _RewardSpacePredictiveMixin:
-    """Reward-space sampling shared by :class:`NormalRegressor` and
-    :class:`BayesianGLM`, over their common ``coef_`` /
-    ``_precision_factor`` / ``sparse`` contract."""
+    """Sampling shared by :class:`NormalRegressor` and :class:`BayesianGLM`,
+    over their common ``coef_`` / ``_precision_factor`` / ``sparse``
+    contract."""
 
     if TYPE_CHECKING:
         coef_: NDArray[np.float64]
         cov_inv_: Union[NDArray[np.float64], csc_array]
         n_features_: int
         sparse: bool
+        random_state_: np.random.Generator
 
         @property
         def _precision_factor(self) -> PrecisionFactor: ...
 
         def _initialize_prior(self, X: Union[NDArray[Any], csc_array]) -> None: ...
+
+    def _joint_rows(
+        self,
+        factor: PrecisionFactor,
+        X: Union[NDArray[Any], csc_array],
+        size: int,
+        divisor: Optional[NDArray[np.float64]] = None,
+    ) -> NDArray[np.float64]:
+        """``size`` joint draws of ``X w`` for validated ``X``, shape
+        ``(size, n_rows)``: through the cheapest exact reduction of
+        ``Cov(Xw)`` when one is (see :func:`build_joint_reduction`), else
+        weight space; same distribution either way, different random
+        stream. ``divisor`` divides the zero-mean part per draw, for the
+        NIG multivariate-t mixing."""
+        draw = build_joint_reduction(factor, X, self.coef_.shape[0], size, self.sparse)
+        if draw is not None:
+            scale = None if divisor is None else 1.0 / divisor
+            mean = _predictive_mean(X, self.coef_)
+            return cast(
+                NDArray[np.float64], draw.joint(size, self.random_state_, mean, scale)
+            )
+        return _weight_space_rows(
+            factor, X, self.coef_, size, self.random_state_, divisor
+        )
 
     def _predictive_cholesky(
         self, X: Union[NDArray[Any], csc_array], block_size: Optional[int] = None
@@ -1673,26 +1698,7 @@ scipy.sparse.csc_array
         predict : Point predictions using the posterior mean.
         """
         X_sample = self._validated_for_sampling(X)
-
-        # Exact joint draws through the cheapest reduction of Cov(Xw);
-        # same distribution as weight space, different random stream.
-        support_draw = build_joint_reduction(
-            self._precision_factor,
-            X_sample,
-            self.coef_.shape[0],
-            size,
-            self.sparse,
-        )
-        if support_draw is not None:
-            mean = _predictive_mean(X_sample, self.coef_)
-            return cast(
-                NDArray[np.float64],
-                support_draw.joint(size, self.random_state_, mean),
-            )
-
-        return _weight_space_rows(
-            self._precision_factor, X_sample, self.coef_, size, self.random_state_
-        )
+        return self._joint_rows(self._precision_factor, X_sample, size)
 
     def sample_marginal(
         self, X: Union[NDArray[Any], csc_array], size: int = 1
@@ -1757,8 +1763,8 @@ scipy.sparse.csc_array
         cheaper than ``sample`` when ``size`` is large relative to the
         number of rows, more expensive otherwise. Linearly dependent
         rows (e.g. repeated contexts) are represented exactly. A sparse
-        model densifies the transposed rows, ``(n_features, n_samples)``,
-        unless ``block_size`` is given.
+        model's dense scratch is the observed features by ``n_samples``,
+        bounded in row blocks when ``block_size`` is given.
 
         With ``block_size=k``, consecutive groups of ``k`` rows are drawn
         jointly within the group and independently across groups (unlike
@@ -2190,39 +2196,13 @@ scipy.sparse.csc_array
         predict : Point predictions using the posterior mean.
         """
         X_sample = self._validated_for_sampling(X)
+        # Multivariate t: a Gaussian draw from ``shape_`` (precision
+        # (a/b)·Λ, so covariance (b/a)·Λ⁻¹) divided by the square root of
+        # a chi-square over its degrees of freedom. The chi-square is
+        # drawn first, then the normals.
         df = 2 * self.a_
-
-        # ``shape_`` carries the (b/a) factor; the chi-square mixing is
-        # a per-draw scalar, so the reduction stays exact.
-        support_draw = build_joint_reduction(
-            self.shape_,
-            X_sample,
-            self.coef_.shape[0],
-            size,
-            self.sparse,
-        )
-        if support_draw is not None:
-            mean = _predictive_mean(X_sample, self.coef_)
-            z = support_draw.joint(size, self.random_state_)
-            x = self.random_state_.chisquare(df, size) / df
-            return cast(
-                NDArray[np.float64],
-                mean + z / np.sqrt(x)[..., None],
-            )
-
-        # Multivariate t in weight space: a Gaussian draw from ``shape_``
-        # (precision (a/b)·Λ, so covariance (b/a)·Λ⁻¹) divided by the
-        # square root of a chi-square over its degrees of freedom. The
-        # chi-square is drawn first, then the normals.
         x = self.random_state_.chisquare(df, size) / df
-        return _weight_space_rows(
-            self.shape_,
-            X_sample,
-            self.coef_,
-            size,
-            self.random_state_,
-            divisor=np.sqrt(x),
-        )
+        return self._joint_rows(self.shape_, X_sample, size, divisor=np.sqrt(x))
 
     def sample_marginal(
         self, X: Union[NDArray[Any], csc_array], size: int = 1
@@ -2909,23 +2889,8 @@ scipy.sparse.csc_array
         predict : Point predictions using the posterior mean.
         """
         X_sample = self._validated_for_sampling(X)
-
-        # The reduction draws eta; the inverse link is elementwise either way.
-        support_draw = build_joint_reduction(
-            self._precision_factor,
-            X_sample,
-            self.coef_.shape[0],
-            size,
-            self.sparse,
-        )
-        if support_draw is not None:
-            mean = _predictive_mean(X_sample, self.coef_)
-            eta = support_draw.joint(size, self.random_state_, mean)
-            return self._inverse_link(cast(NDArray[np.float64], eta))
-
-        eta = _weight_space_rows(
-            self._precision_factor, X_sample, self.coef_, size, self.random_state_
-        )
+        # eta is drawn either way; the inverse link is elementwise
+        eta = self._joint_rows(self._precision_factor, X_sample, size)
         return self._inverse_link(eta)
 
     def sample_marginal(

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from collections import defaultdict
 from functools import cached_property, partial, wraps
-from typing import Any, Callable, Dict, Optional, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, TypeVar, Union, cast
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 from scipy.linalg import cho_factor, cho_solve, cholesky
-from scipy.linalg.blas import dgemv, dsymv  # type: ignore
+from scipy.linalg.blas import dgemm, dgemv, dsymv  # type: ignore
 from scipy.sparse import csc_array, diags, eye, issparse
 from scipy.special import expit
 from scipy.stats import (
@@ -26,7 +26,15 @@ from sklearn.utils.validation import (
 )
 from typing_extensions import Concatenate, ParamSpec, Self
 
-from ._blas_helpers import compute_eta_dense, update_precision_dense
+from . import _support_covariance
+from ._blas_helpers import (
+    affine_lower_factor,
+    compute_eta_dense,
+    dense_matvec,
+    lower_predictive_sqrt,
+    standard_normal_f,
+    update_precision_dense,
+)
 from ._gaussian import (
     LaplaceApproximator,
     LinkFunction,
@@ -820,22 +828,33 @@ def _marginal_predictive_sd(
     ever formed; the cost is linear in the number of prediction rows.
     A sparse ``X`` is densified for the solve in row blocks, keeping the
     dense scratch bounded regardless of the number of prediction rows.
+
+    When ``X`` is sparse and touches fewer distinct columns than it has
+    rows, the support-covariance route is exact and cheaper -- it pays
+    one solve per distinct column instead of one per row -- so it is
+    used instead. See :mod:`bayesianbandits._support_covariance`.
     """
     # Dispatch on the actual type of X: sparse models accept dense X too
     # (check_array's accept_sparse only *permits* sparse input)
     if not issparse(X):
         rhs = np.asarray(X, dtype=np.float64).T
         B = np.asarray(factor.half_solve(rhs), dtype=np.float64)
-        return cast(NDArray[np.float64], np.sqrt((B * B).sum(axis=0)))
+        return cast(NDArray[np.float64], np.sqrt(np.einsum("ij,ij->j", B, B)))
     assert X.shape is not None  # for the type checker
     n_rows, n_features = X.shape
+    support_draw = _support_covariance.build(factor, X, n_features, budget=n_rows)
+    if support_draw is not None:
+        return support_draw.sd()
     block = max(1, _MARGINAL_SD_BLOCK_ELEMS // max(1, n_features))
+    # Rows are CSC's minor axis, so slicing rows per chunk would scan all
+    # of X's nnz each chunk; slice from a CSR copy when chunking
+    X_rows: Any = cast(csc_array, X).tocsr() if n_rows > block else X
     var = np.empty(n_rows, dtype=np.float64)
     for start in range(0, n_rows, block):
         stop = min(n_rows, start + block)
-        rhs = np.asarray(X[start:stop].T.toarray(), dtype=np.float64)
+        rhs = np.asarray(X_rows[start:stop].T.toarray(), dtype=np.float64)
         B = np.asarray(factor.half_solve(rhs), dtype=np.float64)
-        var[start:stop] = (B * B).sum(axis=0)
+        var[start:stop] = np.einsum("ij,ij->j", B, B)
     return cast(NDArray[np.float64], np.sqrt(var))
 
 
@@ -858,7 +877,290 @@ def _validated_marginal_mean_sd(
     return mean, sd
 
 
-class NormalRegressor(BaseEstimator, RegressorMixin):
+def _reward_space_is_cheaper(
+    n: int,
+    d: int,
+    size: int,
+    sparse: bool,
+    precision_nnz: int,
+    block_size: Optional[int] = None,
+) -> bool:
+    """Is reward-space sampling cheaper than weight-space for this call?
+
+    Weight-space draws ``size`` weight vectors from the ``d``-dimensional
+    posterior and projects them through ``X``.  Reward-space computes an
+    exact square root of the predictive covariance
+    :math:`X \\Lambda^{-1} X^T` once (``n`` triangular half-solves plus a
+    QR) and draws directly in reward space, so its per-draw cost is
+    independent of ``d``.
+
+    The decision rests on the one quantity both paths pay in the same
+    currency: **triangular solves against the cached factor**.
+    Reward-space performs ``n`` of them, weight-space ``size``.  Both are
+    exactly known integers, so comparing them needs no calibration.
+    Requiring ``2n <= size`` rather than ``n < size`` leaves the other
+    half of the weight-space solve budget to cover reward-space's
+    remaining work, which the guards below then check fits.
+
+    With ``k`` rows per QR block (``k = n`` in full mode), that remaining
+    work is ``n·k·d`` for the QR and ``n·k·size`` for the draws:
+
+    - Dense.  Weight-space spends ``d²·size`` colorizing, so the draw
+      term fits when ``2·n·k <= d²``.  This is what stops the path being
+      taken at ``n ≈ d``, where the two do the same work but
+      reward-space does it in many small, latency-bound calls rather
+      than one large one.  ``n <= d`` additionally keeps reward-space's
+      ``n·size`` normals under weight-space's ``d·size``.
+    - Sparse.  A solve costs ``nnz``, not ``d²``, so the draw term fits
+      when ``2·n·k <= nnz``.  Sparse also densifies a ``(d, k)`` scratch
+      for the half-solves, which is the only allocation here that can
+      exceed the factor itself, so it is held to the same element budget
+      the marginal path uses.  That budget, not the cost model, is what
+      declines large ``n`` at high ``d``; ``block_size`` is the way to
+      take those calls.
+    """
+    k = n if block_size is None else block_size
+    if 2 * n > size:
+        return False
+    if sparse:
+        return k * d <= _MARGINAL_SD_BLOCK_ELEMS and 2 * n * k <= precision_nnz
+    return n <= d and 2 * n * k <= d * d
+
+
+class _RowSpaceDraw:
+    """Zero-mean joint draws from an ``n x n`` lower factor of the
+    predictive covariance -- the row-side counterpart of
+    :class:`~bayesianbandits._support_covariance.SupportDraw`."""
+
+    __slots__ = ("_L",)
+
+    def __init__(self, L: NDArray[np.float64]) -> None:
+        self._L = L
+
+    def joint(self, size: int, rng: np.random.Generator) -> NDArray[np.float64]:
+        n_rows = self._L.shape[0]
+        z = standard_normal_f(rng, size, n_rows)
+        return cast(NDArray[np.float64], dgemm(1.0, z, self._L, trans_b=1))
+
+
+def build_joint_reduction(
+    factor: PrecisionFactor,
+    X: Union[NDArray[Any], csc_array],
+    n_features: int,
+    size: int,
+    sparse: bool,
+    precision_nnz: int,
+) -> Optional[Any]:
+    """Cheapest exact reduction of ``Cov(Xw)``, or ``None`` for weight space.
+
+    ``Cov(Xw) = X \\Lambda^{-1} X^T`` has rank at most
+    ``min(n_rows, |U|, n_features)``, and there is a reduction to a
+    square root on each side.  All three routes are exact and give the
+    same distribution; they differ only in how many triangular solves
+    against the cached factor they cost:
+
+    ==================  ===================  =========================
+    route               solves               square root
+    ==================  ===================  =========================
+    weight space        ``size``             cached, ``d x d``
+    row side            ``n_rows``           ``n_rows x n_rows``
+    column side         ``|U|``              ``|U| x |U|``
+    ==================  ===================  =========================
+
+    So the choice is just ``min(size, n_rows, |U|)``, three exactly
+    known integers.  Weight space is the one whose square root is
+    *cached* -- it factors :math:`\\Lambda`, which does not depend on
+    ``X`` -- so it needs no build at all and simply pays per draw. The
+    other two must refactor on every call, which is why neither can win
+    at small ``size``: there is nothing to amortize.
+
+    Passing ``min(size, n_rows)`` as the column-side budget is what
+    makes this one comparison rather than two: the column route already
+    declines unless ``|U|`` beats its budget, so handing it the row
+    route's cost lets it fire only when it is the cheapest of the three.
+
+    A dense model has no column-side route -- ``|U|`` is every feature,
+    so there is nothing to reduce -- but the row side still applies, and
+    :func:`_reward_space_is_cheaper` carries the extra guards a dense
+    model needs: weight space there does no solve at all, multiplying by
+    a cached inverse factor instead, so the row side must also fit its
+    draw term under that.
+    """
+    n_rows = cast("tuple[int, int]", X.shape)[0]
+    row_ok = _reward_space_is_cheaper(n_rows, n_features, size, sparse, precision_nnz)
+    support_draw = _support_covariance.build(
+        factor, X, n_features, budget=min(size, n_rows) if row_ok else size
+    )
+    if support_draw is not None:
+        return support_draw
+    if row_ok:
+        B = np.asarray(
+            factor.half_solve(
+                np.asarray(X.todense() if issparse(X) else X, dtype=np.float64).T
+            ),
+            dtype=np.float64,
+        ).reshape(-1, n_rows)
+        return _RowSpaceDraw(lower_predictive_sqrt(B, n_rows))
+    return None
+
+
+def _predictive_cholesky_from_factor(
+    factor: PrecisionFactor,
+    coef: NDArray[np.float64],
+    X: Union[NDArray[Any], csc_array],
+    block_size: Optional[int] = None,
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Predictive mean and lower-triangular square root(s) of :math:`X \\Lambda^{-1} X^T`.
+
+    Computes ``B = factor.half_solve(X.T)`` -- one triangular solve per
+    prediction row against the cached factor, so ``B.T @ B`` equals the
+    predictive covariance without :math:`\\Lambda^{-1}` or the covariance
+    itself ever being formed -- and takes the ``R`` factor of its QR
+    decomposition: ``R.T @ R = B.T @ B``, making ``R.T`` an exact lower
+    triangular square root even when ``X`` has linearly dependent rows
+    (e.g. repeated contexts) -- unlike a Cholesky of the explicit
+    covariance, which would need regularization there and would square
+    the condition number.
+
+    With ``block_size=k``, rows are treated as consecutive groups of
+    ``k`` and the QR is batched per group, returning one ``(k, k)``
+    factor per group with shape ``(n_blocks, k, k)``: exact joint
+    structure within each group, none across groups. This is the shape
+    a caller wants when rows group into independent decision units
+    (e.g. one block of arm rows per context). Blocked mode processes
+    rows in chunks so the dense half-solve scratch stays within the
+    same ``_MARGINAL_SD_BLOCK_ELEMS`` budget ``_marginal_predictive_sd``
+    uses, regardless of the total row count. Full mode has no such cap:
+    a sparse ``X`` is densified transposed all at once, so the scratch
+    is a dense ``(n_features, n_rows)`` array -- pass ``block_size`` to
+    bound memory when both dimensions are large.
+    """
+
+    def half_solve_rows(rows: slice) -> NDArray[np.float64]:
+        # Dispatch on the actual type: sparse models accept dense X too
+        # (check_array's accept_sparse only *permits* sparse input)
+        X_rows = X_row_sliceable[rows]
+        if issparse(X_rows):
+            rhs = np.asarray(X_rows.T.toarray(), dtype=np.float64)
+        else:
+            rhs = np.asarray(X_rows, dtype=np.float64).T
+        return np.asarray(factor.half_solve(rhs), dtype=np.float64)
+
+    # Sparse products never enter a BLAS thread pool, so only the dense
+    # case needs routing away from numpy.
+    if issparse(X):
+        mean = np.asarray(X @ coef, dtype=np.float64).ravel()
+    else:
+        mean = dense_matvec(X, coef)
+    n = mean.shape[0]
+    X_row_sliceable: Any = X
+
+    if block_size is None:
+        B = half_solve_rows(slice(0, n)).reshape(-1, n)
+        return mean, lower_predictive_sqrt(B, n)
+
+    if block_size <= 0 or n % block_size:
+        raise ValueError(
+            f"block_size={block_size} must be positive and divide the "
+            f"number of prediction rows ({n})"
+        )
+    n_blocks = n // block_size
+    # Only the small (block_size, block_size) factors survive, so bound
+    # the dense (n_features, chunk_rows) half-solve scratch by chunking
+    # over consecutive blocks
+    chunk_blocks = max(1, _MARGINAL_SD_BLOCK_ELEMS // max(1, X.shape[1] * block_size))
+    if issparse(X) and n_blocks > chunk_blocks:
+        # Rows are CSC's minor axis, so slicing rows per chunk would scan
+        # all of X's nnz each chunk; slice from a CSR copy when chunking
+        X_row_sliceable = cast(csc_array, X).tocsr()
+    L = np.empty((n_blocks, block_size, block_size))
+    for start in range(0, n_blocks, chunk_blocks):
+        stop = min(start + chunk_blocks, n_blocks)
+        B = half_solve_rows(slice(start * block_size, stop * block_size))
+        B = B.reshape(-1, (stop - start) * block_size)
+        blocks = B.reshape(B.shape[0], stop - start, block_size).transpose(1, 0, 2)
+        # One factorization per block rather than numpy's batched QR: the
+        # batched call is a single trip into numpy's OpenBLAS, and the
+        # round trip out of scipy's costs more than this loop does. See
+        # ``lower_predictive_sqrt``.
+        for offset, block in enumerate(blocks):
+            L[start + offset] = lower_predictive_sqrt(block, block_size)
+    return mean, L
+
+
+def _blocked_colorize(
+    L: NDArray[np.float64], z: NDArray[np.floating[Any]]
+) -> NDArray[np.float64]:
+    """Apply per-block lower factors: ``(L_b @ z_{s,b})`` for every draw.
+
+    ``L`` has shape ``(n_blocks, k, k)``, ``z`` has shape
+    ``(n_blocks, size, k)``; returns shape ``(size, n_blocks * k)``. The
+    result is written straight into a C-order ``(size, n_blocks, k)``
+    array, so neither the draw tensor nor the result is copied through
+    a transposed intermediate.
+    """
+    n_blocks, size, k = z.shape
+    out = np.empty((size, n_blocks, k))
+    np.matmul(z, L.transpose(0, 2, 1), out=out.transpose(1, 0, 2))
+    # explicit column count: reshape(size, -1) is ambiguous when size == 0
+    return out.reshape(size, n_blocks * k)
+
+
+class _RewardSpacePredictiveMixin:
+    """Reward-space sampling support shared by the conjugate linear models.
+
+    Hosts the predictive-Cholesky construction, the flop-model gate, and
+    the shared ``sample``/``sample_reward_space`` validation preamble
+    over the ``coef_``/``_precision_factor``/``sparse`` contract that
+    :class:`NormalRegressor` and :class:`BayesianGLM` share.
+    """
+
+    if TYPE_CHECKING:
+        coef_: NDArray[np.float64]
+        cov_inv_: Union[NDArray[np.float64], csc_array]
+        n_features_: int
+        sparse: bool
+
+        @property
+        def _precision_factor(self) -> PrecisionFactor: ...
+
+        def _initialize_prior(self, X: Union[NDArray[Any], csc_array]) -> None: ...
+
+    def _predictive_cholesky(
+        self, X: Union[NDArray[Any], csc_array], block_size: Optional[int] = None
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+        """Predictive mean and lower square root(s) of the linear
+        predictor's covariance :math:`X \\Lambda^{-1} X^T`. Assumes ``X``
+        is already validated and the model is fitted (or the prior
+        initialized). For the NIG subclass this is the *unscaled* factor:
+        the ``b/a`` scaling is applied by ``sample_reward_space``."""
+        return _predictive_cholesky_from_factor(
+            self._precision_factor, self.coef_, X, block_size
+        )
+
+    @property
+    def _precision_nnz(self) -> int:
+        """Stored entries in the precision, the per-solve cost proxy for
+        a sparse model. Zero for a dense one, where a solve costs
+        ``d^2`` regardless."""
+        return cast(csc_array, self.cov_inv_).nnz if self.sparse else 0
+
+    def _validated_for_sampling(
+        self, X: Union[NDArray[Any], csc_array]
+    ) -> Union[NDArray[Any], csc_array]:
+        """Shared ``sample``/``sample_reward_space`` preamble: validate
+        ``X`` and initialize the prior if the model is unfitted."""
+        X_pred = check_array(
+            X, copy=True, ensure_2d=True, accept_sparse="csc" if self.sparse else False
+        )
+        try:
+            check_is_fitted(self, "coef_")
+        except NotFittedError:
+            self._initialize_prior(X_pred)
+        return X_pred
+
+
+class NormalRegressor(_RewardSpacePredictiveMixin, BaseEstimator, RegressorMixin):
     """
     Bayesian linear regression with known noise variance.
 
@@ -1291,6 +1593,26 @@ scipy.sparse.csc_array
             X, copy=False, ensure_2d=True, accept_sparse="csc" if self.sparse else False
         )
 
+        # Exact joint draws through whichever reduction of the
+        # predictive covariance is cheapest here: one solve per draw
+        # (weight space), one per prediction row, or one per distinct
+        # column X touches. Same distribution, different consumption of
+        # the random stream.
+        support_draw = build_joint_reduction(
+            self._precision_factor,
+            X_sample,
+            X_sample.shape[1],
+            size,
+            self.sparse,
+            self._precision_nnz,
+        )
+        if support_draw is not None:
+            mean = np.asarray(X_sample @ self.coef_, dtype=np.float64).ravel()
+            return cast(
+                NDArray[np.float64],
+                mean + support_draw.joint(size, self.random_state_),
+            )
+
         samples = np.atleast_2d(
             multivariate_normal_sample_from_precision(
                 self.coef_,
@@ -1345,6 +1667,82 @@ scipy.sparse.csc_array
         mean, sd = _validated_marginal_mean_sd(self, X)
         z = self.random_state_.standard_normal((size, mean.shape[0]))
         return cast(NDArray[np.float64], mean + sd * z)
+
+    def sample_reward_space(
+        self,
+        X: Union[NDArray[Any], csc_array],
+        size: int = 1,
+        *,
+        block_size: Optional[int] = None,
+    ) -> NDArray[np.float64]:
+        """
+        Sample jointly from the posterior predictive, drawing in reward space.
+
+        Distributionally identical to :meth:`sample` -- draws from
+        :math:`X w \\sim \\mathcal{N}(X \\hat{w}, X \\Lambda^{-1} X^T)`
+        -- but computed by factoring the ``n``-row predictive covariance
+        once (one triangular half-solve per prediction row against the
+        cached precision factor, then a QR) and drawing directly in
+        reward space. Per-draw cost is then independent of the number of
+        features, so this is much cheaper than ``sample`` when ``size``
+        is large relative to the number of rows, and much more expensive
+        in the opposite regime. Neither :math:`\\Lambda^{-1}` nor the
+        covariance is ever formed, and linearly dependent rows (e.g.
+        repeated contexts) are represented exactly. Note that without
+        ``block_size``, a sparse model densifies the transposed
+        prediction rows all at once -- a dense
+        ``(n_features, n_samples)`` scratch array -- so pass
+        ``block_size`` to bound memory when both dimensions are large.
+
+        With ``block_size=k``, consecutive groups of ``k`` rows are
+        factored and drawn independently: draws are joint within each
+        group and independent across groups (unlike ``sample``, where
+        all rows of one draw share a weight vector). Use this when rows
+        group into independent decision units -- e.g. one block of arm
+        rows per context -- and no cross-group statistic is consumed;
+        the per-group joint distribution is exact.
+
+        If the model has not been fitted, samples are drawn from the
+        prior predictive distribution.
+
+        .. note::
+
+           Only the sampling *distribution* is guaranteed to match
+           ``sample``, not the bitstream: the two methods consume
+           different amounts of randomness, so the same seed yields
+           different (equally distributed) realizations.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input data. May be dense, or a ``scipy.sparse.csc_array``
+            when ``sparse=True``.
+        size : int, default=1
+            Number of posterior samples to draw.
+        block_size : int, optional
+            If given, must divide ``n_samples``; rows are drawn jointly
+            within consecutive blocks of this many rows and
+            independently across blocks.
+
+        Returns
+        -------
+        samples : ndarray of shape (size, n_samples)
+            Predicted values for each posterior draw.
+
+        See Also
+        --------
+        sample : Joint draws in weight space (cheaper for small ``size``).
+        sample_marginal : iid per-row draws for per-row statistics.
+        """
+        X_sample = self._validated_for_sampling(X)
+        mean, L = self._predictive_cholesky(X_sample, block_size)
+        if block_size is None:
+            z = standard_normal_f(self.random_state_, size, mean.shape[0])
+            return affine_lower_factor(mean, z, L)
+        z = self.random_state_.standard_normal(
+            (mean.shape[0] // block_size, size, block_size)
+        )
+        return cast(NDArray[np.float64], mean + _blocked_colorize(L, z))
 
     @_invalidate_cached_properties
     def decay(
@@ -1763,6 +2161,27 @@ scipy.sparse.csc_array
         )
         df = 2 * self.a_
 
+        # Exact joint draws via the support covariance, built from
+        # ``shape_`` so S already carries the (b/a) factor. The
+        # chi-square mixing is a per-draw scalar, so it commutes with
+        # the linear map and the reduction stays exact.
+        support_draw = build_joint_reduction(
+            self.shape_,
+            X_sample,
+            X_sample.shape[1],
+            size,
+            self.sparse,
+            self._precision_nnz,
+        )
+        if support_draw is not None:
+            mean = np.asarray(X_sample @ self.coef_, dtype=np.float64).ravel()
+            z = support_draw.joint(size, self.random_state_)
+            x = self.random_state_.chisquare(df, size) / df
+            return cast(
+                NDArray[np.float64],
+                mean + z / np.sqrt(x)[..., None],
+            )
+
         # Sample from multivariate t via precision parameterization
         # shape_ returns a PrecisionFactor (DenseFactor or SparseFactor)
         # whose precision is (a/b)·Λ, i.e. shape cov = (b/a)·Λ⁻¹
@@ -1824,6 +2243,76 @@ scipy.sparse.csc_array
         # per-cell scale
         scale = np.sqrt((self.b_ / self.a_) * df / g)
         return cast(NDArray[np.float64], mean + (sd * z) * scale)
+
+    def sample_reward_space(
+        self,
+        X: Union[NDArray[Any], csc_array],
+        size: int = 1,
+        *,
+        block_size: Optional[int] = None,
+    ) -> NDArray[np.float64]:
+        """
+        Sample jointly from the posterior predictive, drawing in reward space.
+
+        Distributionally identical to :meth:`sample` -- the ``n``-row
+        multivariate t with :math:`2 a_n` degrees of freedom, location
+        :math:`X \\mu_n`, and shape :math:`(b_n / a_n) X \\Lambda_n^{-1} X^T`
+        -- but drawn via the exact square root of the shape matrix, with
+        one shared chi-square mixing variable per draw. See
+        :meth:`NormalRegressor.sample_reward_space` for the cost model
+        and the bitstream caveat.
+
+        With ``block_size=k``, consecutive groups of ``k`` rows are
+        drawn independently, each with its own chi-square mixing
+        variable per draw: every group's joint t distribution is exact,
+        and groups are fully independent (whereas ``sample`` shares one
+        noise-scale draw across all rows). Use only when no cross-group
+        statistic is consumed.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input data. May be dense, or a ``scipy.sparse.csc_array``
+            when ``sparse=True``.
+        size : int, default=1
+            Number of posterior samples to draw.
+        block_size : int, optional
+            If given, must divide ``n_samples``; rows are drawn jointly
+            within consecutive blocks of this many rows and
+            independently across blocks.
+
+        Returns
+        -------
+        samples : ndarray of shape (size, n_samples)
+            Predicted values for each posterior draw.
+
+        See Also
+        --------
+        sample : Joint draws in weight space (cheaper for small ``size``).
+        sample_marginal : iid per-row draws for per-row statistics.
+        """
+        X_sample = self._validated_for_sampling(X)
+        mean, L = self._predictive_cholesky(X_sample, block_size)
+        df = 2.0 * self.a_
+        if block_size is None:
+            z = standard_normal_f(self.random_state_, size, mean.shape[0])
+            g = self.random_state_.chisquare(df, size=size)
+            # t draw: location + sqrt(df/g) · (shape-chol @ z), with the
+            # (b/a) shape scaling (shape cov = (b/a) · X Λ⁻¹ Xᵀ) folded
+            # into the per-draw scale. Scaling the draws rather than the
+            # product is equivalent (both scale whole rows) and lets the
+            # mean be accumulated inside the same GEMM.
+            scale = np.sqrt((self.b_ / self.a_) * df / g)
+            z *= scale[:, np.newaxis]
+            return affine_lower_factor(mean, z, L)
+        n_blocks = mean.shape[0] // block_size
+        z = self.random_state_.standard_normal((n_blocks, size, block_size))
+        # one chi-square per (draw, block): joint t within a block,
+        # independence across blocks
+        g = self.random_state_.chisquare(df, size=(size, n_blocks))
+        scale = np.sqrt((self.b_ / self.a_) * df / g)
+        y = _blocked_colorize(L, z * scale.T[:, :, np.newaxis])
+        return cast(NDArray[np.float64], mean + y)
 
     @_invalidate_cached_properties
     def decay(
@@ -1945,7 +2434,7 @@ def multivariate_t_sample_from_covariance(
     return _squeeze_output(samples)
 
 
-class BayesianGLM(BaseEstimator, RegressorMixin):
+class BayesianGLM(_RewardSpacePredictiveMixin, BaseEstimator, RegressorMixin):
     """
     Bayesian Generalized Linear Model with Laplace approximation.
 
@@ -2421,6 +2910,22 @@ scipy.sparse.csc_array
             X, copy=False, ensure_2d=True, accept_sparse="csc" if self.sparse else False
         )
 
+        # The support covariance gives the linear predictor's exact joint
+        # law directly; the inverse link is applied elementwise either
+        # way, so it composes unchanged.
+        support_draw = build_joint_reduction(
+            self._precision_factor,
+            X_sample,
+            X_sample.shape[1],
+            size,
+            self.sparse,
+            self._precision_nnz,
+        )
+        if support_draw is not None:
+            mean = np.asarray(X_sample @ self.coef_, dtype=np.float64).ravel()
+            eta = mean + support_draw.joint(size, self.random_state_)
+            return self._inverse_link(cast(NDArray[np.float64], eta))
+
         param_samples = np.atleast_2d(
             multivariate_normal_sample_from_precision(
                 self.coef_,
@@ -2473,6 +2978,59 @@ scipy.sparse.csc_array
         mean, sd = _validated_marginal_mean_sd(self, X)
         z = self.random_state_.standard_normal((size, mean.shape[0]))
         return self._inverse_link(mean + sd * z)
+
+    def sample_reward_space(
+        self,
+        X: Union[NDArray[Any], csc_array],
+        size: int = 1,
+        *,
+        block_size: Optional[int] = None,
+    ) -> NDArray[np.float64]:
+        """
+        Sample jointly from the posterior predictive, drawing in eta space.
+
+        Distributionally identical to :meth:`sample` -- draws linear
+        predictors :math:`\\eta \\sim \\mathcal{N}(X \\hat{w},
+        X \\Lambda^{-1} X^T)` and applies the inverse link elementwise
+        -- but the :math:`\\eta` draws come directly from the ``n``-row
+        predictive Gaussian via the exact square root of its covariance.
+        See :meth:`NormalRegressor.sample_reward_space` for the cost
+        model, the ``block_size`` semantics, and the bitstream caveat.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input data. May be dense, or a ``scipy.sparse.csc_array``
+            when ``sparse=True``.
+        size : int, default=1
+            Number of posterior samples to draw.
+        block_size : int, optional
+            If given, must divide ``n_samples``; rows are drawn jointly
+            within consecutive blocks of this many rows and
+            independently across blocks.
+
+        Returns
+        -------
+        samples : ndarray of shape (size, n_samples)
+            Predicted values for each posterior sample, on the response
+            scale of the link.
+
+        See Also
+        --------
+        sample : Joint draws in weight space (cheaper for small ``size``).
+        sample_marginal : iid per-row draws for per-row statistics.
+        """
+        X_sample = self._validated_for_sampling(X)
+        mean, L = self._predictive_cholesky(X_sample, block_size)
+        if block_size is None:
+            z = standard_normal_f(self.random_state_, size, mean.shape[0])
+            eta = affine_lower_factor(mean, z, L)
+        else:
+            z = self.random_state_.standard_normal(
+                (mean.shape[0] // block_size, size, block_size)
+            )
+            eta = mean + _blocked_colorize(L, z)
+        return self._inverse_link(cast(NDArray[np.float64], eta))
 
     @_invalidate_cached_properties
     def decay(

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -48,8 +48,6 @@ from ._sparse_bayesian_linear_regression import (
     PrecisionFactor,
     SparseFactor,
     create_sparse_factor,
-    multivariate_normal_sample_from_precision,
-    multivariate_t_sample_from_precision,
     scale_factor,
 )
 
@@ -817,19 +815,6 @@ def _invalidate_cached_properties(
 _MARGINAL_SD_BLOCK_ELEMS = 2**21
 
 
-def _dense_rows_t(X_rows: Any) -> NDArray[np.float64]:
-    """``X_rows.T`` densified, ``(n_features, rows)`` and F-contiguous.
-
-    Densifying first and transposing the result costs one pass over the
-    row-major block; transposing the sparse matrix first (``X.T.toarray()``)
-    lands on the same layout by way of a CSR-to-CSC conversion of the
-    whole block. F-contiguous either way, which is what the sparse
-    factors' solvers want -- CHOLMOD's dense format is column-major, and
-    a C-ordered right-hand side is copied before the solve.
-    """
-    return cast(NDArray[np.float64], np.asarray(X_rows.toarray(), dtype=np.float64).T)
-
-
 def _marginal_support_is_cheaper(n_u: int, n_rows: int, precision_nnz: int) -> bool:
     """Is the column-side reduction cheaper than the half-solve path?
 
@@ -852,7 +837,7 @@ def _marginal_support_is_cheaper(n_u: int, n_rows: int, precision_nnz: int) -> b
 
 
 def _marginal_predictive_sd(
-    factor: PrecisionFactor, X: Union[NDArray[Any], csc_array], precision_nnz: int
+    factor: PrecisionFactor, X: Union[NDArray[Any], csc_array]
 ) -> NDArray[np.float64]:
     """Per-row predictive standard deviations :math:`\\sqrt{x_i^T \\Lambda^{-1} x_i}`.
 
@@ -861,8 +846,13 @@ def _marginal_predictive_sd(
     equals :math:`X \\Lambda^{-1} X^T` -- and takes column norms.
     Neither :math:`\\Lambda^{-1}` nor any :math:`n \\times n` matrix is
     ever formed; the cost is linear in the number of prediction rows.
-    A sparse ``X`` is densified for the solve in row blocks, keeping the
-    dense scratch bounded regardless of the number of prediction rows.
+    A sparse ``X`` is handed over sparse in row blocks: the factor
+    half-solves at the features it factors and returns a compact
+    ``(n_factored + t, rows)`` block, so the scratch, and the block size
+    that bounds it, are in ``factor.n_factored`` rather than
+    ``n_features`` -- at :math:`2^{20}` features with 26k observed that
+    is 80 rows per block instead of 2, and no pass over the never
+    observed features at all.
 
     A sparse ``X`` touching few enough distinct columns goes through
     :mod:`bayesianbandits._support_covariance` instead: one solve per
@@ -884,19 +874,18 @@ def _marginal_predictive_sd(
         X,
         n_features,
         budget=n_rows,
-        accept=lambda n_u: _marginal_support_is_cheaper(n_u, n_rows, precision_nnz),
+        accept=lambda n_u: _marginal_support_is_cheaper(n_u, n_rows, factor.solve_cost),
     )
     if support_draw is not None:
         return support_draw.sd()
-    block = max(1, _MARGINAL_SD_BLOCK_ELEMS // max(1, n_features))
+    block = max(1, _MARGINAL_SD_BLOCK_ELEMS // max(1, factor.n_factored))
     # Rows are CSC's minor axis, so slicing rows per chunk would scan all
     # of X's nnz each chunk; slice from a CSR copy when chunking
     X_rows: Any = cast(csc_array, X).tocsr() if n_rows > block else X
     var = np.empty(n_rows, dtype=np.float64)
     for start in range(0, n_rows, block):
         stop = min(n_rows, start + block)
-        rhs = _dense_rows_t(X_rows[start:stop])
-        B = np.asarray(factor.half_solve(rhs), dtype=np.float64)
+        B = np.asarray(factor.half_solve(X_rows[start:stop].T), dtype=np.float64)
         var[start:stop] = np.einsum("ij,ij->j", B, B)
     return cast(NDArray[np.float64], np.sqrt(var))
 
@@ -916,7 +905,7 @@ def _validated_marginal_mean_sd(
     except NotFittedError:
         est._initialize_prior(X_pred)
     mean = np.asarray(X_pred @ est.coef_, dtype=np.float64).ravel()
-    sd = _marginal_predictive_sd(est._precision_factor, X_pred, est._precision_nnz)
+    sd = _marginal_predictive_sd(est._precision_factor, X_pred)
     return mean, sd
 
 
@@ -934,19 +923,47 @@ def _predictive_mean(
     return dense_matvec(X, coef)
 
 
-def _rows_from_weight_draws(
-    draws: NDArray[np.float64], X: Union[NDArray[Any], csc_array]
+def _weight_space_rows(
+    factor: PrecisionFactor,
+    X: Union[NDArray[Any], csc_array],
+    coef: NDArray[np.float64],
+    size: int,
+    rng: np.random.Generator,
+    divisor: Optional[NDArray[np.floating[Any]]] = None,
 ) -> NDArray[np.float64]:
-    """``draws @ X.T``: weight-space draws mapped to prediction rows.
+    """``X w`` for ``size`` weight-space draws ``w = ŵ + M z``, shape
+    ``(size, n_rows)``; the one path every ``sample`` falls back to.
 
-    Dense ``X`` goes through ``dgemm`` rather than ``numpy``, which would
-    otherwise cross BLAS thread pools immediately after the triangular
-    solve that produced ``draws``.
+    The factor draws the zero-mean part itself
+    (:meth:`~bayesianbandits._sparse_bayesian_linear_regression.CholmodSparseFactor.sample_at`),
+    at exactly the features asked for, so how many normals that takes
+    is its business, not this function's. A sparse ``X`` asks for its
+    support only: everything after the solve then runs on the ``|U|``
+    columns ``X`` touches, ``O(nnz(X))`` plus one ``O(n_features)`` scan
+    for the support, where a weight vector would spend the same on
+    entries no row reads. A dense ``X`` reads every feature and takes
+    them all.
+
+    ``divisor`` divides the zero-mean part per draw, for the
+    multivariate-t mixing of the Normal-Inverse-Gamma posterior; ``ŵ``
+    is added after it, as in weight space.
     """
-    draws2 = np.atleast_2d(draws)
     if issparse(X):
-        return cast(NDArray[np.float64], draws2 @ X.T)
-    return dense_matmul_bt(draws2, cast(NDArray[Any], X))
+        Xs = cast(csc_array, X)
+        support = _support_covariance.support_of(Xs)
+        XU = _support_covariance.compact_columns(Xs, support)
+        rows = np.asarray(XU @ factor.sample_at(support, size, rng), dtype=np.float64)
+        if divisor is not None:
+            rows /= divisor
+        rows += np.asarray(XU @ coef[support], dtype=np.float64)[:, np.newaxis]
+        return cast(NDArray[np.float64], rows.T)
+    # (size, n_features), C-ordered: the transpose of the factor's
+    # column-major draw, so dgemm takes it uncopied
+    W = factor.sample_at(None, size, rng).T
+    if divisor is not None:
+        W /= divisor[:, np.newaxis]
+    W += coef
+    return dense_matmul_bt(W, cast(NDArray[Any], X))
 
 
 def _reward_space_is_cheaper(
@@ -961,7 +978,9 @@ def _reward_space_is_cheaper(
     guards check against what weight space spends per solve: ``d²``
     dense, ``nnz`` sparse. Dense also needs ``n <= d`` (fewer normals per
     draw); sparse also caps the ``(d, n)`` half-solve scratch at the
-    marginal path's element budget.
+    marginal path's element budget. ``d`` is what the factor factors --
+    ``factor.n_factored`` -- which for a sparse factor is its observed
+    block, the true row count of that scratch.
     """
     if 2 * n > size:
         return False
@@ -1005,7 +1024,6 @@ def build_joint_reduction(
     n_features: int,
     size: int,
     sparse: bool,
-    precision_nnz: int,
 ) -> Optional[Any]:
     """Cheapest exact reduction of ``Cov(Xw)``, or ``None`` for weight space.
 
@@ -1027,19 +1045,19 @@ def build_joint_reduction(
     where ``|U|`` is every feature.
     """
     n_rows = cast("tuple[int, int]", X.shape)[0]
-    row_ok = _reward_space_is_cheaper(n_rows, n_features, size, sparse, precision_nnz)
+    row_ok = _reward_space_is_cheaper(
+        n_rows, factor.n_factored, size, sparse, factor.solve_cost
+    )
     support_draw = _support_covariance.build(
         factor, X, n_features, budget=min(size, n_rows) if row_ok else size
     )
     if support_draw is not None:
         return support_draw
     if row_ok:
-        B = np.asarray(
-            factor.half_solve(
-                np.asarray(X.todense() if issparse(X) else X, dtype=np.float64).T
-            ),
-            dtype=np.float64,
-        ).reshape(-1, n_rows)
+        # sparse X goes over sparse: the factor half-solves at its block
+        # and returns a compact result whose Gram is the same
+        rhs = X.T if issparse(X) else np.asarray(X, dtype=np.float64).T
+        B = np.asarray(factor.half_solve(rhs), dtype=np.float64).reshape(-1, n_rows)
         return _RowSpaceDraw(lower_predictive_sqrt(B, n_rows))
     return None
 
@@ -1061,17 +1079,17 @@ def _predictive_cholesky_from_factor(
     consecutive group of ``k`` rows, shape ``(n_blocks, k, k)``: joint
     within a group, nothing across groups. Blocked mode chunks the dense
     half-solve scratch under ``_MARGINAL_SD_BLOCK_ELEMS``; full mode
-    densifies a sparse ``X`` all at once, ``(n_features, n_rows)``.
+    half-solves a sparse ``X`` all at once. A sparse ``X`` goes over
+    sparse: the factor half-solves at the features it factors and
+    returns a compact ``(n_factored + t, rows)`` block with the same
+    Gram, so the scratch is sized in ``factor.n_factored``.
     """
 
     def half_solve_rows(rows: slice) -> NDArray[np.float64]:
         # Dispatch on the actual type: sparse models accept dense X too
         # (check_array's accept_sparse only *permits* sparse input)
         X_rows = X_row_sliceable[rows]
-        if issparse(X_rows):
-            rhs = _dense_rows_t(X_rows)
-        else:
-            rhs = np.asarray(X_rows, dtype=np.float64).T
+        rhs = X_rows.T if issparse(X_rows) else np.asarray(X_rows, dtype=np.float64).T
         return np.asarray(factor.half_solve(rhs), dtype=np.float64)
 
     mean = _predictive_mean(X, coef)
@@ -1089,9 +1107,11 @@ def _predictive_cholesky_from_factor(
         )
     n_blocks = n // block_size
     # Only the small (block_size, block_size) factors survive, so bound
-    # the dense (n_features, chunk_rows) half-solve scratch by chunking
+    # the dense (n_factored, chunk_rows) half-solve scratch by chunking
     # over consecutive blocks
-    chunk_blocks = max(1, _MARGINAL_SD_BLOCK_ELEMS // max(1, X.shape[1] * block_size))
+    chunk_blocks = max(
+        1, _MARGINAL_SD_BLOCK_ELEMS // max(1, factor.n_factored * block_size)
+    )
     if issparse(X) and n_blocks > chunk_blocks:
         # Rows are CSC's minor axis, so slicing rows per chunk would scan
         # all of X's nnz each chunk; slice from a CSR copy when chunking
@@ -1149,12 +1169,6 @@ class _RewardSpacePredictiveMixin:
         return _predictive_cholesky_from_factor(
             self._precision_factor, self.coef_, X, block_size
         )
-
-    @property
-    def _precision_nnz(self) -> int:
-        """Per-solve cost proxy: stored precision entries for a sparse
-        model, zero for a dense one."""
-        return cast(csc_array, self.cov_inv_).nnz if self.sparse else 0
 
     def _validated_for_sampling(
         self, X: Union[NDArray[Any], csc_array]
@@ -1615,7 +1629,6 @@ scipy.sparse.csc_array
             X_sample.shape[1],
             size,
             self.sparse,
-            self._precision_nnz,
         )
         if support_draw is not None:
             mean = _predictive_mean(X_sample, self.coef_)
@@ -1624,16 +1637,9 @@ scipy.sparse.csc_array
                 support_draw.joint(size, self.random_state_, mean),
             )
 
-        samples = np.atleast_2d(
-            multivariate_normal_sample_from_precision(
-                self.coef_,
-                self._precision_factor,
-                size=size,
-                random_state=self.random_state_,
-            )
+        return _weight_space_rows(
+            self._precision_factor, X_sample, self.coef_, size, self.random_state_
         )
-
-        return _rows_from_weight_draws(samples, X_sample)
 
     def sample_marginal(
         self, X: Union[NDArray[Any], csc_array], size: int = 1
@@ -1788,12 +1794,7 @@ scipy.sparse.csc_array
         # mean.
         self.cov_inv_ = prior_decay * self.cov_inv_
         if "_precision_factor" in self.__dict__:
-            if self.sparse:
-                factor = self._precision_factor
-                assert isinstance(factor, SparseFactor)
-                self._precision_factor = scale_factor(factor, prior_decay)
-            else:
-                del self._precision_factor
+            self._precision_factor = scale_factor(self._precision_factor, prior_decay)
 
 
 class NormalInverseGammaRegressor(NormalRegressor):
@@ -2103,20 +2104,10 @@ scipy.sparse.csc_array
         """Precision of the shape matrix for the multivariate t posterior.
 
         The shape covariance is (b/a)·Λ⁻¹, so the shape precision is
-        (a/b)·Λ.  For dense models this is represented as a DenseFactor
-        with U_scaled = √(a/b)·U (zero extra factorizations); for sparse
-        models it wraps the existing SparseFactor via ``scale_factor``.
+        (a/b)·Λ: the cached precision factor with that scalar composed
+        in, no factorization and no copy of the factor.
         """
-        if self.sparse:
-            factor = self._precision_factor
-            assert isinstance(factor, SparseFactor)
-            return scale_factor(factor, float(self.a_ / self.b_))
-        else:
-            factor = self._precision_factor
-            assert isinstance(factor, DenseFactor)
-            scale = np.sqrt(self.a_ / self.b_)
-            U_scaled = np.triu(scale * factor._U)
-            return DenseFactor(_U=U_scaled, _n_features=factor._n_features)
+        return scale_factor(self._precision_factor, float(self.a_ / self.b_))
 
     def sample(
         self, X: Union[NDArray[Any], csc_array], size: int = 1
@@ -2169,7 +2160,6 @@ scipy.sparse.csc_array
             X_sample.shape[1],
             size,
             self.sparse,
-            self._precision_nnz,
         )
         if support_draw is not None:
             mean = _predictive_mean(X_sample, self.coef_)
@@ -2180,21 +2170,19 @@ scipy.sparse.csc_array
                 mean + z / np.sqrt(x)[..., None],
             )
 
-        # Sample from multivariate t via precision parameterization
-        # shape_ returns a PrecisionFactor (DenseFactor or SparseFactor)
-        # whose precision is (a/b)·Λ, i.e. shape cov = (b/a)·Λ⁻¹
-        samples = multivariate_t_sample_from_precision(
-            self.coef_,
+        # Multivariate t in weight space: a Gaussian draw from ``shape_``
+        # (precision (a/b)·Λ, so covariance (b/a)·Λ⁻¹) divided by the
+        # square root of a chi-square over its degrees of freedom. The
+        # chi-square is drawn first, then the normals.
+        x = self.random_state_.chisquare(df, size) / df
+        return _weight_space_rows(
             self.shape_,
-            df,
+            X_sample,
+            self.coef_,
             size,
-            self.random_state_,  # type: ignore[arg-type]
+            self.random_state_,
+            divisor=np.sqrt(x),
         )
-
-        if self.n_features_ == 1:
-            samples = np.expand_dims(samples, -1)
-
-        return _rows_from_weight_draws(samples, X_sample)
 
     def sample_marginal(
         self, X: Union[NDArray[Any], csc_array], size: int = 1
@@ -2360,12 +2348,7 @@ scipy.sparse.csc_array
         self.a_ = prior_decay * self.a_
         self.b_ = prior_decay * self.b_
         if "_precision_factor" in self.__dict__:
-            if self.sparse:
-                factor = self._precision_factor
-                assert isinstance(factor, SparseFactor)
-                self._precision_factor = scale_factor(factor, prior_decay)
-            else:
-                del self._precision_factor
+            self._precision_factor = scale_factor(self._precision_factor, prior_decay)
 
 
 def multivariate_t_sample_from_covariance(
@@ -2909,25 +2892,16 @@ scipy.sparse.csc_array
             X_sample.shape[1],
             size,
             self.sparse,
-            self._precision_nnz,
         )
         if support_draw is not None:
             mean = _predictive_mean(X_sample, self.coef_)
             eta = support_draw.joint(size, self.random_state_, mean)
             return self._inverse_link(cast(NDArray[np.float64], eta))
 
-        param_samples = np.atleast_2d(
-            multivariate_normal_sample_from_precision(
-                self.coef_,
-                self._precision_factor,
-                size=size,
-                random_state=self.random_state_,
-            )
+        eta = _weight_space_rows(
+            self._precision_factor, X_sample, self.coef_, size, self.random_state_
         )
-
-        eta = _rows_from_weight_draws(param_samples, X_sample)
-
-        return self._inverse_link(cast(NDArray[np.float64], eta))
+        return self._inverse_link(eta)
 
     def sample_marginal(
         self, X: Union[NDArray[Any], csc_array], size: int = 1
@@ -3063,9 +3037,4 @@ scipy.sparse.csc_array
 
         self.cov_inv_ = prior_decay * self.cov_inv_
         if "_precision_factor" in self.__dict__:
-            if self.sparse:
-                factor = self._precision_factor
-                assert isinstance(factor, SparseFactor)
-                self._precision_factor = scale_factor(factor, prior_decay)
-            else:
-                del self._precision_factor
+            self._precision_factor = scale_factor(self._precision_factor, prior_decay)

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -8,7 +8,7 @@ import numpy as np
 from numpy.typing import ArrayLike, NDArray
 from scipy.linalg import cho_factor, cho_solve, cholesky
 from scipy.linalg.blas import dgemm, dgemv, dsymv  # type: ignore
-from scipy.sparse import csc_array, diags, eye, issparse
+from scipy.sparse import block_diag, csc_array, csr_array, diags, eye, issparse
 from scipy.special import expit
 from scipy.stats import (
     Covariance,
@@ -47,6 +47,7 @@ from ._sparse_bayesian_linear_regression import (
     DenseFactor,
     PrecisionFactor,
     SparseFactor,
+    SparseHalfSolve,
     create_sparse_factor,
     scale_factor,
 )
@@ -810,9 +811,23 @@ def _invalidate_cached_properties(
     return wrapper
 
 
-# Cap on the dense (n_features, block) scratch densified from a sparse
-# X in _marginal_predictive_sd: ~2M float64 elements = 16 MB per array.
+# Cap on the dense (n_factored, block) half-solve scratch for a sparse X
+# in _marginal_predictive_sd and the reward-space paths: ~2M float64
+# elements = 16 MB per array.
 _MARGINAL_SD_BLOCK_ELEMS = 2**21
+
+
+def _half_solve_rows(
+    factor: PrecisionFactor, X_rows: Union[NDArray[Any], csc_array]
+) -> SparseHalfSolve:
+    """``factor.half_solve(X_rows.T)`` as a :class:`SparseHalfSolve` either
+    way; a dense ``X`` populates every feature, so it has nothing to split
+    off. Sparse models accept dense ``X`` too, so dispatch on the actual
+    type."""
+    if issparse(X_rows):
+        return cast(SparseHalfSolve, factor.half_solve(cast(Any, X_rows).T))
+    B = np.asarray(factor.half_solve(np.asarray(X_rows, dtype=np.float64).T))
+    return SparseHalfSolve(B, csc_array((0, B.shape[1]), dtype=np.float64))
 
 
 def _marginal_support_is_cheaper(n_u: int, n_rows: int, precision_nnz: int) -> bool:
@@ -847,9 +862,9 @@ def _marginal_predictive_sd(
     Neither :math:`\\Lambda^{-1}` nor any :math:`n \\times n` matrix is
     ever formed; the cost is linear in the number of prediction rows.
     A sparse ``X`` is handed over sparse in row blocks: the factor
-    half-solves at the features it factors and returns a compact
-    ``(n_factored + t, rows)`` block, so the scratch, and the block size
-    that bounds it, are in ``factor.n_factored`` rather than
+    half-solves at the features it factors and returns the never-observed
+    part sparse (:class:`SparseHalfSolve`), so the scratch, and the block
+    size that bounds it, are in ``factor.n_factored`` rather than
     ``n_features`` -- at :math:`2^{20}` features with 26k observed that
     is 80 rows per block instead of 2, and no pass over the never
     observed features at all.
@@ -885,8 +900,9 @@ def _marginal_predictive_sd(
     var = np.empty(n_rows, dtype=np.float64)
     for start in range(0, n_rows, block):
         stop = min(n_rows, start + block)
-        B = np.asarray(factor.half_solve(X_rows[start:stop].T), dtype=np.float64)
-        var[start:stop] = np.einsum("ij,ij->j", B, B)
+        B = _half_solve_rows(factor, X_rows[start:stop])
+        var[start:stop] = np.einsum("ij,ij->j", B.block, B.block)
+        var[start:stop] += B.trivial.power(2).sum(axis=0)
     return cast(NDArray[np.float64], np.sqrt(var))
 
 
@@ -990,32 +1006,61 @@ def _reward_space_is_cheaper(
 
 
 class _RowSpaceDraw:
-    """Zero-mean joint draws from an ``n x n`` lower factor of the
-    predictive covariance -- the row-side counterpart of
-    :class:`~bayesianbandits._support_covariance.SupportDraw`."""
+    """Joint draws from ``L Lᵀ + M Mᵀ = X Λ⁻¹ Xᵀ`` -- the row-side
+    counterpart of :class:`~bayesianbandits._support_covariance.SupportDraw`.
 
-    __slots__ = ("_L",)
+    ``L`` is one ``(n, n)`` lower factor, or ``(n_blocks, k, k)`` of them
+    for blocked draws (joint within a block, independent across); ``M``
+    is the sparse map from one normal per never-observed feature to the
+    rows touching it, ``(n, 0)`` when there are none.
+    """
 
-    def __init__(self, L: NDArray[np.float64]) -> None:
-        self._L = L
+    __slots__ = ("L", "M")
+
+    def __init__(self, L: NDArray[np.float64], M: csr_array) -> None:
+        self.L = L
+        self.M = M
 
     def joint(
         self,
         size: int,
         rng: np.random.Generator,
         mean: Optional[NDArray[np.float64]] = None,
+        scale: Optional[NDArray[np.float64]] = None,
     ) -> NDArray[np.float64]:
-        """``size`` jointly-distributed draws, shape ``(size, n_rows)``.
+        """``size`` draws from ``N(mean, L Lᵀ + M Mᵀ)``, shape ``(size, n)``.
 
-        ``mean`` is accumulated inside the same ``dgemm`` rather than
-        added by the caller, which would cost a second ``(size, n_rows)``
-        array; omit it when the caller has to rescale the zero-mean draw
-        first, as the multivariate-t path does.
+        ``scale`` multiplies the zero-mean part per draw, ``(size,)`` or
+        ``(size, n_blocks)`` when blocked, for the NIG multivariate-t
+        mixing; it is folded into ``z`` and ``mean`` accumulated inside
+        the ``dgemm``, so neither costs a second ``(size, n)`` array.
         """
-        z = standard_normal_f(rng, size, self._L.shape[0])
-        if mean is None:
-            return cast(NDArray[np.float64], dgemm(1.0, z, self._L, trans_b=1))
-        return affine_lower_factor(mean, z, self._L)
+        L, M = self.L, self.M
+        if L.ndim == 2:
+            z = standard_normal_f(rng, size, L.shape[0])
+            if scale is not None:
+                z *= scale[:, np.newaxis]
+            if mean is None:
+                out = cast(NDArray[np.float64], dgemm(1.0, z, L, trans_b=1))
+            else:
+                out = affine_lower_factor(mean, z, L)
+        else:
+            n_blocks, k, _ = L.shape
+            z = rng.standard_normal((n_blocks, size, k))
+            if scale is not None:
+                z *= scale.T[:, :, np.newaxis]
+            out = _blocked_colorize(L, z)
+            if mean is not None:
+                out += mean
+        n_pairs = cast("tuple[int, int]", M.shape)[1]
+        if n_pairs:
+            # (n, size), the sparse product's natural orientation
+            e = np.asarray(M @ rng.standard_normal((n_pairs, size)), dtype=np.float64)
+            if scale is not None:
+                # per draw, or per (draw, block) spread over the block's rows
+                e *= scale if L.ndim == 2 else np.repeat(scale, L.shape[1], axis=1).T
+            out += e.T
+        return out
 
 
 def build_joint_reduction(
@@ -1053,52 +1098,52 @@ def build_joint_reduction(
     )
     if support_draw is not None:
         return support_draw
-    if row_ok:
-        # sparse X goes over sparse: the factor half-solves at its block
-        # and returns a compact result whose Gram is the same
-        rhs = X.T if issparse(X) else np.asarray(X, dtype=np.float64).T
-        B = np.asarray(factor.half_solve(rhs), dtype=np.float64).reshape(-1, n_rows)
-        return _RowSpaceDraw(lower_predictive_sqrt(B, n_rows))
-    return None
+    return _row_space_draw(factor, X) if row_ok else None
 
 
-def _predictive_cholesky_from_factor(
+def _trivial_map(trivial: csc_array, block_size: int) -> csr_array:
+    """The blocked ``M``: ``trivial`` is the ``(t, k)`` part of a
+    :class:`SparseHalfSolve` over ``k`` consecutive rows in blocks of
+    ``block_size``; the map is ``(k, n_pairs)``, one column per distinct
+    (block, feature) pair, so a feature two blocks share gets an
+    independent normal in each and ``M Mᵀ = trivialᵀ trivial``
+    block-diagonally."""
+    entries = trivial.tocoo()
+    t, k = cast("tuple[int, int]", trivial.shape)
+    key = (entries.col // block_size) * t + entries.row
+    pairs, inverse = np.unique(key, return_inverse=True)
+    return csr_array(
+        (entries.data, (entries.col, inverse.ravel())), shape=(k, pairs.size)
+    )
+
+
+def _row_space_draw(
     factor: PrecisionFactor,
-    coef: NDArray[np.float64],
     X: Union[NDArray[Any], csc_array],
     block_size: Optional[int] = None,
-) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-    """Predictive mean and lower-triangular square root(s) of :math:`X \\Lambda^{-1} X^T`.
+) -> _RowSpaceDraw:
+    """The two-part square root of :math:`X \\Lambda^{-1} X^T`.
 
     ``B = factor.half_solve(X.T)`` satisfies ``B.T @ B = X Λ⁻¹ Xᵀ``, so
     the ``R`` of its QR is an exact square root even for linearly
     dependent rows, where a Cholesky of the explicit covariance would
-    fail (see :func:`lower_predictive_sqrt`).
+    fail (see :func:`lower_predictive_sqrt`). For a sparse ``X`` only the
+    dense block of the half-solve goes through the QR; its never-observed
+    part is a diagonal covariance read through ``X`` and stays one, as
+    the sparse map ``M`` (see :class:`SparseHalfSolve`), so the scratch
+    is sized in ``factor.n_factored`` whatever the rows touch.
 
-    With ``block_size=k``, one ``(k, k)`` factor is returned per
-    consecutive group of ``k`` rows, shape ``(n_blocks, k, k)``: joint
-    within a group, nothing across groups. Blocked mode chunks the dense
-    half-solve scratch under ``_MARGINAL_SD_BLOCK_ELEMS``; full mode
-    half-solves a sparse ``X`` all at once. A sparse ``X`` goes over
-    sparse: the factor half-solves at the features it factors and
-    returns a compact ``(n_factored + t, rows)`` block with the same
-    Gram, so the scratch is sized in ``factor.n_factored``.
+    With ``block_size=k``, one ``(k, k)`` factor per consecutive group
+    of ``k`` rows, shape ``(n_blocks, k, k)``: joint within a group,
+    nothing across groups, and ``M`` block-diagonal to match. Blocked
+    mode chunks the dense half-solve scratch under
+    ``_MARGINAL_SD_BLOCK_ELEMS``; full mode half-solves ``X`` all at once.
     """
-
-    def half_solve_rows(rows: slice) -> NDArray[np.float64]:
-        # Dispatch on the actual type: sparse models accept dense X too
-        # (check_array's accept_sparse only *permits* sparse input)
-        X_rows = X_row_sliceable[rows]
-        rhs = X_rows.T if issparse(X_rows) else np.asarray(X_rows, dtype=np.float64).T
-        return np.asarray(factor.half_solve(rhs), dtype=np.float64)
-
-    mean = _predictive_mean(X, coef)
-    n = mean.shape[0]
-    X_row_sliceable: Any = X
-
+    n = cast("tuple[int, int]", X.shape)[0]
     if block_size is None:
-        B = half_solve_rows(slice(0, n)).reshape(-1, n)
-        return mean, lower_predictive_sqrt(B, n)
+        B = _half_solve_rows(factor, X)
+        # one normal per never-observed feature the rows touch: M = trivialᵀ
+        return _RowSpaceDraw(lower_predictive_sqrt(B.block, n), B.trivial.T)
 
     if block_size <= 0 or n % block_size:
         raise ValueError(
@@ -1112,21 +1157,25 @@ def _predictive_cholesky_from_factor(
     chunk_blocks = max(
         1, _MARGINAL_SD_BLOCK_ELEMS // max(1, factor.n_factored * block_size)
     )
+    X_row_sliceable: Any = X
     if issparse(X) and n_blocks > chunk_blocks:
         # Rows are CSC's minor axis, so slicing rows per chunk would scan
         # all of X's nnz each chunk; slice from a CSR copy when chunking
         X_row_sliceable = cast(csc_array, X).tocsr()
     L = np.empty((n_blocks, block_size, block_size))
+    maps: list[csr_array] = []
     for start in range(0, n_blocks, chunk_blocks):
         stop = min(start + chunk_blocks, n_blocks)
-        B = half_solve_rows(slice(start * block_size, stop * block_size))
-        B = B.reshape(-1, (stop - start) * block_size)
-        blocks = B.reshape(B.shape[0], stop - start, block_size).transpose(1, 0, 2)
+        rows = slice(start * block_size, stop * block_size)
+        B = _half_solve_rows(factor, X_row_sliceable[rows])
+        blocks = B.block.reshape(B.block.shape[0], stop - start, block_size)
         # Per-block dgeqrf rather than numpy's batched QR, which would
         # leave scipy's BLAS pool; see ``lower_predictive_sqrt``.
-        for offset, block in enumerate(blocks):
+        for offset, block in enumerate(blocks.transpose(1, 0, 2)):
             L[start + offset] = lower_predictive_sqrt(block, block_size)
-    return mean, L
+        # consecutive rows, pairs per chunk: the maps stack block-diagonally
+        maps.append(_trivial_map(B.trivial, block_size))
+    return _RowSpaceDraw(L, cast(csr_array, block_diag(maps, format="csr")))
 
 
 def _blocked_colorize(
@@ -1162,19 +1211,24 @@ class _RewardSpacePredictiveMixin:
 
     def _predictive_cholesky(
         self, X: Union[NDArray[Any], csc_array], block_size: Optional[int] = None
-    ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        """Predictive mean and lower square root(s) of
+    ) -> tuple[NDArray[np.float64], _RowSpaceDraw]:
+        """Predictive mean and :class:`_RowSpaceDraw` of
         :math:`X \\Lambda^{-1} X^T` for validated ``X``. Unscaled for the
         NIG subclass: ``sample_reward_space`` applies ``b/a`` itself."""
-        return _predictive_cholesky_from_factor(
-            self._precision_factor, self.coef_, X, block_size
+        return _predictive_mean(X, self.coef_), _row_space_draw(
+            self._precision_factor, X, block_size
         )
 
     def _validated_for_sampling(
         self, X: Union[NDArray[Any], csc_array]
     ) -> Union[NDArray[Any], csc_array]:
         """Shared ``sample``/``sample_reward_space`` preamble: validate
-        ``X`` and initialize the prior if the model is unfitted.
+        ``X``, initialize the prior if the model is unfitted, and check
+        the feature count against ``coef_``.
+
+        The width check is explicit: a sparse ``X`` reaches the
+        weight-space path through its support only, which would read a
+        too-narrow ``X`` as if its missing features were zero.
 
         Not copied: every consumer only reads ``X``, matching ``sample``.
         """
@@ -1185,6 +1239,12 @@ class _RewardSpacePredictiveMixin:
             check_is_fitted(self, "coef_")
         except NotFittedError:
             self._initialize_prior(X_pred)
+        if X_pred.shape[1] != self.coef_.shape[0]:
+            raise ValueError(
+                f"X has {X_pred.shape[1]} features, but "
+                f"{type(self).__name__} is expecting {self.coef_.shape[0]} "
+                "features as input."
+            )
         return X_pred
 
 
@@ -1612,21 +1672,14 @@ scipy.sparse.csc_array
         --------
         predict : Point predictions using the posterior mean.
         """
-        try:
-            check_is_fitted(self, "coef_")
-        except NotFittedError:
-            self._initialize_prior(X)
-
-        X_sample = check_array(
-            X, copy=False, ensure_2d=True, accept_sparse="csc" if self.sparse else False
-        )
+        X_sample = self._validated_for_sampling(X)
 
         # Exact joint draws through the cheapest reduction of Cov(Xw);
         # same distribution as weight space, different random stream.
         support_draw = build_joint_reduction(
             self._precision_factor,
             X_sample,
-            X_sample.shape[1],
+            self.coef_.shape[0],
             size,
             self.sparse,
         )
@@ -1741,14 +1794,8 @@ scipy.sparse.csc_array
         sample_marginal : iid per-row draws for per-row statistics.
         """
         X_sample = self._validated_for_sampling(X)
-        mean, L = self._predictive_cholesky(X_sample, block_size)
-        if block_size is None:
-            z = standard_normal_f(self.random_state_, size, mean.shape[0])
-            return affine_lower_factor(mean, z, L)
-        z = self.random_state_.standard_normal(
-            (mean.shape[0] // block_size, size, block_size)
-        )
-        return cast(NDArray[np.float64], mean + _blocked_colorize(L, z))
+        mean, draw = self._predictive_cholesky(X_sample, block_size)
+        return draw.joint(size, self.random_state_, mean)
 
     @_invalidate_cached_properties
     def decay(
@@ -2142,14 +2189,7 @@ scipy.sparse.csc_array
         --------
         predict : Point predictions using the posterior mean.
         """
-        try:
-            check_is_fitted(self, "coef_")
-        except NotFittedError:
-            self._initialize_prior(X)
-
-        X_sample = check_array(
-            X, copy=False, ensure_2d=True, accept_sparse="csc" if self.sparse else False
-        )
+        X_sample = self._validated_for_sampling(X)
         df = 2 * self.a_
 
         # ``shape_`` carries the (b/a) factor; the chi-square mixing is
@@ -2157,7 +2197,7 @@ scipy.sparse.csc_array
         support_draw = build_joint_reduction(
             self.shape_,
             X_sample,
-            X_sample.shape[1],
+            self.coef_.shape[0],
             size,
             self.sparse,
         )
@@ -2274,25 +2314,17 @@ scipy.sparse.csc_array
         sample_marginal : iid per-row draws for per-row statistics.
         """
         X_sample = self._validated_for_sampling(X)
-        mean, L = self._predictive_cholesky(X_sample, block_size)
+        mean, draw = self._predictive_cholesky(X_sample, block_size)
         df = 2.0 * self.a_
-        if block_size is None:
-            z = standard_normal_f(self.random_state_, size, mean.shape[0])
-            g = self.random_state_.chisquare(df, size=size)
-            # t draw: location + sqrt(df/g) · (shape-chol @ z), with the
-            # (b/a) shape scaling folded into the per-draw scale so the
-            # mean accumulates inside the same GEMM.
-            scale = np.sqrt((self.b_ / self.a_) * df / g)
-            z *= scale[:, np.newaxis]
-            return affine_lower_factor(mean, z, L)
-        n_blocks = mean.shape[0] // block_size
-        z = self.random_state_.standard_normal((n_blocks, size, block_size))
-        # one chi-square per (draw, block): joint t within a block,
+        # t draw: location + sqrt(df/g) · (shape-chol @ z), with the (b/a)
+        # shape scaling folded into the per-draw scale; one chi-square per
+        # draw, or per (draw, block) when blocked: joint t within a block,
         # independence across blocks
-        g = self.random_state_.chisquare(df, size=(size, n_blocks))
+        g = self.random_state_.chisquare(
+            df, size=size if block_size is None else (size, mean.shape[0] // block_size)
+        )
         scale = np.sqrt((self.b_ / self.a_) * df / g)
-        y = _blocked_colorize(L, z * scale.T[:, :, np.newaxis])
-        return cast(NDArray[np.float64], mean + y)
+        return draw.joint(size, self.random_state_, mean, scale)
 
     @_invalidate_cached_properties
     def decay(
@@ -2876,20 +2908,13 @@ scipy.sparse.csc_array
         --------
         predict : Point predictions using the posterior mean.
         """
-        try:
-            check_is_fitted(self, "coef_")
-        except NotFittedError:
-            self._initialize_prior(X)
-
-        X_sample = check_array(
-            X, copy=False, ensure_2d=True, accept_sparse="csc" if self.sparse else False
-        )
+        X_sample = self._validated_for_sampling(X)
 
         # The reduction draws eta; the inverse link is elementwise either way.
         support_draw = build_joint_reduction(
             self._precision_factor,
             X_sample,
-            X_sample.shape[1],
+            self.coef_.shape[0],
             size,
             self.sparse,
         )
@@ -2983,16 +3008,8 @@ scipy.sparse.csc_array
         sample_marginal : iid per-row draws for per-row statistics.
         """
         X_sample = self._validated_for_sampling(X)
-        mean, L = self._predictive_cholesky(X_sample, block_size)
-        if block_size is None:
-            z = standard_normal_f(self.random_state_, size, mean.shape[0])
-            eta = affine_lower_factor(mean, z, L)
-        else:
-            z = self.random_state_.standard_normal(
-                (mean.shape[0] // block_size, size, block_size)
-            )
-            eta = mean + _blocked_colorize(L, z)
-        return self._inverse_link(cast(NDArray[np.float64], eta))
+        mean, draw = self._predictive_cholesky(X_sample, block_size)
+        return self._inverse_link(draw.joint(size, self.random_state_, mean))
 
     @_invalidate_cached_properties
     def decay(

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -830,8 +830,29 @@ def _dense_rows_t(X_rows: Any) -> NDArray[np.float64]:
     return cast(NDArray[np.float64], np.asarray(X_rows.toarray(), dtype=np.float64).T)
 
 
+def _marginal_support_is_cheaper(n_u: int, n_rows: int, precision_nnz: int) -> bool:
+    """Is the column-side reduction cheaper than the half-solve path?
+
+    The half-solve path spends one half-solve per prediction row,
+    ``n_rows`` times the per-solve cost ``nnz``. The column side spends
+    ``|U|`` full solves, two triangles each, plus the ``|U|³/3``
+    Cholesky of ``S``; half that budget covers each, giving
+    ``4|U| <= n_rows`` and ``2|U|³ <= 3·n_rows·nnz``. ``S`` is also the
+    one dense array on this route that no block loop bounds, so it is
+    held to the same element budget as the scratch it replaces.
+
+    Only a sparse model reaches here (``check_array`` densifies ``X``
+    for a dense one), so ``nnz`` is never the zero placeholder.
+    """
+    return (
+        4 * n_u <= n_rows
+        and 2 * n_u**3 <= 3 * n_rows * precision_nnz
+        and n_u * n_u <= _MARGINAL_SD_BLOCK_ELEMS
+    )
+
+
 def _marginal_predictive_sd(
-    factor: PrecisionFactor, X: Union[NDArray[Any], csc_array]
+    factor: PrecisionFactor, X: Union[NDArray[Any], csc_array], precision_nnz: int
 ) -> NDArray[np.float64]:
     """Per-row predictive standard deviations :math:`\\sqrt{x_i^T \\Lambda^{-1} x_i}`.
 
@@ -843,9 +864,12 @@ def _marginal_predictive_sd(
     A sparse ``X`` is densified for the solve in row blocks, keeping the
     dense scratch bounded regardless of the number of prediction rows.
 
-    A sparse ``X`` touching fewer distinct columns than it has rows
-    goes through :mod:`bayesianbandits._support_covariance` instead: one
-    solve per distinct column rather than one per row, exactly.
+    A sparse ``X`` touching few enough distinct columns goes through
+    :mod:`bayesianbandits._support_covariance` instead: one solve per
+    distinct column rather than one per row, exactly. Solve counts
+    alone do not decide it here, since the block loop below keeps this
+    path's scratch bounded while the reduction's ``|U| x |U|``
+    covariance is not; see :func:`_marginal_support_is_cheaper`.
     """
     # Dispatch on the actual type of X: sparse models accept dense X too
     # (check_array's accept_sparse only *permits* sparse input)
@@ -855,7 +879,13 @@ def _marginal_predictive_sd(
         return cast(NDArray[np.float64], np.sqrt(np.einsum("ij,ij->j", B, B)))
     assert X.shape is not None  # for the type checker
     n_rows, n_features = X.shape
-    support_draw = _support_covariance.build(factor, X, n_features, budget=n_rows)
+    support_draw = _support_covariance.build(
+        factor,
+        X,
+        n_features,
+        budget=n_rows,
+        accept=lambda n_u: _marginal_support_is_cheaper(n_u, n_rows, precision_nnz),
+    )
     if support_draw is not None:
         return support_draw.sd()
     block = max(1, _MARGINAL_SD_BLOCK_ELEMS // max(1, n_features))
@@ -886,7 +916,7 @@ def _validated_marginal_mean_sd(
     except NotFittedError:
         est._initialize_prior(X_pred)
     mean = np.asarray(X_pred @ est.coef_, dtype=np.float64).ravel()
-    sd = _marginal_predictive_sd(est._precision_factor, X_pred)
+    sd = _marginal_predictive_sd(est._precision_factor, X_pred, est._precision_nnz)
     return mean, sd
 
 

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -30,6 +30,7 @@ from . import _support_covariance
 from ._blas_helpers import (
     affine_lower_factor,
     compute_eta_dense,
+    dense_matmul_bt,
     dense_matvec,
     lower_predictive_sqrt,
     standard_normal_f,
@@ -334,7 +335,7 @@ class DirichletClassifier(BaseEstimator, ClassifierMixin):
         except NotFittedError:
             self._initialize_prior()
 
-        X_pred = check_array(X, copy=True, ensure_2d=True)
+        X_pred = check_array(X, copy=False, ensure_2d=True)
 
         alphas = np.vstack(list(self.known_alphas_[x.item()] for x in X_pred))
         return alphas / alphas.sum(axis=1)[:, np.newaxis]
@@ -715,7 +716,7 @@ class GammaRegressor(BaseEstimator, RegressorMixin):
         except NotFittedError:
             self._initialize_prior()
 
-        X_pred = check_array(X, copy=True, ensure_2d=True)
+        X_pred = check_array(X, copy=False, ensure_2d=True)
 
         shape_params = np.vstack(list(self.coef_[x.item()] for x in X_pred))
         return shape_params[:, 0] / shape_params[:, 1]
@@ -876,6 +877,35 @@ def _validated_marginal_mean_sd(
     return mean, sd
 
 
+def _predictive_mean(
+    X: Union[NDArray[Any], csc_array], coef: NDArray[np.float64]
+) -> NDArray[np.float64]:
+    """``X @ coef`` as a 1-D array of predictive means.
+
+    Sparse products never enter a BLAS thread pool, so only the dense
+    case needs routing away from numpy (see
+    :func:`~bayesianbandits._blas_helpers.lower_predictive_sqrt`).
+    """
+    if issparse(X):
+        return np.asarray(X @ coef, dtype=np.float64).ravel()
+    return dense_matvec(X, coef)
+
+
+def _rows_from_weight_draws(
+    draws: NDArray[np.float64], X: Union[NDArray[Any], csc_array]
+) -> NDArray[np.float64]:
+    """``draws @ X.T``: weight-space draws mapped to prediction rows.
+
+    Dense ``X`` goes through ``dgemm`` rather than ``numpy``, which would
+    otherwise cross BLAS thread pools immediately after the triangular
+    solve that produced ``draws``.
+    """
+    draws2 = np.atleast_2d(draws)
+    if issparse(X):
+        return cast(NDArray[np.float64], draws2 @ X.T)
+    return dense_matmul_bt(draws2, cast(NDArray[Any], X))
+
+
 def _reward_space_is_cheaper(
     n: int, d: int, size: int, sparse: bool, precision_nnz: int
 ) -> bool:
@@ -907,10 +937,23 @@ class _RowSpaceDraw:
     def __init__(self, L: NDArray[np.float64]) -> None:
         self._L = L
 
-    def joint(self, size: int, rng: np.random.Generator) -> NDArray[np.float64]:
-        n_rows = self._L.shape[0]
-        z = standard_normal_f(rng, size, n_rows)
-        return cast(NDArray[np.float64], dgemm(1.0, z, self._L, trans_b=1))
+    def joint(
+        self,
+        size: int,
+        rng: np.random.Generator,
+        mean: Optional[NDArray[np.float64]] = None,
+    ) -> NDArray[np.float64]:
+        """``size`` jointly-distributed draws, shape ``(size, n_rows)``.
+
+        ``mean`` is accumulated inside the same ``dgemm`` rather than
+        added by the caller, which would cost a second ``(size, n_rows)``
+        array; omit it when the caller has to rescale the zero-mean draw
+        first, as the multivariate-t path does.
+        """
+        z = standard_normal_f(rng, size, self._L.shape[0])
+        if mean is None:
+            return cast(NDArray[np.float64], dgemm(1.0, z, self._L, trans_b=1))
+        return affine_lower_factor(mean, z, self._L)
 
 
 def build_joint_reduction(
@@ -988,12 +1031,7 @@ def _predictive_cholesky_from_factor(
             rhs = np.asarray(X_rows, dtype=np.float64).T
         return np.asarray(factor.half_solve(rhs), dtype=np.float64)
 
-    # Sparse products never enter a BLAS thread pool, so only the dense
-    # case needs routing away from numpy.
-    if issparse(X):
-        mean = np.asarray(X @ coef, dtype=np.float64).ravel()
-    else:
-        mean = dense_matvec(X, coef)
+    mean = _predictive_mean(X, coef)
     n = mean.shape[0]
     X_row_sliceable: Any = X
 
@@ -1079,9 +1117,12 @@ class _RewardSpacePredictiveMixin:
         self, X: Union[NDArray[Any], csc_array]
     ) -> Union[NDArray[Any], csc_array]:
         """Shared ``sample``/``sample_reward_space`` preamble: validate
-        ``X`` and initialize the prior if the model is unfitted."""
+        ``X`` and initialize the prior if the model is unfitted.
+
+        Not copied: every consumer only reads ``X``, matching ``sample``.
+        """
         X_pred = check_array(
-            X, copy=True, ensure_2d=True, accept_sparse="csc" if self.sparse else False
+            X, copy=False, ensure_2d=True, accept_sparse="csc" if self.sparse else False
         )
         try:
             check_is_fitted(self, "coef_")
@@ -1478,7 +1519,7 @@ scipy.sparse.csc_array
             self._initialize_prior(X)
 
         X_pred = check_array(
-            X, copy=True, ensure_2d=True, accept_sparse="csc" if self.sparse else False
+            X, copy=False, ensure_2d=True, accept_sparse="csc" if self.sparse else False
         )
 
         return X_pred @ self.coef_
@@ -1534,10 +1575,10 @@ scipy.sparse.csc_array
             self._precision_nnz,
         )
         if support_draw is not None:
-            mean = np.asarray(X_sample @ self.coef_, dtype=np.float64).ravel()
+            mean = _predictive_mean(X_sample, self.coef_)
             return cast(
                 NDArray[np.float64],
-                mean + support_draw.joint(size, self.random_state_),
+                support_draw.joint(size, self.random_state_, mean),
             )
 
         samples = np.atleast_2d(
@@ -1549,7 +1590,7 @@ scipy.sparse.csc_array
             )
         )
 
-        return samples @ X_sample.T  # type: ignore
+        return _rows_from_weight_draws(samples, X_sample)
 
     def sample_marginal(
         self, X: Union[NDArray[Any], csc_array], size: int = 1
@@ -2088,7 +2129,7 @@ scipy.sparse.csc_array
             self._precision_nnz,
         )
         if support_draw is not None:
-            mean = np.asarray(X_sample @ self.coef_, dtype=np.float64).ravel()
+            mean = _predictive_mean(X_sample, self.coef_)
             z = support_draw.joint(size, self.random_state_)
             x = self.random_state_.chisquare(df, size) / df
             return cast(
@@ -2110,7 +2151,7 @@ scipy.sparse.csc_array
         if self.n_features_ == 1:
             samples = np.expand_dims(samples, -1)
 
-        return np.atleast_2d(samples @ X_sample.T)  # type: ignore
+        return _rows_from_weight_draws(samples, X_sample)
 
     def sample_marginal(
         self, X: Union[NDArray[Any], csc_array], size: int = 1
@@ -2758,7 +2799,7 @@ scipy.sparse.csc_array
             self._initialize_prior(X)
 
         X_pred = check_array(
-            X, copy=True, ensure_2d=True, accept_sparse="csc" if self.sparse else False
+            X, copy=False, ensure_2d=True, accept_sparse="csc" if self.sparse else False
         )
 
         eta = X_pred @ self.coef_
@@ -2828,8 +2869,8 @@ scipy.sparse.csc_array
             self._precision_nnz,
         )
         if support_draw is not None:
-            mean = np.asarray(X_sample @ self.coef_, dtype=np.float64).ravel()
-            eta = mean + support_draw.joint(size, self.random_state_)
+            mean = _predictive_mean(X_sample, self.coef_)
+            eta = support_draw.joint(size, self.random_state_, mean)
             return self._inverse_link(cast(NDArray[np.float64], eta))
 
         param_samples = np.atleast_2d(
@@ -2841,8 +2882,7 @@ scipy.sparse.csc_array
             )
         )
 
-        # Vectorized: (size, n_features) @ (n_features, n_samples) -> (size, n_samples)
-        eta = param_samples @ X_sample.T
+        eta = _rows_from_weight_draws(param_samples, X_sample)
 
         return self._inverse_link(cast(NDArray[np.float64], eta))
 

--- a/src/bayesianbandits/_sparse_bayesian_linear_regression.py
+++ b/src/bayesianbandits/_sparse_bayesian_linear_regression.py
@@ -1,3 +1,4 @@
+import copy
 import os
 from dataclasses import dataclass
 from enum import Enum
@@ -6,6 +7,8 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    Optional,
+    TypeVar,
     Union,
     cast,
 )
@@ -16,6 +19,8 @@ from scipy.linalg import LinAlgError, cho_solve, solve_triangular  # type: ignor
 from scipy.linalg.blas import dtrsm  # type: ignore[attr-defined]
 from scipy.linalg.lapack import dtrtri  # type: ignore[attr-defined]
 from scipy.sparse import (  # type: ignore  # type: ignore
+    block_diag,
+    coo_array,
     csc_array,
     csc_matrix,
     csr_matrix,
@@ -24,7 +29,6 @@ from scipy.sparse import (  # type: ignore  # type: ignore
 )
 from scipy.sparse.linalg import (  # type: ignore
     splu,
-    spsolve,
     spsolve_triangular,
     use_solver,
 )
@@ -64,24 +68,342 @@ if TYPE_CHECKING:
     )  # type: ignore
 
 
+def takahashi_diagonal(L_csc: csc_array) -> NDArray[np.float64]:
+    """``diag((L Lᵀ)⁻¹)`` by Takahashi recursion (selected inversion).
+
+    Given a lower-triangular CSC ``L`` with ``L Lᵀ = A``, computes the
+    diagonal of ``A⁻¹`` exactly by backward recursion through ``L``'s
+    sparsity structure. Cost is ``O(Σⱼ nⱼ²)`` in the sub-diagonal counts
+    ``nⱼ``, the same order as the Cholesky that produced ``L``.
+
+    Delegates to a Cython implementation. Lives beside the factors
+    because it reads a Cholesky factor and nothing else; consumers want
+    :meth:`CholmodSparseFactor.trace_inv`, not the factor itself.
+
+    References
+    ----------
+    .. [1] Takahashi, K., Fagan, J., & Chin, M.-S. (1973). "Formation of
+       a sparse bus impedance matrix and its application to short circuit
+       study." 8th PICA Conference Proceedings.
+    """
+    from ._takahashi import takahashi_diagonal as _cy_impl
+
+    p = cast(tuple[int, int], L_csc.shape)[0]
+    if not L_csc.has_sorted_indices:
+        L_csc = L_csc.copy()
+        L_csc.sort_indices()
+    return cast(
+        NDArray[np.float64],
+        _cy_impl(
+            L_csc.data,
+            L_csc.indices.astype(np.int32),
+            L_csc.indptr.astype(np.int32),
+            p,
+        ),
+    )
+
+
+def trivial_columns(precision: csc_array) -> NDArray[np.intp]:
+    """Features whose posterior is an independent scalar: columns storing
+    a single positive diagonal entry that no other column references.
+
+    ``Λ = αI + Σ x_t x_tᵀ`` puts an off-diagonal entry between two
+    features only when some observation touched both, so a feature no
+    observation has touched holds nothing but its diagonal -- exactly,
+    not approximately -- and ``Λ`` is block diagonal between those
+    features and the rest. Their part of ``Λ⁻¹`` is ``1/Λ_jj``, no
+    factorization required.
+
+    The test reads the stored pattern, so it holds for any matrix, not
+    just ones built that way. Both sides are checked -- the column's own
+    length, and how many entries anywhere point at its row -- so a
+    coupling stored only in the other column (triangular storage) still
+    counts. A stored explicit zero counts as structure, which errs toward
+    factoring more, never less. A non-positive diagonal is left to the
+    backends, whose non-SPD behaviour this must not change.
+    """
+    indptr, indices = precision.indptr, precision.indices
+    n = cast("tuple[int, int]", precision.shape)[0]
+    single = np.flatnonzero(indptr[1:] - indptr[:-1] == 1)
+    if single.size == 0:
+        return single
+    first = indptr[single]
+    keep = (indices[first] == single) & (precision.data[first] > 0)
+    single = single[keep]
+    # every entry pointing at a candidate row must be its own diagonal
+    referenced = np.bincount(indices, minlength=n)[single]
+    return cast(NDArray[np.intp], single[referenced == 1])
+
+
+def _principal_block(precision: csc_array, observed: NDArray[np.intp]) -> csc_array:
+    """``Λ[observed, observed]`` for the ``observed`` complement of
+    :func:`trivial_columns`; those columns' entries all sit in observed
+    rows (a trivial row is referenced by nothing else), so this is a
+    column selection and an ``O(nnz)`` row relabel.
+
+    The relabel keeps the matrix's own index dtype: an ``intp`` table
+    would widen the block's indices to int64, and CHOLMOD then builds an
+    int64 factor whose *sparse* solve segfaults on an int32 right-hand
+    side (the dense solve is indifferent)."""
+    n = cast("tuple[int, int]", precision.shape)[0]
+    cols = cast(csc_array, precision[:, observed])
+    lut = np.empty(n, dtype=cols.indices.dtype)
+    lut[observed] = np.arange(observed.size, dtype=cols.indices.dtype)
+    return csc_array(
+        (cols.data, lut[cols.indices], cols.indptr),
+        shape=(observed.size, observed.size),
+    )
+
+
+def _partition(
+    precision: csc_array,
+) -> tuple[Union[NDArray[np.intp], slice], NDArray[np.intp], NDArray[np.float64]]:
+    """``(observed, trivial, trivial_diag)`` for a factor over ``precision``.
+
+    ``observed`` is a full slice when nothing is trivial, so indexing
+    the block's operands stays a view rather than an ``O(n)`` copy. An
+    all-trivial matrix is factored whole as well: the block backends
+    want at least one column, and it is the fresh-prior case, where the
+    diagonal factorization is cheap.
+    """
+    trivial = trivial_columns(precision)
+    n = cast("tuple[int, int]", precision.shape)[0]
+    if trivial.size in (0, n):
+        return slice(None), np.empty(0, dtype=np.intp), np.empty(0, dtype=np.float64)
+    keep = np.ones(n, dtype=bool)
+    keep[trivial] = False
+    observed = np.flatnonzero(keep)
+    diag = np.asarray(precision.data[precision.indptr[trivial]], dtype=np.float64)
+    return observed, trivial, diag
+
+
+def _column_scale(values: NDArray[np.float64], ndim: int) -> NDArray[np.float64]:
+    """``values`` shaped to scale the rows of a 1-D or 2-D operand."""
+    return values if ndim == 1 else values[:, np.newaxis]
+
+
+def _merge(
+    observed: Union[NDArray[np.intp], slice],
+    trivial: NDArray[np.intp],
+    block: NDArray[np.floating[Any]],
+    trivial_values: NDArray[np.floating[Any]],
+    shape: tuple[int, ...],
+) -> NDArray[np.float64]:
+    """A feature-ordered result from its block and trivial parts; the
+    block itself when nothing is trivial (no copy)."""
+    if trivial.size == 0:
+        return cast(NDArray[np.float64], block)
+    out = np.empty(shape, dtype=np.float64)
+    out[observed] = block
+    out[trivial] = trivial_values
+    return out
+
+
+class _SparseRhs:
+    """A sparse right-hand side split for the partitioned solve: its
+    observed rows densified for the block solver, its trivial entries
+    kept as triples.
+
+    Neither backend is handed a sparse operand. CHOLMOD's sparse solve
+    reads the operand's index arrays with the factor's own integer type,
+    and a mismatch (a CSC row-indexed in scipy comes back with int64
+    indices against an int32 factor) does not raise -- it returns the
+    wrong answer, silently, or segfaults. Densifying the block rows
+    sidesteps that entirely and lets the solve run as one BLAS-3 call.
+
+    Entries are classified through :func:`_locate` on the COO triples,
+    ``O(nnz log n)``, rather than by row-indexing the matrix, which
+    scipy does in ``O(n)`` per call however few entries there are.
+    """
+
+    __slots__ = ("block", "trivial_rank", "trivial_col", "trivial_val", "shape")
+
+    def __init__(
+        self,
+        b: Any,
+        observed: Union[NDArray[np.intp], slice],
+        trivial: NDArray[np.intp],
+    ) -> None:
+        c = coo_array(b)
+        c.sum_duplicates()
+        n, k = cast("tuple[int, int]", c.shape)
+        row = np.asarray(c.row, dtype=np.intp)
+        col = np.asarray(c.col, dtype=np.intp)
+        val = np.asarray(c.data, dtype=np.float64)
+        is_trivial, block_pos, rank = _locate(observed, trivial, row)
+        m = n - trivial.size
+        block = np.zeros((m, k), dtype=np.float64, order="F")
+        block[block_pos, col[~is_trivial]] = val[~is_trivial]
+        self.block = block
+        self.trivial_rank = rank
+        self.trivial_col = col[is_trivial]
+        self.trivial_val = val[is_trivial]
+        self.shape = (n, k)
+
+    def solution(
+        self,
+        observed: Union[NDArray[np.intp], slice],
+        trivial: NDArray[np.intp],
+        trivial_diag: NDArray[np.float64],
+        block: NDArray[np.float64],
+    ) -> csc_array:
+        """The solution as CSC over all features: the dense block solve
+        at the observed rows, plus each trivial entry over its diagonal.
+
+        Assembled straight into CSC -- every column holds the observed
+        rows, already sorted, so the block is one column-major ravel
+        with a tiled index -- never through a dense ``(n, k)``; the cost
+        is ``O(m k)``, not ``O(n k)``.
+        """
+        n, k = self.shape
+        m = block.shape[0]
+        idx_dtype = np.int32 if n < np.iinfo(np.int32).max else np.intp
+        rows = (
+            np.arange(n, dtype=idx_dtype) if isinstance(observed, slice) else observed
+        )
+        out = csc_array(
+            (
+                np.asfortranarray(block).ravel(order="F"),
+                np.tile(np.asarray(rows, dtype=idx_dtype), k),
+                np.arange(0, m * k + 1, m, dtype=idx_dtype),
+            ),
+            shape=self.shape,
+        )
+        if self.trivial_val.size == 0:
+            return out
+        scaled = csc_array(
+            (
+                self.trivial_val / trivial_diag[self.trivial_rank],
+                (trivial[self.trivial_rank], self.trivial_col),
+            ),
+            shape=self.shape,
+        )
+        return cast(csc_array, out + scaled)
+
+    def compact_trivial(self, trivial_diag: NDArray[np.float64]) -> NDArray[np.float64]:
+        """The trivial part of a half-solve, compact: one row per
+        *distinct* trivial feature the right-hand side touches, holding
+        ``value / sqrt(Λ_jj)`` at that entry's column, in ascending
+        feature order. Rows for trivial features it does not touch would
+        be zero and are omitted; see
+        :meth:`CholmodSparseFactor.half_solve`."""
+        _, k = self.shape
+        if self.trivial_val.size == 0:
+            return np.empty((0, k), dtype=np.float64)
+        distinct, inverse = np.unique(self.trivial_rank, return_inverse=True)
+        out = np.zeros((distinct.size, k), dtype=np.float64)
+        out[inverse, self.trivial_col] = self.trivial_val / np.sqrt(
+            trivial_diag[self.trivial_rank]
+        )
+        return out
+
+
+def _stack(
+    block: NDArray[np.floating[Any]], trivial_values: NDArray[np.floating[Any]]
+) -> NDArray[np.float64]:
+    """A factor-row-ordered result: block rows first, then the trivial
+    features in ascending order; the block itself when nothing is trivial."""
+    if trivial_values.shape[0] == 0:
+        return cast(NDArray[np.float64], block)
+    return cast(NDArray[np.float64], np.concatenate([block, trivial_values], axis=0))
+
+
+def _locate(
+    observed: Union[NDArray[np.intp], slice],
+    trivial: NDArray[np.intp],
+    features: NDArray[np.intp],
+) -> tuple[NDArray[np.bool_], NDArray[np.intp], NDArray[np.intp]]:
+    """Split ``features`` for :meth:`~CholmodSparseFactor.sample_at`:
+    a trivial mask, the block positions of the rest, and the ranks of the
+    trivial ones within the trivial set."""
+    if trivial.size == 0:
+        return np.zeros(features.size, dtype=bool), features, features[:0]
+    rank = np.searchsorted(trivial, features)
+    is_trivial = (rank < trivial.size) & (
+        trivial[np.minimum(rank, trivial.size - 1)] == features
+    )
+    block_pos = np.searchsorted(cast(NDArray[np.intp], observed), features[~is_trivial])
+    return is_trivial, block_pos, rank[is_trivial]
+
+
+def _normals(rng: np.random.Generator, size: int, n: int) -> NDArray[np.float64]:
+    """``(n, size)`` standard normals, drawn as ``(size, n)`` and
+    transposed: the stream is that of ``size`` weight vectors drawn in
+    turn, and the layout is column-major, which is what CHOLMOD's dense
+    format and ``dtrsm`` take without a copy."""
+    return cast(NDArray[np.float64], rng.standard_normal((size, n)).T)
+
+
+def _scatter_draws(
+    is_trivial: NDArray[np.bool_],
+    block: NDArray[np.floating[Any]],
+    rank: NDArray[np.intp],
+    trivial_diag: NDArray[np.float64],
+    size: int,
+    rng: np.random.Generator,
+) -> NDArray[np.float64]:
+    """Interleave the block's draws with fresh scalar draws for the
+    trivial features asked for: one normal per *distinct* trivial
+    feature, so a repeated feature repeats its value; the block's draws
+    alone when none was asked for."""
+    if not is_trivial.any():
+        return cast(NDArray[np.float64], block)
+    distinct, inverse = np.unique(rank, return_inverse=True)
+    scalars = (
+        _normals(rng, size, distinct.size)
+        / np.sqrt(trivial_diag[distinct])[:, np.newaxis]
+    )
+    out = np.empty((is_trivial.size, size), dtype=np.float64)
+    out[~is_trivial] = block
+    out[is_trivial] = scalars[inverse]
+    return out
+
+
+def _stacked_L(L_block: csc_array, trivial_diag: NDArray[np.float64]) -> csc_array:
+    """The factor's ``L`` over all features, block rows first: the block's
+    ``L`` and ``sqrt`` of the trivial diagonal, block diagonal."""
+    if trivial_diag.size == 0:
+        return L_block
+    return csc_array(block_diag([L_block, diags(np.sqrt(trivial_diag))], format="csc"))
+
+
 @dataclass
 class CholmodSparseFactor:
-    """Wraps a CHOLMOD factor for solving and sampling."""
+    """A CHOLMOD factor over the observed block of a precision matrix, and
+    the trivial diagonal beside it.
+
+    ``_precision`` is the whole matrix; ``_factor`` covers only the
+    ``_observed`` features (see :func:`trivial_columns`), and
+    ``_trivial_diag`` holds ``Λ_jj`` for the ``_trivial`` rest, whose
+    every operation is elementwise. Factor-row order, where a method's
+    contract is in terms of it, is the block's own rows followed by the
+    trivial features ascending.
+
+    ``_scale`` makes this a factor of ``_scale · Λ`` without refactoring:
+    ``decay`` multiplies the precision by a scalar, and the
+    Normal-Inverse-Gamma shape precision is ``(a/b) · Λ``. If
+    ``L Lᵀ = Λ`` then ``(√s L)(√s L)ᵀ = s Λ``, so every operation is the
+    unscaled one times a power of ``s``; see :func:`scale_factor`.
+    """
 
     _factor: Any  # sksparse.cholmod.Factor (C extension, no useful type)
     _precision: csc_array
+    _observed: Union[NDArray[np.intp], slice]
+    _trivial: NDArray[np.intp]
+    _trivial_diag: NDArray[np.float64]
+    _scale: float = 1.0
 
     @cached_property
     def _inv_perm(self) -> NDArray[np.intp]:
         """Inverse of CHOLMOD's fill-reducing permutation, for
-        :meth:`colorize`.
+        :meth:`sample_at`.
 
         Scattered in one O(n_features) pass rather than sorted: a
         permutation's inverse is where each entry points, which
         ``argsort`` recovers by comparison at O(n log n). Lazy on top of
         that, because the factor is rebuilt by every ``fit``/
-        ``partial_fit`` and neither colorizes -- but a Thompson pull does
-        colorize, so in a pull-and-update loop this is paid fresh every
+        ``partial_fit`` and neither samples -- but a Thompson pull does,
+        so in a pull-and-update loop this is paid fresh every
         round and never amortizes.
         """
         perm = self._factor.perm
@@ -89,55 +411,178 @@ class CholmodSparseFactor:
         inv[perm] = np.arange(perm.size, dtype=perm.dtype)
         return cast(NDArray[np.intp], inv)
 
-    def solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
-        return self._factor.solve(b)
+    @property
+    def solve_cost(self) -> int:
+        """Cost of one solve against this factor, in stored entries.
 
-    def colorize(self, z: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
-        """Solve L^T x = z, undo permutation."""
-        return self._factor.solve(z, system="Lt")[self._inv_perm]
+        The routing gates weigh solve counts against the other work each
+        sampling route does, so they need a per-solve price. It belongs
+        to the factor rather than the estimator's precision matrix: the
+        two agree today, but only the factor knows what it actually
+        solves against -- the block, not the trivial diagonal.
+        """
+        return self._precision.nnz - self._trivial.size
+
+    @property
+    def n_factored(self) -> int:
+        """Features the factor actually factors: the observed block, not
+        the trivial diagonal beside it. It is the row count of the
+        factor's dense operands, and so the unit in which callers should
+        size scratch and chunk work -- ``n_features`` overstates both by
+        the trivial count."""
+        return cast("tuple[int, int]", self._precision.shape)[0] - self._trivial.size
+
+    def solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
+        """Solve ``Λ x = b``. A sparse ``b`` comes back sparse (the RVGA
+        Gram matrix and the support covariance both solve against sparse
+        right-hand sides); see :class:`_SparseRhs` for why the block
+        rows are densified first."""
+        if issparse(b):
+            rhs = _SparseRhs(b, self._observed, self._trivial)
+            block = np.asarray(self._factor.solve(rhs.block), dtype=np.float64)
+            out = rhs.solution(self._observed, self._trivial, self._trivial_diag, block)
+            return cast(NDArray[np.float64], out / self._scale)
+        block = np.asarray(self._factor.solve(b[self._observed]), dtype=np.float64)
+        rest = b[self._trivial] / _column_scale(self._trivial_diag, b.ndim)
+        out = _merge(self._observed, self._trivial, block, rest, b.shape)
+        return cast(NDArray[np.float64], out / self._scale)
+
+    def sample_at(
+        self,
+        features: Optional[NDArray[np.intp]],
+        size: int,
+        rng: np.random.Generator,
+    ) -> NDArray[np.float64]:
+        """Zero-mean draws ``w ~ N(0, Λ⁻¹)`` at ``features``, shape
+        ``(|features|, size)``; every feature when ``features`` is None.
+
+        The factor draws its own normals, so it draws only what it
+        needs: one per block feature, plus one per *distinct* trivial
+        feature asked for -- never one per never-observed feature it was
+        not asked about. A repeated feature gets the same draw, and the
+        caller reads the result through the design matrix (``X_U @ G``),
+        so two rows touching one feature share its value: the joint law
+        of ``X w``, not an independent draw per cell.
+
+        Block draws are ``L⁻ᵀ z`` in CHOLMOD's row order, un-permuted on
+        the way out; a trivial feature's draw is ``z / sqrt(Λ_jj)``.
+        """
+        m = cast("tuple[int, int]", self._precision.shape)[0] - self._trivial.size
+        root = np.sqrt(self._scale)
+        if features is None:
+            Z = _normals(rng, size, m + self._trivial.size)
+            block = self._factor.solve(Z[:m], system="Lt")[self._inv_perm]
+            rest = Z[m:] / np.sqrt(self._trivial_diag)[:, np.newaxis]
+            return _merge(self._observed, self._trivial, block, rest, Z.shape) / root
+        is_trivial, block_pos, rank = _locate(self._observed, self._trivial, features)
+        block = self._factor.solve(_normals(rng, size, m), system="Lt")[
+            self._inv_perm[block_pos]
+        ]
+        return (
+            _scatter_draws(is_trivial, block, rank, self._trivial_diag, size, rng)
+            / root
+        )
 
     def half_solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
-        """Apply the transpose of the ``colorize`` operator: L^{-1} P b.
+        """Apply the transpose of the ``sample_at`` operator: L^{-1} P b.
 
-        If ``M`` is the colorize operator (``M M^T = Λ^{-1}``), this
+        If ``M`` is the operator ``sample_at`` applies to its normals
+        (``M M^T = Λ^{-1}``), this
         returns ``M^T b``, so ``half_solve(X.T).T @ half_solve(X.T)``
         equals ``X Λ^{-1} X^T`` -- a half-solve per column against the
-        cached factor, without ever forming ``Λ^{-1}``.
+        cached factor, without ever forming ``Λ^{-1}``. The result is in
+        factor-row order.
+
+        A sparse ``b`` comes back *compact*: the block rows, then one row
+        per distinct trivial feature ``b`` touches; the trivial rows it
+        does not touch would be zero and are omitted (see
+        :class:`_SparseRhs`). Every caller reads a half-solve only
+        through the Gram ``Bᵀ B``, which dropping zero rows leaves
+        unchanged, and it is what keeps the marginal and reward-space
+        paths at ``O(n_factored)`` per column rather than ``O(n)``.
         """
-        return self._factor.solve(b[self._factor.perm], system="L")
+        root = np.sqrt(self._scale)
+        if issparse(b):
+            rhs = _SparseRhs(b, self._observed, self._trivial)
+            block = self._factor.solve(rhs.block[self._factor.perm], system="L")
+            return _stack(block, rhs.compact_trivial(self._trivial_diag)) / root
+        block = self._factor.solve(b[self._observed][self._factor.perm], system="L")
+        rest = b[self._trivial] / _column_scale(np.sqrt(self._trivial_diag), b.ndim)
+        return _stack(block, rest) / root
 
     def logdet(self) -> float:
-        """Log-determinant of the factored matrix via CHOLMOD."""
-        return float(self._factor.logdet())
+        """Log-determinant: the block's via CHOLMOD, plus the trivial
+        diagonal's, plus ``n log s`` for the scale."""
+        n = cast("tuple[int, int]", self._precision.shape)[0]
+        return float(
+            self._factor.logdet()
+            + np.sum(np.log(self._trivial_diag))
+            + n * np.log(self._scale)
+        )
+
+    def trace_inv(self) -> float:
+        """``tr(Λ⁻¹)``, exactly: Takahashi recursion over the block's
+        ``L`` plus ``Σ 1/Λ_jj`` over the trivial features.
+
+        The trace is permutation-invariant, so the fill-reducing
+        permutation needs no undoing. Computed here rather than by
+        handing ``L`` to a caller: only the factor knows what it
+        factored.
+        """
+        block = np.sum(takahashi_diagonal(csc_array(self._factor.L)))
+        return float(block + np.sum(1.0 / self._trivial_diag)) / self._scale
 
     def refactorize(self, precision: csc_array) -> "CholmodSparseFactor":
         """Numeric refactorization reusing the existing symbolic analysis.
 
         The fill-reducing permutation belongs to that symbolic analysis
         and so survives the refactorization, which is what lets
-        :attr:`_inv_perm` stay cached across this call.
+        :attr:`_inv_perm` stay cached across this call. Valid only while
+        the partition is the same; a feature that has since been observed
+        changes the block, and the factor is rebuilt from scratch.
+
+        The result is a factor of ``precision`` itself, so the scale is
+        reset. The numeric factorization is shared with every view
+        :func:`scale_factor` made of this factor, and they are invalid
+        after this call -- as they were when scaling was a wrapper.
         """
-        self._factor.factorize(csc_matrix(precision))
+        observed, trivial, diag = _partition(precision)
+        if not np.array_equal(trivial, self._trivial):
+            return create_sparse_factor(precision, SparseSolver.CHOLMOD)  # type: ignore[return-value]
+        block = (
+            precision
+            if isinstance(observed, slice)
+            else _principal_block(precision, observed)
+        )
+        self._factor.factorize(csc_matrix(block))
         self._precision = precision
+        self._trivial_diag = diag
+        self._scale = 1.0
         return self
 
     def get_L_csc(self) -> csc_array:
-        """Return the lower triangular Cholesky factor as CSC.
-
-        The factor satisfies PΛP' = LL' where P is the fill-reducing
-        permutation.  The returned L includes the permutation implicitly
-        (rows/cols are in permuted order).
+        """Return the lower triangular Cholesky factor as CSC, in
+        factor-row order: the block's ``L`` (its rows in CHOLMOD's
+        fill-reducing permutation) and then ``sqrt`` of the trivial
+        diagonal, so ``L Lᵀ`` is a symmetric permutation of ``s Λ``.
         """
-        return csc_array(self._factor.L)
+        L = _stacked_L(csc_array(self._factor.L), self._trivial_diag)
+        return L if self._scale == 1.0 else csc_array(L * np.sqrt(self._scale))
 
 
 @dataclass
 class SuperLUSparseFactor:
-    """Wraps SuperLU decomposition for solving and sampling."""
+    """A SuperLU decomposition over the observed block of a precision
+    matrix, and the trivial diagonal beside it; see
+    :class:`CholmodSparseFactor` for the layout."""
 
     _lu: Any  # scipy.sparse.linalg.SuperLU (C extension, no useful type)
     _inv_perm: NDArray[np.intp]
     _precision: csc_array
+    _observed: Union[NDArray[np.intp], slice]
+    _trivial: NDArray[np.intp]
+    _trivial_diag: NDArray[np.float64]
+    _scale: float = 1.0
 
     @cached_property
     def _L(self) -> csr_matrix:
@@ -152,9 +597,9 @@ class SuperLUSparseFactor:
 
     @cached_property
     def _Lt_csc(self) -> csc_array:
-        """``Lᵀ`` in CSC, for :meth:`colorize`. Lazy, like :attr:`_perm`:
+        """``Lᵀ`` in CSC, for :meth:`sample_at`. Lazy, like :attr:`_perm`:
         the transpose is O(nnz) and ``fit``/``partial_fit`` never
-        colorize."""
+        sample."""
         return csc_array(self._L.T)
 
     @cached_property
@@ -165,27 +610,58 @@ class SuperLUSparseFactor:
         perm[self._inv_perm] = np.arange(self._inv_perm.size)
         return perm
 
+    @property
+    def solve_cost(self) -> int:
+        """See :attr:`CholmodSparseFactor.solve_cost`."""
+        return self._precision.nnz - self._trivial.size
+
+    @property
+    def n_factored(self) -> int:
+        """See :attr:`CholmodSparseFactor.n_factored`."""
+        return cast("tuple[int, int]", self._precision.shape)[0] - self._trivial.size
+
     def solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
-        """Solve ``Λ x = b``: through the retained SuperLU object for
-        dense ``b``, through ``spsolve`` (which refactorizes) for sparse.
+        """Solve ``Λ x = b`` through the retained SuperLU object. A sparse
+        ``b`` comes back sparse; see :class:`_SparseRhs`.
 
         ``SuperLU.solve`` runs both triangular sweeps and both
         permutations inside one ``gstrs`` call, where going through
-        :meth:`half_solve` and :meth:`colorize` pays two trips out to
+        :meth:`half_solve` and :meth:`sample_at` pays two trips out to
         ``spsolve_triangular`` -- each of which rebuilds its own solver
         state -- to reach the same answer.
         """
         if issparse(b):
-            return cast(NDArray[np.float64], spsolve(self._precision, b))
-        return cast(
-            NDArray[np.float64], self._lu.solve(np.asarray(b, dtype=np.float64))
-        )
+            rhs = _SparseRhs(b, self._observed, self._trivial)
+            block = np.asarray(self._lu.solve(rhs.block), dtype=np.float64)
+            out = rhs.solution(self._observed, self._trivial, self._trivial_diag, block)
+            return cast(NDArray[np.float64], out / self._scale)
+        b = np.asarray(b, dtype=np.float64)
+        block = np.asarray(self._lu.solve(b[self._observed]), dtype=np.float64)
+        rest = b[self._trivial] / _column_scale(self._trivial_diag, b.ndim)
+        out = _merge(self._observed, self._trivial, block, rest, b.shape)
+        return cast(NDArray[np.float64], out / self._scale)
 
-    def colorize(self, z: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
-        """Solve L^T x = z, undo permutation."""
-        return cast(
-            NDArray[np.float64],
-            spsolve_triangular(self._Lt_csc, z, lower=False)[self._inv_perm],
+    def sample_at(
+        self,
+        features: Optional[NDArray[np.intp]],
+        size: int,
+        rng: np.random.Generator,
+    ) -> NDArray[np.float64]:
+        """See :meth:`CholmodSparseFactor.sample_at`."""
+        m = cast("tuple[int, int]", self._precision.shape)[0] - self._trivial.size
+        root = np.sqrt(self._scale)
+        if features is None:
+            Z = _normals(rng, size, m + self._trivial.size)
+            block = spsolve_triangular(self._Lt_csc, Z[:m], lower=False)[self._inv_perm]
+            rest = Z[m:] / np.sqrt(self._trivial_diag)[:, np.newaxis]
+            return _merge(self._observed, self._trivial, block, rest, Z.shape) / root
+        is_trivial, block_pos, rank = _locate(self._observed, self._trivial, features)
+        block = spsolve_triangular(self._Lt_csc, _normals(rng, size, m), lower=False)[
+            self._inv_perm[block_pos]
+        ]
+        return (
+            _scatter_draws(is_trivial, block, rank, self._trivial_diag, size, rng)
+            / root
         )
 
     @cached_property
@@ -199,7 +675,7 @@ class SuperLUSparseFactor:
         return L_unit, invdiag
 
     def half_solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
-        """Apply the transpose of the ``colorize`` operator: L^{-1} P b.
+        """Apply the transpose of the ``sample_at`` operator: L^{-1} P b.
 
         Same contract as :meth:`CholmodSparseFactor.half_solve`, against
         the cached triangular factor (no refactorization, unlike ``solve``).
@@ -209,38 +685,52 @@ class SuperLUSparseFactor:
         overwriting both operands is safe).
         """
         L_unit, invdiag = self._half_solve_factor
+        if issparse(b):
+            rhs = _SparseRhs(b, self._observed, self._trivial)
+            operand, rest = rhs.block, rhs.compact_trivial(self._trivial_diag)
+        else:
+            operand = b[self._observed]
+            rest = b[self._trivial] / _column_scale(np.sqrt(self._trivial_diag), b.ndim)
         y = spsolve_triangular(
             L_unit,
-            b[self._perm],
+            operand[self._perm],
             lower=True,
             unit_diagonal=True,
             overwrite_A=True,
             overwrite_b=True,
         )
-        scale = invdiag if y.ndim == 1 else invdiag[:, None]
-        return cast(NDArray[np.float64], y * scale)
+        return _stack(y * _column_scale(invdiag, y.ndim), rest) / np.sqrt(self._scale)
 
     def logdet(self) -> float:
         """Log-determinant of the factored matrix.
 
-        ``U``'s diagonal holds the pivots ``D``, which ``_L`` carries as
-        ``sqrt(D)``: ``log|Λ| = 2 * sum(log|diag(_L)|) = sum(log|D|)``,
-        reading the pivots straight off ``U`` rather than building
-        ``_L``.
+        ``U``'s diagonal holds the block's pivots ``D``, which ``_L``
+        carries as ``sqrt(D)``: ``log|Λ_block| = 2 * sum(log|diag(_L)|)
+        = sum(log|D|)``, reading the pivots straight off ``U`` rather
+        than building ``_L``; plus the trivial diagonal's.
         """
-        return float(np.sum(np.log(np.abs(self._lu.U.diagonal()))))
+        n = cast("tuple[int, int]", self._precision.shape)[0]
+        block = np.sum(np.log(np.abs(self._lu.U.diagonal())))
+        return float(
+            block + np.sum(np.log(self._trivial_diag)) + n * np.log(self._scale)
+        )
+
+    def trace_inv(self) -> float:
+        """See :meth:`CholmodSparseFactor.trace_inv`."""
+        block = np.sum(takahashi_diagonal(csc_array(self._L)))
+        return float(block + np.sum(1.0 / self._trivial_diag)) / self._scale
 
     def refactorize(self, precision: csc_array) -> "SuperLUSparseFactor":
         """SuperLU has no symbolic reuse API; performs a full refactorization."""
         return _superlu_factor(precision)
 
     def get_L_csc(self) -> csc_array:
-        """Return the lower triangular factor as CSC.
-
-        The SuperLU factor already has D folded in: L = L_splu @ diag(√D).
-        Rows are in permuted order (matching _Pr).
-        """
-        return csc_array(self._L)
+        """Return the lower triangular factor as CSC, in factor-row
+        order: the block's ``L`` (``D`` folded in, rows in SuperLU's
+        permutation) and then ``sqrt`` of the trivial diagonal, times
+        ``sqrt`` of the scale."""
+        L = _stacked_L(csc_array(self._L), self._trivial_diag)
+        return L if self._scale == 1.0 else csc_array(L * np.sqrt(self._scale))
 
 
 def _superlu_factor(precision: csc_array) -> SuperLUSparseFactor:
@@ -250,8 +740,14 @@ def _superlu_factor(precision: csc_array) -> SuperLUSparseFactor:
     :meth:`SuperLUSparseFactor.solve` drives, and the symmetric ``L`` the
     sampling operators want is derived from it on demand.
     """
+    observed, trivial, diag = _partition(precision)
+    block = (
+        precision
+        if isinstance(observed, slice)
+        else _principal_block(precision, observed)
+    )
     splu_ = splu(
-        precision,
+        block,
         diag_pivot_thresh=0,
         permc_spec="MMD_AT_PLUS_A",
         options=dict(SymmetricMode=True),
@@ -259,57 +755,16 @@ def _superlu_factor(precision: csc_array) -> SuperLUSparseFactor:
     if (splu_.perm_r != splu_.perm_c).any():
         raise ValueError("Matrix must be symmetric")
     return SuperLUSparseFactor(
-        _lu=splu_, _inv_perm=splu_.perm_r.copy(), _precision=precision
+        _lu=splu_,
+        _inv_perm=splu_.perm_r.copy(),
+        _precision=precision,
+        _observed=observed,
+        _trivial=trivial,
+        _trivial_diag=diag,
     )
 
 
-ConcreteFactor = CholmodSparseFactor | SuperLUSparseFactor
-
-
-@dataclass
-class ScaledSparseFactor:
-    """A factor scaled by a scalar. Avoids refactorizing for scalar precision changes.
-
-    If L L^T = P, then (s*P) has factor (√s * L).
-    - solve(s*P, b) = (1/s) * solve(P, b)
-    - colorize(s*P, z) = (1/√s) * colorize(P, z)
-    - half_solve(s*P, b) = (1/√s) * half_solve(P, b)
-    """
-
-    _inner: ConcreteFactor
-    _scale: float
-    _precision: csc_array  # the inner's precision; only used for .shape
-
-    def solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
-        return cast(NDArray[np.float64], self._inner.solve(b) / self._scale)
-
-    def colorize(self, z: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
-        return cast(NDArray[np.float64], self._inner.colorize(z) / np.sqrt(self._scale))
-
-    def half_solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
-        return cast(
-            NDArray[np.float64], self._inner.half_solve(b) / np.sqrt(self._scale)
-        )
-
-    def logdet(self) -> float:
-        """Log-determinant: log|s*P| = p*log(s) + log|P|."""
-        p = cast(tuple[int, int], self._precision.shape)[0]
-        return float(p * np.log(self._scale) + self._inner.logdet())
-
-    def refactorize(self, precision: csc_array) -> ConcreteFactor:
-        """Unwrap and delegate to the inner factor."""
-        return self._inner.refactorize(precision)
-
-    def get_L_csc(self) -> csc_array:
-        """Return the scaled lower triangular factor as CSC.
-
-        If inner factor has LL' = P, then scaled factor has (√s·L)(√s·L)' = s·P.
-        """
-        L = self._inner.get_L_csc()
-        return csc_array(L * np.sqrt(self._scale))
-
-
-SparseFactor = CholmodSparseFactor | SuperLUSparseFactor | ScaledSparseFactor
+SparseFactor = CholmodSparseFactor | SuperLUSparseFactor
 
 
 @dataclass
@@ -325,6 +780,20 @@ class DenseFactor:
 
     _U: NDArray[np.float64]
     _n_features: int
+    _scale: float = 1.0
+
+    @property
+    def solve_cost(self) -> int:
+        """Zero: the gates price a dense solve off the feature count
+        instead, so they never read this. See
+        :attr:`CholmodSparseFactor.solve_cost`."""
+        return 0
+
+    @property
+    def n_factored(self) -> int:
+        """Every feature: a dense factor has nothing trivial to set aside.
+        See :attr:`CholmodSparseFactor.n_factored`."""
+        return self._n_features
 
     @cached_property
     def _U_inv(self) -> NDArray[np.float64]:
@@ -352,10 +821,20 @@ class DenseFactor:
         return cast(NDArray[np.float64], np.triu(U_inv))
 
     def solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
-        return cho_solve((self._U, False), b, check_finite=False)
+        out = cho_solve((self._U, False), b, check_finite=False)
+        return cast(NDArray[np.float64], out / self._scale)
 
-    def colorize(self, z: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
-        """Compute U^{-1} z, producing samples from N(0, Λ^{-1}).
+    def sample_at(
+        self,
+        features: Optional[NDArray[np.intp]],
+        size: int,
+        rng: np.random.Generator,
+    ) -> NDArray[np.float64]:
+        """Zero-mean draws ``U⁻¹ z ~ N(0, Λ⁻¹)`` at ``features``, shape
+        ``(|features|, size)``; every feature when ``features`` is None.
+        Same contract as :meth:`CholmodSparseFactor.sample_at`; a dense
+        factor has no trivial features to skip, so it always draws all
+        of them.
 
         Solves against ``U`` rather than multiplying by an explicit
         inverse.  The factor is rebuilt after every ``partial_fit``, so
@@ -366,170 +845,85 @@ class DenseFactor:
         keeps the draw inside scipy's BLAS pool (see
         :func:`~bayesianbandits._blas_helpers.lower_predictive_sqrt`).
         """
-        z2 = np.asfortranarray(z, dtype=np.float64)
-        vector = z2.ndim == 1
-        if vector:
-            z2 = z2.reshape(-1, 1)
-        out = dtrsm(1.0, self._U, z2, lower=0, side=0)
-        return cast(NDArray[np.float64], out[:, 0] if vector else out)
+        # the scale rides in dtrsm's alpha: alpha * U^{-1} Z in one call
+        alpha = 1.0 / np.sqrt(self._scale)
+        out = dtrsm(
+            alpha, self._U, _normals(rng, size, self._n_features), lower=0, side=0
+        )
+        return cast(NDArray[np.float64], out if features is None else out[features])
 
     def half_solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
-        """Solve U^T x = b, the transpose of the ``colorize`` operator.
+        """Solve U^T x = b, the transpose of the ``sample_at`` operator.
 
         Same contract as :meth:`CholmodSparseFactor.half_solve`; one
-        triangular solve, without building ``U^{-1}``.
+        triangular solve, without building ``U^{-1}``. A sparse ``b`` is
+        densified: a dense factor has no trivial rows to leave out.
         """
-        return cast(
-            NDArray[np.float64],
-            solve_triangular(self._U, b, trans=1, lower=False, check_finite=False),
-        )
+        rhs = cast(Any, b).toarray() if issparse(b) else b
+        out = solve_triangular(self._U, rhs, trans=1, lower=False, check_finite=False)
+        return cast(NDArray[np.float64], out / np.sqrt(self._scale))
 
     def logdet(self) -> float:
-        """log|Λ| = 2·sum(log(diag(U)))."""
-        return 2.0 * float(np.sum(np.log(np.diag(self._U))))
+        """log|sΛ| = 2·sum(log(diag(U))) + d·log s."""
+        return 2.0 * float(np.sum(np.log(np.diag(self._U)))) + self._n_features * float(
+            np.log(self._scale)
+        )
 
     def trace_inv(self) -> float:
-        """tr(Λ⁻¹) = ||U⁻¹||²_F."""
-        return float(np.sum(self._U_inv**2))
+        """tr((sΛ)⁻¹) = ||U⁻¹||²_F / s."""
+        return float(np.sum(self._U_inv**2)) / self._scale
 
 
 PrecisionFactor = SparseFactor | DenseFactor
 
 
-def scale_factor(factor: SparseFactor, scale: float) -> SparseFactor:
-    """Scale a sparse factor by a scalar, composing rather than nesting."""
+_Factor = TypeVar("_Factor", bound="PrecisionFactor")
+
+
+def scale_factor(factor: _Factor, scale: float) -> _Factor:
+    """A factor of ``scale`` times what ``factor`` factors, sharing its
+    factorization: ``decay`` and the Normal-Inverse-Gamma shape
+    precision both need a scalar multiple of an existing factor, and
+    neither should pay a refactorization for it.
+
+    A shallow copy with the scale composed in, so the caller's factor is
+    untouched and lazily built state (permutations, triangular views)
+    carries over. Views made this way share one numeric factorization;
+    :meth:`~CholmodSparseFactor.refactorize` on any of them invalidates
+    the others.
+    """
     if scale == 1.0:
         return factor
-    if isinstance(factor, ScaledSparseFactor):
-        return ScaledSparseFactor(
-            _inner=factor._inner,
-            _scale=factor._scale * scale,
-            _precision=factor._precision,
-        )
-    return ScaledSparseFactor(_inner=factor, _scale=scale, _precision=factor._precision)
+    scaled = copy.copy(factor)
+    scaled._scale = factor._scale * scale
+    return scaled
 
 
 def create_sparse_factor(
     precision: csc_array, solver: Union[SparseSolver, None] = None
 ) -> SparseFactor:
-    """Create a SparseFactor from a precision matrix."""
+    """Create a SparseFactor from a precision matrix.
+
+    Only the observed block is factored; the trivial features (see
+    :func:`trivial_columns`) are carried as a diagonal.
+    """
     if solver is None:
         solver = globals()["solver"]
     if not issparse(precision):
         raise TypeError("precision must be a sparse array")
     if solver == SparseSolver.CHOLMOD:
+        observed, trivial, diag = _partition(precision)
+        block = (
+            precision
+            if isinstance(observed, slice)
+            else _principal_block(precision, observed)
+        )
         return CholmodSparseFactor(
-            _factor=cholmod_cho_factor(csc_matrix(precision)),
+            _factor=cholmod_cho_factor(csc_matrix(block)),
             _precision=precision,
+            _observed=observed,
+            _trivial=trivial,
+            _trivial_diag=diag,
         )
     else:
         return _superlu_factor(precision)
-
-
-def multivariate_normal_sample_from_precision(
-    mean: Union[csc_array, NDArray[np.float64], None],
-    factor: PrecisionFactor,
-    size: int = 1,
-    random_state: Union[int, None, np.random.Generator] = None,
-) -> NDArray[np.float64]:
-    """
-    Sample from a multivariate normal distribution parameterized by a
-    factored precision matrix.
-
-    Works with both dense (``DenseFactor``) and sparse
-    (``CholmodSparseFactor``, ``SuperLUSparseFactor``,
-    ``ScaledSparseFactor``) precision factors via the common
-    ``colorize`` interface.
-
-    Parameters
-    ----------
-    mean : array_like or None
-        Mean of the distribution. If None, the zero vector is used.
-    factor : PrecisionFactor
-        Factored precision matrix (dense or sparse).
-    size : int, default=1
-        Number of samples to draw.
-    random_state : int, Generator, or None, default=None
-        Random state for reproducibility.
-
-    Returns
-    -------
-    out : ndarray of shape (size, n_features) or (n_features,) if size=1
-        The drawn samples.
-    """
-    rng = np.random.default_rng(random_state)
-    if isinstance(factor, DenseFactor):
-        n_features = factor._n_features
-    else:
-        n_features = cast(tuple[int, int], factor._precision.shape)[0]
-    _Z = rng.standard_normal((size, n_features))
-    samples = factor.colorize(_Z.T).T
-    if samples.shape[0] == 1:
-        samples = samples[0]
-    if mean is not None:
-        samples += mean
-    return samples
-
-
-# Backwards-compatible alias
-multivariate_normal_sample_from_sparse_precision = (
-    multivariate_normal_sample_from_precision
-)
-
-
-def multivariate_t_sample_from_precision(
-    loc: Union[csc_array, NDArray[np.float64], None],
-    factor: PrecisionFactor,
-    df: float = 1.0,
-    size: int = 1,
-    random_state: Union[int, None, np.random.Generator] = None,
-) -> NDArray[np.float64]:
-    """
-    Sample from a multivariate t distribution with mean loc, shape matrix
-    shape, and degrees of freedom df.
-
-    Parameters
-    ----------
-    loc : array_like
-        Mean of the distribution.
-    factor : PrecisionFactor
-        Factored precision (inverse shape) matrix.
-    df : int or float, optional
-        Degrees of freedom of the distribution. Default is 1.
-    size : int or tuple of ints, optional
-        Given a shape of, for example, (m,n,k), m*n*k samples are generated,
-        and packed in an m-by-n-by-k arrangement. Because each sample is
-        N-dimensional, the output shape is (m,n,k,N). If no shape is specified,
-        a single (N-D) sample is returned.
-    random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random.default_rng`.
-
-    Returns
-    -------
-    out : ndarray
-        The drawn samples, of shape size, if that was provided. If not, the
-        shape is (N,).
-
-
-    """
-    rng = np.random.default_rng(random_state)
-
-    x = rng.chisquare(df, size) / df
-
-    z = multivariate_normal_sample_from_precision(
-        mean=None,
-        factor=factor,
-        size=size,
-        random_state=random_state,
-    )
-    if loc is None:
-        loc = np.zeros_like(z)
-    samples = cast(NDArray[np.float64], loc + z / np.sqrt(x)[..., None])
-    from scipy.stats._multivariate import _squeeze_output  # type: ignore
-
-    samples = _squeeze_output(samples)
-
-    return samples

--- a/src/bayesianbandits/_sparse_bayesian_linear_regression.py
+++ b/src/bayesianbandits/_sparse_bayesian_linear_regression.py
@@ -12,7 +12,7 @@ from typing import (
 
 import numpy as np
 from numpy.typing import NDArray
-from scipy.linalg import cho_solve, solve_triangular  # type: ignore
+from scipy.linalg import LinAlgError, cho_solve, solve_triangular  # type: ignore
 from scipy.linalg.blas import dtrsm  # type: ignore[attr-defined]
 from scipy.linalg.lapack import dtrtri  # type: ignore[attr-defined]
 from scipy.sparse import (  # type: ignore  # type: ignore
@@ -335,8 +335,20 @@ class DenseFactor:
         triangle of its result, leaving whatever ``cho_factor`` left
         below the diagonal, hence the ``triu``.  ``_U`` itself is not
         overwritten.
+
+        A singular ``U`` is reported through ``info`` rather than
+        raised, and leaves the triangle untouched -- so the ``triu``
+        below would return ``U`` itself, and :meth:`trace_inv` a
+        plausible number rather than an error.  Raise instead, matching
+        the ``solve_triangular`` this replaced.
         """
-        U_inv, _info = dtrtri(self._U, lower=0)
+        U_inv, info = dtrtri(self._U, lower=0)
+        if info > 0:
+            raise LinAlgError(
+                f"singular precision factor: U[{info - 1}, {info - 1}] is zero"
+            )
+        if info < 0:
+            raise ValueError(f"dtrtri: illegal value in argument {-info}")
         return cast(NDArray[np.float64], np.triu(U_inv))
 
     def solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:

--- a/src/bayesianbandits/_sparse_bayesian_linear_regression.py
+++ b/src/bayesianbandits/_sparse_bayesian_linear_regression.py
@@ -1,5 +1,5 @@
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from functools import cached_property
 from typing import (
@@ -70,10 +70,24 @@ class CholmodSparseFactor:
 
     _factor: Any  # sksparse.cholmod.Factor (C extension, no useful type)
     _precision: csc_array
-    _inv_perm: NDArray[np.intp] = field(init=False, repr=False)
 
-    def __post_init__(self) -> None:
-        self._inv_perm = np.argsort(self._factor.perm)
+    @cached_property
+    def _inv_perm(self) -> NDArray[np.intp]:
+        """Inverse of CHOLMOD's fill-reducing permutation, for
+        :meth:`colorize`.
+
+        Scattered in one O(n_features) pass rather than sorted: a
+        permutation's inverse is where each entry points, which
+        ``argsort`` recovers by comparison at O(n log n). Lazy on top of
+        that, because the factor is rebuilt by every ``fit``/
+        ``partial_fit`` and neither colorizes -- but a Thompson pull does
+        colorize, so in a pull-and-update loop this is paid fresh every
+        round and never amortizes.
+        """
+        perm = self._factor.perm
+        inv = np.empty_like(perm)
+        inv[perm] = np.arange(perm.size, dtype=perm.dtype)
+        return cast(NDArray[np.intp], inv)
 
     def solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
         return self._factor.solve(b)
@@ -97,7 +111,12 @@ class CholmodSparseFactor:
         return float(self._factor.logdet())
 
     def refactorize(self, precision: csc_array) -> "CholmodSparseFactor":
-        """Numeric refactorization reusing the existing symbolic analysis."""
+        """Numeric refactorization reusing the existing symbolic analysis.
+
+        The fill-reducing permutation belongs to that symbolic analysis
+        and so survives the refactorization, which is what lets
+        :attr:`_inv_perm` stay cached across this call.
+        """
         self._factor.factorize(csc_matrix(precision))
         self._precision = precision
         return self
@@ -116,13 +135,27 @@ class CholmodSparseFactor:
 class SuperLUSparseFactor:
     """Wraps SuperLU decomposition for solving and sampling."""
 
-    _L: csr_matrix
+    _lu: Any  # scipy.sparse.linalg.SuperLU (C extension, no useful type)
     _inv_perm: NDArray[np.intp]
     _precision: csc_array
-    _Lt_csc: csc_array = field(init=False, repr=False)
 
-    def __post_init__(self) -> None:
-        self._Lt_csc = csc_array(self._L.T)
+    @cached_property
+    def _L(self) -> csr_matrix:
+        """Lower triangular factor with ``D`` folded in, ``L Lᵀ = P Λ Pᵀ``.
+
+        SuperLU's own ``L`` is unit-diagonal, with the pivots on ``U``'s
+        diagonal; folding ``sqrt(D)`` in gives the symmetric factor the
+        sampling operators need. Lazy, like everything else here that
+        only sampling reaches -- ``fit``/``partial_fit`` solve through
+        :attr:`_lu` and never build it."""
+        return cast(csr_matrix, self._lu.L @ diags(np.sqrt(self._lu.U.diagonal())))
+
+    @cached_property
+    def _Lt_csc(self) -> csc_array:
+        """``Lᵀ`` in CSC, for :meth:`colorize`. Lazy, like :attr:`_perm`:
+        the transpose is O(nnz) and ``fit``/``partial_fit`` never
+        colorize."""
+        return csc_array(self._L.T)
 
     @cached_property
     def _perm(self) -> NDArray[np.intp]:
@@ -133,11 +166,20 @@ class SuperLUSparseFactor:
         return perm
 
     def solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
-        """Solve ``Λ x = b``: through the cached triangular factor for
-        dense ``b``, through ``spsolve`` (which refactorizes) for sparse."""
+        """Solve ``Λ x = b``: through the retained SuperLU object for
+        dense ``b``, through ``spsolve`` (which refactorizes) for sparse.
+
+        ``SuperLU.solve`` runs both triangular sweeps and both
+        permutations inside one ``gstrs`` call, where going through
+        :meth:`half_solve` and :meth:`colorize` pays two trips out to
+        ``spsolve_triangular`` -- each of which rebuilds its own solver
+        state -- to reach the same answer.
+        """
         if issparse(b):
             return cast(NDArray[np.float64], spsolve(self._precision, b))
-        return self.colorize(self.half_solve(b))
+        return cast(
+            NDArray[np.float64], self._lu.solve(np.asarray(b, dtype=np.float64))
+        )
 
     def colorize(self, z: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
         """Solve L^T x = z, undo permutation."""
@@ -181,25 +223,16 @@ class SuperLUSparseFactor:
     def logdet(self) -> float:
         """Log-determinant of the factored matrix.
 
-        L already has D folded in (L = L_splu @ diag(sqrt(D))), so
-        |P| = |L|^2  =>  log|P| = 2 * sum(log|diag(L)|).
+        ``U``'s diagonal holds the pivots ``D``, which ``_L`` carries as
+        ``sqrt(D)``: ``log|Λ| = 2 * sum(log|diag(_L)|) = sum(log|D|)``,
+        reading the pivots straight off ``U`` rather than building
+        ``_L``.
         """
-        return float(2.0 * np.sum(np.log(np.abs(self._L.diagonal()))))
+        return float(np.sum(np.log(np.abs(self._lu.U.diagonal()))))
 
     def refactorize(self, precision: csc_array) -> "SuperLUSparseFactor":
         """SuperLU has no symbolic reuse API; performs a full refactorization."""
-        splu_ = splu(
-            precision,
-            diag_pivot_thresh=0,
-            permc_spec="MMD_AT_PLUS_A",
-            options=dict(SymmetricMode=True),
-        )
-        if (splu_.perm_r != splu_.perm_c).any():
-            raise ValueError("Matrix must be symmetric")
-        L = splu_.L.dot(diags(np.sqrt(splu_.U.diagonal())))
-        return SuperLUSparseFactor(
-            _L=L, _inv_perm=splu_.perm_r.copy(), _precision=precision
-        )
+        return _superlu_factor(precision)
 
     def get_L_csc(self) -> csc_array:
         """Return the lower triangular factor as CSC.
@@ -208,6 +241,26 @@ class SuperLUSparseFactor:
         Rows are in permuted order (matching _Pr).
         """
         return csc_array(self._L)
+
+
+def _superlu_factor(precision: csc_array) -> SuperLUSparseFactor:
+    """Factor ``precision`` with SuperLU, retaining the decomposition.
+
+    The ``SuperLU`` object itself is kept, not just its ``L``: it is what
+    :meth:`SuperLUSparseFactor.solve` drives, and the symmetric ``L`` the
+    sampling operators want is derived from it on demand.
+    """
+    splu_ = splu(
+        precision,
+        diag_pivot_thresh=0,
+        permc_spec="MMD_AT_PLUS_A",
+        options=dict(SymmetricMode=True),
+    )
+    if (splu_.perm_r != splu_.perm_c).any():
+        raise ValueError("Matrix must be symmetric")
+    return SuperLUSparseFactor(
+        _lu=splu_, _inv_perm=splu_.perm_r.copy(), _precision=precision
+    )
 
 
 ConcreteFactor = CholmodSparseFactor | SuperLUSparseFactor
@@ -358,18 +411,7 @@ def create_sparse_factor(
             _precision=precision,
         )
     else:
-        splu_ = splu(
-            precision,
-            diag_pivot_thresh=0,
-            permc_spec="MMD_AT_PLUS_A",
-            options=dict(SymmetricMode=True),
-        )
-        if (splu_.perm_r != splu_.perm_c).any():
-            raise ValueError("Matrix must be symmetric")
-        L = splu_.L.dot(diags(np.sqrt(splu_.U.diagonal())))
-        return SuperLUSparseFactor(
-            _L=L, _inv_perm=splu_.perm_r.copy(), _precision=precision
-        )
+        return _superlu_factor(precision)
 
 
 def multivariate_normal_sample_from_precision(

--- a/src/bayesianbandits/_sparse_bayesian_linear_regression.py
+++ b/src/bayesianbandits/_sparse_bayesian_linear_regression.py
@@ -7,6 +7,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    NamedTuple,
     Optional,
     TypeVar,
     Union,
@@ -199,6 +200,24 @@ def _merge(
     return out
 
 
+class SparseHalfSolve(NamedTuple):
+    """A half-solve against a sparse right-hand side, in two parts whose
+    Gram add: ``Bᵀ B = blockᵀ block + trivialᵀ trivial``.
+
+    ``block`` is the dense ``(n_factored, k)`` half-solve at the features
+    the factor factors; ``trivial`` is sparse ``(t, k)``, one row per
+    distinct never-observed feature the right-hand side touches
+    (ascending), holding ``value / sqrt(Λ_jj)`` at that entry's column.
+    ``t`` is bounded by the right-hand side's nonzeros, not by anything
+    the factor knows, so it is never densified: callers read a half-solve
+    through its Gram or draw with it (``blockᵀ z₁ + trivialᵀ z₂``), and
+    both split across the parts.
+    """
+
+    block: NDArray[np.float64]
+    trivial: csc_array
+
+
 class _SparseRhs:
     """A sparse right-hand side split for the partitioned solve: its
     observed rows densified for the block solver, its trivial entries
@@ -280,22 +299,21 @@ class _SparseRhs:
         )
         return cast(csc_array, out + scaled)
 
-    def compact_trivial(self, trivial_diag: NDArray[np.float64]) -> NDArray[np.float64]:
-        """The trivial part of a half-solve, compact: one row per
-        *distinct* trivial feature the right-hand side touches, holding
-        ``value / sqrt(Λ_jj)`` at that entry's column, in ascending
-        feature order. Rows for trivial features it does not touch would
-        be zero and are omitted; see
-        :meth:`CholmodSparseFactor.half_solve`."""
+    def compact_trivial(
+        self, trivial_diag: NDArray[np.float64], scale: float = 1.0
+    ) -> csc_array:
+        """The trivial part of a half-solve, the sparse ``(t, k)`` of
+        :class:`SparseHalfSolve`: one row per *distinct* trivial feature
+        the right-hand side touches, ascending, holding
+        ``value / sqrt(scale · Λ_jj)`` at that entry's column."""
         _, k = self.shape
         if self.trivial_val.size == 0:
-            return np.empty((0, k), dtype=np.float64)
+            return csc_array((0, k), dtype=np.float64)
         distinct, inverse = np.unique(self.trivial_rank, return_inverse=True)
-        out = np.zeros((distinct.size, k), dtype=np.float64)
-        out[inverse, self.trivial_col] = self.trivial_val / np.sqrt(
-            trivial_diag[self.trivial_rank]
+        values = self.trivial_val / np.sqrt(scale * trivial_diag[self.trivial_rank])
+        return csc_array(
+            (values, (inverse.ravel(), self.trivial_col)), shape=(distinct.size, k)
         )
-        return out
 
 
 def _stack(
@@ -483,29 +501,29 @@ class CholmodSparseFactor:
             / root
         )
 
-    def half_solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
+    def half_solve(
+        self, b: NDArray[np.floating[Any]]
+    ) -> Union[NDArray[np.float64], SparseHalfSolve]:
         """Apply the transpose of the ``sample_at`` operator: L^{-1} P b.
 
         If ``M`` is the operator ``sample_at`` applies to its normals
         (``M M^T = Λ^{-1}``), this
         returns ``M^T b``, so ``half_solve(X.T).T @ half_solve(X.T)``
         equals ``X Λ^{-1} X^T`` -- a half-solve per column against the
-        cached factor, without ever forming ``Λ^{-1}``. The result is in
-        factor-row order.
-
-        A sparse ``b`` comes back *compact*: the block rows, then one row
-        per distinct trivial feature ``b`` touches; the trivial rows it
-        does not touch would be zero and are omitted (see
-        :class:`_SparseRhs`). Every caller reads a half-solve only
-        through the Gram ``Bᵀ B``, which dropping zero rows leaves
-        unchanged, and it is what keeps the marginal and reward-space
-        paths at ``O(n_factored)`` per column rather than ``O(n)``.
+        cached factor, without ever forming ``Λ^{-1}``. A dense ``b``
+        comes back dense in factor-row order (block rows, then the
+        trivial features ascending); a sparse ``b`` comes back as a
+        :class:`SparseHalfSolve`, its trivial part never densified, which
+        keeps the marginal and reward-space paths at ``O(n_factored)``
+        per column plus ``O(nnz)`` whatever ``b`` touches.
         """
         root = np.sqrt(self._scale)
         if issparse(b):
             rhs = _SparseRhs(b, self._observed, self._trivial)
             block = self._factor.solve(rhs.block[self._factor.perm], system="L")
-            return _stack(block, rhs.compact_trivial(self._trivial_diag)) / root
+            return SparseHalfSolve(
+                block / root, rhs.compact_trivial(self._trivial_diag, self._scale)
+            )
         block = self._factor.solve(b[self._observed][self._factor.perm], system="L")
         rest = b[self._trivial] / _column_scale(np.sqrt(self._trivial_diag), b.ndim)
         return _stack(block, rest) / root
@@ -674,7 +692,9 @@ class SuperLUSparseFactor:
         L_unit = csc_array(self._L @ diags(invdiag))
         return L_unit, invdiag
 
-    def half_solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
+    def half_solve(
+        self, b: NDArray[np.floating[Any]]
+    ) -> Union[NDArray[np.float64], SparseHalfSolve]:
         """Apply the transpose of the ``sample_at`` operator: L^{-1} P b.
 
         Same contract as :meth:`CholmodSparseFactor.half_solve`, against
@@ -685,12 +705,9 @@ class SuperLUSparseFactor:
         overwriting both operands is safe).
         """
         L_unit, invdiag = self._half_solve_factor
-        if issparse(b):
-            rhs = _SparseRhs(b, self._observed, self._trivial)
-            operand, rest = rhs.block, rhs.compact_trivial(self._trivial_diag)
-        else:
-            operand = b[self._observed]
-            rest = b[self._trivial] / _column_scale(np.sqrt(self._trivial_diag), b.ndim)
+        root = np.sqrt(self._scale)
+        rhs = _SparseRhs(b, self._observed, self._trivial) if issparse(b) else None
+        operand = b[self._observed] if rhs is None else rhs.block
         y = spsolve_triangular(
             L_unit,
             operand[self._perm],
@@ -699,7 +716,13 @@ class SuperLUSparseFactor:
             overwrite_A=True,
             overwrite_b=True,
         )
-        return _stack(y * _column_scale(invdiag, y.ndim), rest) / np.sqrt(self._scale)
+        y *= _column_scale(invdiag / root, y.ndim)
+        if rhs is not None:
+            return SparseHalfSolve(
+                y, rhs.compact_trivial(self._trivial_diag, self._scale)
+            )
+        rest = b[self._trivial] / _column_scale(np.sqrt(self._trivial_diag), b.ndim)
+        return _stack(y, rest / root)
 
     def logdet(self) -> float:
         """Log-determinant of the factored matrix.

--- a/src/bayesianbandits/_sparse_bayesian_linear_regression.py
+++ b/src/bayesianbandits/_sparse_bayesian_linear_regression.py
@@ -131,14 +131,8 @@ class SuperLUSparseFactor:
         return perm
 
     def solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
-        """Solve ``Λ x = b``.
-
-        For a dense ``b`` this goes through the cached triangular factor
-        (``Λ⁻¹ = P^T L^{-T} L^{-1} P``, i.e. ``colorize(half_solve(b))``)
-        rather than ``spsolve``, which refactorizes the precision on
-        every call. Sparse right-hand sides keep the ``spsolve`` path,
-        which accepts them directly.
-        """
+        """Solve ``Λ x = b``: through the cached triangular factor for
+        dense ``b``, through ``spsolve`` (which refactorizes) for sparse."""
         if issparse(b):
             return cast(NDArray[np.float64], spsolve(self._precision, b))
         return self.colorize(self.half_solve(b))

--- a/src/bayesianbandits/_sparse_bayesian_linear_regression.py
+++ b/src/bayesianbandits/_sparse_bayesian_linear_regression.py
@@ -13,6 +13,8 @@ from typing import (
 import numpy as np
 from numpy.typing import NDArray
 from scipy.linalg import cho_solve, solve_triangular  # type: ignore
+from scipy.linalg.blas import dtrsm  # type: ignore[attr-defined]
+from scipy.linalg.lapack import dtrtri  # type: ignore[attr-defined]
 from scipy.sparse import (  # type: ignore  # type: ignore
     csc_array,
     csc_matrix,
@@ -261,10 +263,11 @@ SparseFactor = CholmodSparseFactor | SuperLUSparseFactor | ScaledSparseFactor
 class DenseFactor:
     """Wraps a LAPACK Cholesky factorization for solving and sampling.
 
-    Stores the upper-triangular factor U where Λ = U^T U.
-    U^{-1} is computed lazily on first ``colorize`` call so that
-    ``fit``/``partial_fit`` (which only need ``solve``) pay no
-    extra cost.
+    Stores the upper-triangular factor U where Λ = U^T U.  Every
+    operation solves against ``U`` directly; the explicit ``U^{-1}`` is
+    built lazily and only for :meth:`trace_inv`, which genuinely needs
+    the inverse.  ``fit``/``partial_fit`` (which only need ``solve``)
+    therefore pay no extra cost, and neither does sampling.
     """
 
     _U: NDArray[np.float64]
@@ -272,16 +275,38 @@ class DenseFactor:
 
     @cached_property
     def _U_inv(self) -> NDArray[np.float64]:
-        return solve_triangular(
-            self._U, np.eye(self._n_features), lower=False, check_finite=False
-        )
+        """Explicit ``U^{-1}``, for :meth:`trace_inv` only.
+
+        ``dtrtri`` inverts the triangle at a third of the flops of
+        solving against a dense identity, but writes only the upper
+        triangle of its result, leaving whatever ``cho_factor`` left
+        below the diagonal, hence the ``triu``.  ``_U`` itself is not
+        overwritten.
+        """
+        U_inv, _info = dtrtri(self._U, lower=0)
+        return cast(NDArray[np.float64], np.triu(U_inv))
 
     def solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
         return cho_solve((self._U, False), b, check_finite=False)
 
     def colorize(self, z: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
-        """Compute U^{-1} z, producing samples from N(0, Λ^{-1})."""
-        return cast(NDArray[np.float64], self._U_inv @ z)
+        """Compute U^{-1} z, producing samples from N(0, Λ^{-1}).
+
+        Solves against ``U`` rather than multiplying by an explicit
+        inverse.  The factor is rebuilt after every ``partial_fit``, so
+        forming ``U^{-1}`` charged an O(d³) triangular inversion to each
+        update -- more than an order of magnitude above the Cholesky
+        that preceded it -- to save nothing: ``dtrsm`` and the ``dgemm``
+        against the inverse cost the same per draw.  ``dtrsm`` also
+        keeps the draw inside scipy's BLAS pool (see
+        :func:`~bayesianbandits._blas_helpers.lower_predictive_sqrt`).
+        """
+        z2 = np.asfortranarray(z, dtype=np.float64)
+        vector = z2.ndim == 1
+        if vector:
+            z2 = z2.reshape(-1, 1)
+        out = dtrsm(1.0, self._U, z2, lower=0, side=0)
+        return cast(NDArray[np.float64], out[:, 0] if vector else out)
 
     def half_solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
         """Solve U^T x = b, the transpose of the ``colorize`` operator.

--- a/src/bayesianbandits/_sparse_bayesian_linear_regression.py
+++ b/src/bayesianbandits/_sparse_bayesian_linear_regression.py
@@ -131,7 +131,17 @@ class SuperLUSparseFactor:
         return perm
 
     def solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
-        return cast(NDArray[np.float64], spsolve(self._precision, b))
+        """Solve ``Λ x = b``.
+
+        For a dense ``b`` this goes through the cached triangular factor
+        (``Λ⁻¹ = P^T L^{-T} L^{-1} P``, i.e. ``colorize(half_solve(b))``)
+        rather than ``spsolve``, which refactorizes the precision on
+        every call. Sparse right-hand sides keep the ``spsolve`` path,
+        which accepts them directly.
+        """
+        if issparse(b):
+            return cast(NDArray[np.float64], spsolve(self._precision, b))
+        return self.colorize(self.half_solve(b))
 
     def colorize(self, z: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
         """Solve L^T x = z, undo permutation."""

--- a/src/bayesianbandits/_support_covariance.py
+++ b/src/bayesianbandits/_support_covariance.py
@@ -1,0 +1,203 @@
+"""Support-covariance reduction for sparse posterior predictive draws.
+
+A sparse design matrix ``X`` touches only a small set of columns ``U``.
+The joint predictive law of ``X w`` for ``w ~ N(ŵ, Λ⁻¹)`` depends on
+``Λ⁻¹`` only through the ``|U| x |U|`` principal submatrix
+``S = (Λ⁻¹)_{U,U}``:
+
+.. math::
+
+    \\operatorname{Cov}(X w) = X \\Lambda^{-1} X^T = X_U S X_U^T
+
+This is an identity, not an approximation: ``X = X_U E_U^T`` exactly,
+where ``E_U`` selects the columns in ``U``.
+
+``S`` costs ``|U|`` solves against the cached factor -- the stock
+multi-RHS solve both CHOLMOD and SuperLU provide -- after which every
+draw and every per-row standard deviation is dense linear algebra on an
+``|U| x |U|`` matrix, with no further reference to the factor. The cost
+is therefore ``O(|U| · nnz(L))`` with no dependence on the elimination
+tree, unlike approaches that walk the factor's sparsity structure.
+
+Because ``S`` is a principal submatrix of the symmetric positive
+definite ``Λ⁻¹``, it is itself SPD for *any* ``X``, so its Cholesky
+always exists. Reducing on the feature side rather than the row side is
+what buys that: the ``n x n`` predictive covariance ``X_U S X_U^T`` is
+singular whenever two rows of ``X`` coincide, while ``S`` never is.
+Duplicate rows come out perfectly correlated within a draw, which is
+what a shared weight vector implies.
+"""
+
+from typing import Any, Optional, Union, cast
+
+import numpy as np
+from numpy.typing import NDArray
+from scipy.sparse import csc_array, issparse  # type: ignore
+
+from ._sparse_bayesian_linear_regression import PrecisionFactor
+
+_SCRATCH_ELEMS = 2**23
+"""Cap on a single dense scratch buffer, in float64 elements (~64 MB).
+
+Sizes both the ``(n_features, k)`` right-hand-side block used to build
+``S`` and the ``(rows, |U|)`` densified design block. Unlike the
+blocking in ``_marginal_predictive_sd``, changing this trades memory for
+nothing: the blocks are independent GEMMs against the same small
+factor, so neither the solve count nor the flop count moves.
+"""
+
+
+def support_of(X: csc_array) -> NDArray[np.intp]:
+    """Column indices ``X`` touches, ascending.
+
+    For CSC these are exactly the columns whose ``indptr`` range is
+    non-empty, so no scan of the row indices is needed. Comparing
+    adjacent entries rather than differencing them keeps the temporary a
+    boolean array instead of an index-width one, which at large feature
+    counts is several times cheaper.
+    """
+    indptr = X.indptr
+    return cast(NDArray[np.intp], np.flatnonzero(indptr[1:] != indptr[:-1]))
+
+
+def _compact_columns(X: csc_array, support: NDArray[np.intp]) -> csc_array:
+    """``X[:, support]`` for a ``support`` that lists every non-empty column.
+
+    Empty columns never advance ``indptr``, so dropping them is a
+    re-slice of ``indptr`` alone -- ``data`` and ``indices`` are shared
+    with ``X``, not copied.
+    """
+    n_rows = cast("tuple[int, int]", X.shape)[0]
+    indptr = np.append(X.indptr[support], X.indptr[-1])
+    return csc_array(
+        (X.data, X.indices, indptr), shape=(n_rows, support.size), copy=False
+    )
+
+
+def support_covariance(
+    factor: PrecisionFactor, support: NDArray[np.intp], n_features: int
+) -> NDArray[np.float64]:
+    """``S = (Λ⁻¹)_{U,U}`` via ``|U|`` solves against ``factor``.
+
+    Solves ``Λ Y = E_U`` in column blocks and keeps the ``U`` rows of
+    each result. Only the small ``|U| x |U|`` block is retained, so the
+    ``(n_features, block)`` scratch is the peak allocation.
+    """
+    n_u = support.size
+    block = int(np.clip(_SCRATCH_ELEMS // max(1, n_features), 1, n_u))
+    S = np.empty((n_u, n_u), dtype=np.float64)
+    rhs = np.zeros((n_features, block), dtype=np.float64)
+    for start in range(0, n_u, block):
+        stop = min(n_u, start + block)
+        width = stop - start
+        cols = np.arange(width)
+        rhs[support[start:stop], cols] = 1.0
+        # Every factor preserves a 2-D right-hand side, but reshaping
+        # rather than trusting that keeps a single-column block safe.
+        out = np.asarray(factor.solve(rhs[:, :width]), dtype=np.float64).reshape(
+            n_features, width
+        )
+        S[:, start:stop] = out[support, :]
+        rhs[support[start:stop], cols] = 0.0
+    # Λ⁻¹ is symmetric; the solves are not bitwise so average the halves.
+    return cast(NDArray[np.float64], 0.5 * (S + S.T))
+
+
+def _factorize(S: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Lower-triangular ``C`` with ``C Cᵀ = S``.
+
+    ``S`` is SPD in exact arithmetic; the eigenvalue branch is a guard
+    against a numerically indefinite result for a severely
+    ill-conditioned precision, not an expected path.
+    """
+    try:
+        return cast(NDArray[np.float64], np.linalg.cholesky(S))
+    except np.linalg.LinAlgError:
+        w, V = np.linalg.eigh(S)
+        return cast(NDArray[np.float64], V * np.sqrt(np.clip(w, 0.0, None)))
+
+
+class SupportDraw:
+    """Exact joint predictive law of ``X w``, reduced to ``X``'s support."""
+
+    __slots__ = ("_C", "_XU", "_n_rows")
+
+    def __init__(self, C: NDArray[np.float64], XU: csc_array) -> None:
+        self._C = C
+        # CSR so row blocks densify contiguously; |U| is small so this
+        # conversion is cheap and happens once.
+        self._XU = XU.tocsr()
+        self._n_rows = cast("tuple[int, int]", XU.shape)[0]
+
+    def _row_block(self) -> int:
+        return max(1, _SCRATCH_ELEMS // max(1, self._C.shape[0]))
+
+    def joint(self, size: int, rng: np.random.Generator) -> NDArray[np.float64]:
+        """``size`` jointly-distributed draws, shape ``(size, n_rows)``.
+
+        Rows within one draw share a weight vector, matching ``sample``.
+        """
+        ZC = rng.standard_normal((size, self._C.shape[0])) @ self._C.T
+        out = np.empty((size, self._n_rows), dtype=np.float64)
+        block = self._row_block()
+        for start in range(0, self._n_rows, block):
+            stop = min(self._n_rows, start + block)
+            out[:, start:stop] = (
+                ZC @ np.asarray(self._XU[start:stop].todense(), dtype=np.float64).T
+            )
+        return out
+
+    def sd(self) -> NDArray[np.float64]:
+        """Per-row predictive standard deviations, shape ``(n_rows,)``."""
+        out = np.empty(self._n_rows, dtype=np.float64)
+        block = self._row_block()
+        for start in range(0, self._n_rows, block):
+            stop = min(self._n_rows, start + block)
+            T = np.asarray(self._XU[start:stop].todense(), dtype=np.float64) @ self._C
+            out[start:stop] = np.sqrt(np.einsum("ij,ij->i", T, T))
+        return out
+
+
+def build(
+    factor: PrecisionFactor,
+    X: Union[NDArray[Any], csc_array],
+    n_features: int,
+    budget: int,
+) -> Optional[SupportDraw]:
+    """Build a :class:`SupportDraw`, or ``None`` to keep the caller's path.
+
+    ``budget`` is the number of triangular solves the caller's existing
+    path would perform: ``size`` for a joint draw (one solve per draw)
+    and ``n_rows`` for per-row standard deviations (one half-solve per
+    row). This route costs ``|U|`` solves, so it is taken only when
+    ``|U| < budget`` -- a comparison of two exactly known integers, with
+    nothing calibrated.
+
+    Returns ``None`` for dense ``X`` (where ``|U| = n_features``, so the
+    reduction buys nothing) and for an all-zero ``X``.
+    """
+    if not issparse(X):
+        return None
+    # ``|U| >= 1`` for any non-empty X, so a budget below 2 can never be
+    # beaten. Checking that first keeps the Thompson-sampling hot path
+    # (``size=1``) clear of the O(n_features) support scan below, which
+    # is otherwise a measurable cost at large feature counts.
+    if budget < 2:
+        return None
+    Xc = cast(csc_array, X)
+    n_rows = cast("tuple[int, int]", Xc.shape)[0]
+    nnz = int(Xc.indptr[-1])
+    if nnz == 0:
+        return None
+    # A column holds at most ``n_rows`` entries, so ``|U| >= nnz / n_rows``.
+    # When that bound alone already meets the budget the answer is known
+    # without scanning: decline in O(1). This is exact whenever the rows
+    # share a common support, which is the shape that reaches here most
+    # often (one design row per arm).
+    if -(-nnz // max(1, n_rows)) >= budget:
+        return None
+    support = support_of(Xc)
+    if support.size >= budget:
+        return None
+    S = support_covariance(factor, support, n_features)
+    return SupportDraw(_factorize(S), _compact_columns(Xc, support))

--- a/src/bayesianbandits/_support_covariance.py
+++ b/src/bayesianbandits/_support_covariance.py
@@ -20,7 +20,7 @@ from typing import Any, Optional, Union, cast
 
 import numpy as np
 from numpy.typing import NDArray
-from scipy.linalg import LinAlgError, cholesky, eigh  # type: ignore
+from scipy.linalg import cholesky  # type: ignore
 from scipy.linalg.blas import dgemm  # type: ignore[attr-defined]
 from scipy.sparse import csc_array, issparse  # type: ignore
 
@@ -75,20 +75,26 @@ def support_covariance(
 
 
 def _factorize(S: NDArray[np.float64]) -> NDArray[np.float64]:
-    """Lower-triangular ``C`` with ``C Cᵀ = S``; the eigenvalue branch
-    guards against a numerically indefinite ``S``.
+    """Lower-triangular ``C`` with ``C Cᵀ = S``.
 
-    Returned Fortran-ordered, so every ``dgemm`` below takes it uncopied.
-    Taken from ``scipy.linalg`` rather than ``numpy.linalg`` to keep the
-    whole route in one BLAS thread pool (see
-    :func:`~bayesianbandits._blas_helpers.lower_predictive_sqrt`).
+    ``S`` is a principal submatrix of the SPD ``Λ⁻¹``, so it is SPD too,
+    and eigenvalue interlacing bounds it away from singular:
+    ``λ_min(S) >= λ_min(Λ⁻¹) = 1 / λ_max(Λ)``, so ``cond(S) <= cond(Λ)``.
+    The Cholesky therefore exists for any ``X``, and can fail only if
+    ``Λ`` is numerically singular -- which already breaks the cached
+    factor that every route shares. Unlike the row side, where repeated
+    prediction rows make ``Bᵀ B`` genuinely singular and force a QR
+    (see :func:`~bayesianbandits._blas_helpers.lower_predictive_sqrt`),
+    there is no degenerate case to guard against here.
+
+    Returned Fortran-ordered, so every ``dgemm`` below takes it uncopied,
+    and taken from ``scipy.linalg`` rather than ``numpy.linalg`` to keep
+    the whole route in one BLAS thread pool.
     """
-    try:
-        C = cholesky(S, lower=True, check_finite=False)
-    except LinAlgError:
-        w, V = eigh(S, check_finite=False)
-        C = V * np.sqrt(np.clip(w, 0.0, None))
-    return cast(NDArray[np.float64], np.asfortranarray(C))
+    return cast(
+        NDArray[np.float64],
+        np.asfortranarray(cholesky(S, lower=True, check_finite=False)),
+    )
 
 
 class SupportDraw:

--- a/src/bayesianbandits/_support_covariance.py
+++ b/src/bayesianbandits/_support_covariance.py
@@ -58,7 +58,11 @@ def support_covariance(
     n_u = support.size
     block = int(np.clip(_SCRATCH_ELEMS // max(1, n_features), 1, n_u))
     S = np.empty((n_u, n_u), dtype=np.float64)
-    rhs = np.zeros((n_features, block), dtype=np.float64)
+    # Fortran order, and sliced from the left so the slice stays
+    # F-contiguous: CHOLMOD's dense format is column-major, so a
+    # C-ordered right-hand side is transposed into a full second copy of
+    # this (n_features, block) buffer before the solve begins.
+    rhs = np.zeros((n_features, block), dtype=np.float64, order="F")
     for start in range(0, n_u, block):
         stop = min(n_u, start + block)
         width = stop - start

--- a/src/bayesianbandits/_support_covariance.py
+++ b/src/bayesianbandits/_support_covariance.py
@@ -20,8 +20,11 @@ from typing import Any, Optional, Union, cast
 
 import numpy as np
 from numpy.typing import NDArray
+from scipy.linalg import LinAlgError, cholesky, eigh  # type: ignore
+from scipy.linalg.blas import dgemm  # type: ignore[attr-defined]
 from scipy.sparse import csc_array, issparse  # type: ignore
 
+from ._blas_helpers import standard_normal_f
 from ._sparse_bayesian_linear_regression import PrecisionFactor
 
 _SCRATCH_ELEMS = 2**23
@@ -73,12 +76,19 @@ def support_covariance(
 
 def _factorize(S: NDArray[np.float64]) -> NDArray[np.float64]:
     """Lower-triangular ``C`` with ``C Cᵀ = S``; the eigenvalue branch
-    guards against a numerically indefinite ``S``."""
+    guards against a numerically indefinite ``S``.
+
+    Returned Fortran-ordered, so every ``dgemm`` below takes it uncopied.
+    Taken from ``scipy.linalg`` rather than ``numpy.linalg`` to keep the
+    whole route in one BLAS thread pool (see
+    :func:`~bayesianbandits._blas_helpers.lower_predictive_sqrt`).
+    """
     try:
-        return cast(NDArray[np.float64], np.linalg.cholesky(S))
-    except np.linalg.LinAlgError:
-        w, V = np.linalg.eigh(S)
-        return cast(NDArray[np.float64], V * np.sqrt(np.clip(w, 0.0, None)))
+        C = cholesky(S, lower=True, check_finite=False)
+    except LinAlgError:
+        w, V = eigh(S, check_finite=False)
+        C = V * np.sqrt(np.clip(w, 0.0, None))
+    return cast(NDArray[np.float64], np.asfortranarray(C))
 
 
 class SupportDraw:
@@ -95,19 +105,41 @@ class SupportDraw:
     def _row_block(self) -> int:
         return max(1, _SCRATCH_ELEMS // max(1, self._C.shape[0]))
 
-    def joint(self, size: int, rng: np.random.Generator) -> NDArray[np.float64]:
+    def _dense_rows(self, start: int, stop: int) -> NDArray[np.float64]:
+        """``X_U[start:stop]`` densified and transposed, ``(|U|, rows)``.
+
+        A densified CSR block is C-ordered, so its transpose is already
+        Fortran-ordered and ``dgemm`` takes it without a copy.
+        """
+        block = np.asarray(self._XU[start:stop].todense(), dtype=np.float64)
+        return cast(NDArray[np.float64], block.T)
+
+    def joint(
+        self,
+        size: int,
+        rng: np.random.Generator,
+        mean: Optional[NDArray[np.float64]] = None,
+    ) -> NDArray[np.float64]:
         """``size`` jointly-distributed draws, shape ``(size, n_rows)``.
 
         Rows within one draw share a weight vector, matching ``sample``.
+        ``mean`` is broadcast into the output buffer rather than added by
+        the caller, which would cost a second ``(size, n_rows)`` array;
+        omit it when the caller has to rescale the zero-mean draw first.
         """
-        ZC = rng.standard_normal((size, self._C.shape[0])) @ self._C.T
+        Z = standard_normal_f(rng, size, self._C.shape[0])
+        ZC = dgemm(1.0, Z, self._C, trans_b=1)
         out = np.empty((size, self._n_rows), dtype=np.float64)
+        if mean is not None:
+            out[:] = mean
         block = self._row_block()
         for start in range(0, self._n_rows, block):
             stop = min(self._n_rows, start + block)
-            out[:, start:stop] = (
-                ZC @ np.asarray(self._XU[start:stop].todense(), dtype=np.float64).T
-            )
+            drawn = dgemm(1.0, ZC, self._dense_rows(start, stop))
+            if mean is None:
+                out[:, start:stop] = drawn
+            else:
+                out[:, start:stop] += drawn
         return out
 
     def sd(self) -> NDArray[np.float64]:
@@ -116,7 +148,7 @@ class SupportDraw:
         block = self._row_block()
         for start in range(0, self._n_rows, block):
             stop = min(self._n_rows, start + block)
-            T = np.asarray(self._XU[start:stop].todense(), dtype=np.float64) @ self._C
+            T = dgemm(1.0, self._dense_rows(start, stop), self._C, trans_a=1)
             out[start:stop] = np.sqrt(np.einsum("ij,ij->i", T, T))
         return out
 

--- a/src/bayesianbandits/_support_covariance.py
+++ b/src/bayesianbandits/_support_covariance.py
@@ -140,15 +140,19 @@ class SupportDraw:
         size: int,
         rng: np.random.Generator,
         mean: Optional[NDArray[np.float64]] = None,
+        scale: Optional[NDArray[np.float64]] = None,
     ) -> NDArray[np.float64]:
         """``size`` jointly-distributed draws, shape ``(size, n_rows)``.
 
         Rows within one draw share a weight vector, matching ``sample``.
-        ``mean`` is broadcast into the output buffer rather than added by
-        the caller, which would cost a second ``(size, n_rows)`` array;
-        omit it when the caller has to rescale the zero-mean draw first.
+        ``scale`` multiplies the zero-mean part per draw, ``(size,)``, for
+        the NIG multivariate-t mixing; ``mean`` is broadcast into the
+        output buffer rather than added by the caller, which would cost
+        a second ``(size, n_rows)`` array.
         """
         Z = standard_normal_f(rng, size, self._C.shape[0])
+        if scale is not None:
+            Z *= scale[:, np.newaxis]
         ZC = dgemm(1.0, Z, self._C, trans_b=1)
         out = np.empty((size, self._n_rows), dtype=np.float64)
         if mean is not None:

--- a/src/bayesianbandits/_support_covariance.py
+++ b/src/bayesianbandits/_support_covariance.py
@@ -1,31 +1,19 @@
 """Support-covariance reduction for sparse posterior predictive draws.
 
-A sparse design matrix ``X`` touches only a small set of columns ``U``.
-The joint predictive law of ``X w`` for ``w ~ N(ŵ, Λ⁻¹)`` depends on
-``Λ⁻¹`` only through the ``|U| x |U|`` principal submatrix
-``S = (Λ⁻¹)_{U,U}``:
+A sparse design matrix ``X`` touches only a small set of columns ``U``,
+and ``X = X_U E_Uᵀ`` exactly, so the joint law of ``X w`` for
+``w ~ N(ŵ, Λ⁻¹)`` depends on ``Λ⁻¹`` only through the principal
+submatrix ``S = (Λ⁻¹)_{U,U}``:
 
 .. math::
 
     \\operatorname{Cov}(X w) = X \\Lambda^{-1} X^T = X_U S X_U^T
 
-This is an identity, not an approximation: ``X = X_U E_U^T`` exactly,
-where ``E_U`` selects the columns in ``U``.
-
-``S`` costs ``|U|`` solves against the cached factor -- the stock
-multi-RHS solve both CHOLMOD and SuperLU provide -- after which every
-draw and every per-row standard deviation is dense linear algebra on an
-``|U| x |U|`` matrix, with no further reference to the factor. The cost
-is therefore ``O(|U| · nnz(L))`` with no dependence on the elimination
-tree, unlike approaches that walk the factor's sparsity structure.
-
-Because ``S`` is a principal submatrix of the symmetric positive
-definite ``Λ⁻¹``, it is itself SPD for *any* ``X``, so its Cholesky
-always exists. Reducing on the feature side rather than the row side is
-what buys that: the ``n x n`` predictive covariance ``X_U S X_U^T`` is
-singular whenever two rows of ``X`` coincide, while ``S`` never is.
-Duplicate rows come out perfectly correlated within a draw, which is
-what a shared weight vector implies.
+``S`` costs ``|U|`` solves against the cached factor; every draw and
+per-row standard deviation after that is dense linear algebra on an
+``|U| x |U|`` matrix. ``S`` is SPD for any ``X`` (unlike the ``n x n``
+predictive covariance, singular whenever rows repeat), so its Cholesky
+always exists.
 """
 
 from typing import Any, Optional, Union, cast
@@ -37,36 +25,21 @@ from scipy.sparse import csc_array, issparse  # type: ignore
 from ._sparse_bayesian_linear_regression import PrecisionFactor
 
 _SCRATCH_ELEMS = 2**23
-"""Cap on a single dense scratch buffer, in float64 elements (~64 MB).
-
-Sizes both the ``(n_features, k)`` right-hand-side block used to build
-``S`` and the ``(rows, |U|)`` densified design block. Unlike the
-blocking in ``_marginal_predictive_sd``, changing this trades memory for
-nothing: the blocks are independent GEMMs against the same small
-factor, so neither the solve count nor the flop count moves.
-"""
+"""Cap on a dense scratch buffer, in float64 elements (~64 MB): the
+``(n_features, k)`` right-hand-side block that builds ``S`` and the
+``(rows, |U|)`` densified design block."""
 
 
 def support_of(X: csc_array) -> NDArray[np.intp]:
-    """Column indices ``X`` touches, ascending.
-
-    For CSC these are exactly the columns whose ``indptr`` range is
-    non-empty, so no scan of the row indices is needed. Comparing
-    adjacent entries rather than differencing them keeps the temporary a
-    boolean array instead of an index-width one, which at large feature
-    counts is several times cheaper.
-    """
+    """Column indices ``X`` touches, ascending: the columns whose CSC
+    ``indptr`` range is non-empty, with no scan of ``indices``."""
     indptr = X.indptr
     return cast(NDArray[np.intp], np.flatnonzero(indptr[1:] != indptr[:-1]))
 
 
 def _compact_columns(X: csc_array, support: NDArray[np.intp]) -> csc_array:
-    """``X[:, support]`` for a ``support`` that lists every non-empty column.
-
-    Empty columns never advance ``indptr``, so dropping them is a
-    re-slice of ``indptr`` alone -- ``data`` and ``indices`` are shared
-    with ``X``, not copied.
-    """
+    """``X[:, support]`` when ``support`` lists every non-empty column:
+    a re-slice of ``indptr`` alone, sharing ``data`` and ``indices``."""
     n_rows = cast("tuple[int, int]", X.shape)[0]
     indptr = np.append(X.indptr[support], X.indptr[-1])
     return csc_array(
@@ -77,12 +50,8 @@ def _compact_columns(X: csc_array, support: NDArray[np.intp]) -> csc_array:
 def support_covariance(
     factor: PrecisionFactor, support: NDArray[np.intp], n_features: int
 ) -> NDArray[np.float64]:
-    """``S = (Λ⁻¹)_{U,U}`` via ``|U|`` solves against ``factor``.
-
-    Solves ``Λ Y = E_U`` in column blocks and keeps the ``U`` rows of
-    each result. Only the small ``|U| x |U|`` block is retained, so the
-    ``(n_features, block)`` scratch is the peak allocation.
-    """
+    """``S = (Λ⁻¹)_{U,U}``: solve ``Λ Y = E_U`` in column blocks and keep
+    the ``U`` rows of each result."""
     n_u = support.size
     block = int(np.clip(_SCRATCH_ELEMS // max(1, n_features), 1, n_u))
     S = np.empty((n_u, n_u), dtype=np.float64)
@@ -92,8 +61,7 @@ def support_covariance(
         width = stop - start
         cols = np.arange(width)
         rhs[support[start:stop], cols] = 1.0
-        # Every factor preserves a 2-D right-hand side, but reshaping
-        # rather than trusting that keeps a single-column block safe.
+        # reshape rather than trust every backend to keep a 2-D RHS 2-D
         out = np.asarray(factor.solve(rhs[:, :width]), dtype=np.float64).reshape(
             n_features, width
         )
@@ -104,12 +72,8 @@ def support_covariance(
 
 
 def _factorize(S: NDArray[np.float64]) -> NDArray[np.float64]:
-    """Lower-triangular ``C`` with ``C Cᵀ = S``.
-
-    ``S`` is SPD in exact arithmetic; the eigenvalue branch is a guard
-    against a numerically indefinite result for a severely
-    ill-conditioned precision, not an expected path.
-    """
+    """Lower-triangular ``C`` with ``C Cᵀ = S``; the eigenvalue branch
+    guards against a numerically indefinite ``S``."""
     try:
         return cast(NDArray[np.float64], np.linalg.cholesky(S))
     except np.linalg.LinAlgError:
@@ -124,8 +88,7 @@ class SupportDraw:
 
     def __init__(self, C: NDArray[np.float64], XU: csc_array) -> None:
         self._C = C
-        # CSR so row blocks densify contiguously; |U| is small so this
-        # conversion is cheap and happens once.
+        # CSR so row blocks densify contiguously
         self._XU = XU.tocsr()
         self._n_rows = cast("tuple[int, int]", XU.shape)[0]
 
@@ -166,22 +129,15 @@ def build(
 ) -> Optional[SupportDraw]:
     """Build a :class:`SupportDraw`, or ``None`` to keep the caller's path.
 
-    ``budget`` is the number of triangular solves the caller's existing
-    path would perform: ``size`` for a joint draw (one solve per draw)
-    and ``n_rows`` for per-row standard deviations (one half-solve per
-    row). This route costs ``|U|`` solves, so it is taken only when
-    ``|U| < budget`` -- a comparison of two exactly known integers, with
-    nothing calibrated.
-
-    Returns ``None`` for dense ``X`` (where ``|U| = n_features``, so the
-    reduction buys nothing) and for an all-zero ``X``.
+    ``budget`` is the number of solves the caller's path would perform
+    (``size`` for a joint draw, ``n_rows`` for per-row standard
+    deviations); this route costs ``|U|``, so it is taken only when
+    ``|U| < budget``. Returns ``None`` for dense or all-zero ``X``.
     """
     if not issparse(X):
         return None
-    # ``|U| >= 1`` for any non-empty X, so a budget below 2 can never be
-    # beaten. Checking that first keeps the Thompson-sampling hot path
-    # (``size=1``) clear of the O(n_features) support scan below, which
-    # is otherwise a measurable cost at large feature counts.
+    # |U| >= 1, so budget < 2 can never be beaten; this keeps the
+    # Thompson hot path (size=1) clear of the O(n_features) scan below.
     if budget < 2:
         return None
     Xc = cast(csc_array, X)
@@ -189,11 +145,8 @@ def build(
     nnz = int(Xc.indptr[-1])
     if nnz == 0:
         return None
-    # A column holds at most ``n_rows`` entries, so ``|U| >= nnz / n_rows``.
-    # When that bound alone already meets the budget the answer is known
-    # without scanning: decline in O(1). This is exact whenever the rows
-    # share a common support, which is the shape that reaches here most
-    # often (one design row per arm).
+    # A column holds at most n_rows entries, so |U| >= nnz / n_rows:
+    # decline in O(1) when that bound alone meets the budget.
     if -(-nnz // max(1, n_rows)) >= budget:
         return None
     support = support_of(Xc)

--- a/src/bayesianbandits/_support_covariance.py
+++ b/src/bayesianbandits/_support_covariance.py
@@ -16,7 +16,7 @@ predictive covariance, singular whenever rows repeat), so its Cholesky
 always exists.
 """
 
-from typing import Any, Optional, Union, cast
+from typing import Any, Callable, Optional, Union, cast
 
 import numpy as np
 from numpy.typing import NDArray
@@ -168,6 +168,7 @@ def build(
     X: Union[NDArray[Any], csc_array],
     n_features: int,
     budget: int,
+    accept: Optional[Callable[[int], bool]] = None,
 ) -> Optional[SupportDraw]:
     """Build a :class:`SupportDraw`, or ``None`` to keep the caller's path.
 
@@ -175,6 +176,14 @@ def build(
     (``size`` for a joint draw, ``n_rows`` for per-row standard
     deviations); this route costs ``|U|``, so it is taken only when
     ``|U| < budget``. Returns ``None`` for dense or all-zero ``X``.
+
+    Solve counts are the whole comparison only when the caller's path
+    already allocates something ``|U|²`` fits inside, as weight space's
+    ``(size, d)`` draw buffer does. A caller whose fallback is bounded
+    tighter than that passes ``accept`` to weigh the route's other
+    costs -- the ``|U| x |U|`` covariance and its ``O(|U|³)`` Cholesky
+    -- against ``|U|``, once the support is known and before it is paid
+    for.
     """
     if not issparse(X):
         return None
@@ -193,6 +202,8 @@ def build(
         return None
     support = support_of(Xc)
     if support.size >= budget:
+        return None
+    if accept is not None and not accept(int(support.size)):
         return None
     S = support_covariance(factor, support, n_features)
     return SupportDraw(_factorize(S), _compact_columns(Xc, support))

--- a/src/bayesianbandits/_support_covariance.py
+++ b/src/bayesianbandits/_support_covariance.py
@@ -40,7 +40,7 @@ def support_of(X: csc_array) -> NDArray[np.intp]:
     return cast(NDArray[np.intp], np.flatnonzero(indptr[1:] != indptr[:-1]))
 
 
-def _compact_columns(X: csc_array, support: NDArray[np.intp]) -> csc_array:
+def compact_columns(X: csc_array, support: NDArray[np.intp]) -> csc_array:
     """``X[:, support]`` when ``support`` lists every non-empty column:
     a re-slice of ``indptr`` alone, sharing ``data`` and ``indices``."""
     n_rows = cast("tuple[int, int]", X.shape)[0]
@@ -54,26 +54,37 @@ def support_covariance(
     factor: PrecisionFactor, support: NDArray[np.intp], n_features: int
 ) -> NDArray[np.float64]:
     """``S = (Λ⁻¹)_{U,U}``: solve ``Λ Y = E_U`` in column blocks and keep
-    the ``U`` rows of each result."""
+    the ``U`` rows of each result.
+
+    ``E_U`` goes in sparse -- it is ``|U|`` ones -- so the factor does
+    the work at the features it actually factors: a partitioned sparse
+    factor densifies only its block rows, ``O(m k)`` for ``m`` observed
+    features, where a dense ``(n_features, k)`` right-hand side would
+    cost ``O(n_features k)`` to build, scatter and read back for the
+    ``|U|`` rows wanted. The block bound is still stated in
+    ``n_features``: it caps the result's footprint when nothing is
+    trivial, and is merely conservative when the block is small.
+    """
     n_u = support.size
     block = int(np.clip(_SCRATCH_ELEMS // max(1, n_features), 1, n_u))
-    S = np.empty((n_u, n_u), dtype=np.float64)
-    # Fortran order, and sliced from the left so the slice stays
-    # F-contiguous: CHOLMOD's dense format is column-major, so a
-    # C-ordered right-hand side is transposed into a full second copy of
-    # this (n_features, block) buffer before the solve begins.
-    rhs = np.zeros((n_features, block), dtype=np.float64, order="F")
+    S = np.zeros((n_u, n_u), dtype=np.float64)
+    # One O(n_features) table for the whole call; reading the ``U`` rows
+    # of each result through it is then O(nnz), where row-indexing the
+    # sparse result would be O(n_features) again per block.
+    lut = np.full(n_features, -1, dtype=np.intp)
+    lut[support] = np.arange(n_u)
     for start in range(0, n_u, block):
         stop = min(n_u, start + block)
         width = stop - start
-        cols = np.arange(width)
-        rhs[support[start:stop], cols] = 1.0
-        # reshape rather than trust every backend to keep a 2-D RHS 2-D
-        out = np.asarray(factor.solve(rhs[:, :width]), dtype=np.float64).reshape(
-            n_features, width
+        rhs = csc_array(
+            (np.ones(width), (support[start:stop], np.arange(width))),
+            shape=(n_features, width),
         )
-        S[:, start:stop] = out[support, :]
-        rhs[support[start:stop], cols] = 0.0
+        out = cast(csc_array, factor.solve(rhs))  # type: ignore[arg-type]
+        rows = lut[out.indices]
+        cols = np.repeat(np.arange(start, stop), np.diff(out.indptr))
+        keep = rows >= 0
+        S[rows[keep], cols[keep]] = out.data[keep]
     # Λ⁻¹ is symmetric; the solves are not bitwise so average the halves.
     return cast(NDArray[np.float64], 0.5 * (S + S.T))
 
@@ -206,4 +217,4 @@ def build(
     if accept is not None and not accept(int(support.size)):
         return None
     S = support_covariance(factor, support, n_features)
-    return SupportDraw(_factorize(S), _compact_columns(Xc, support))
+    return SupportDraw(_factorize(S), compact_columns(Xc, support))

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -9,6 +9,8 @@ package, so import these as ``from tests._helpers import ...``.
 import numpy as np
 import scipy.sparse as sp
 
+from bayesianbandits import NormalRegressor
+
 
 def symmetrize(A) -> np.ndarray:
     """Mirror the upper triangle to the lower, producing a full symmetric
@@ -31,3 +33,27 @@ def cov_inv_dense(est) -> np.ndarray:
     if sp.issparse(est.cov_inv_):
         return est.cov_inv_.toarray()
     return symmetrize(est.cov_inv_)
+
+
+def fit_dense(cls=NormalRegressor, d=40, rows=200, seed=0, **kwargs) -> tuple:
+    """Fit an estimator on random dense data; returns ``(est, rng)``."""
+    rng = np.random.default_rng(seed)
+    if cls is NormalRegressor:
+        kwargs.setdefault("alpha", 1.0)
+        kwargs.setdefault("beta", 1.0)
+    est = cls(**kwargs)
+    X_train = rng.standard_normal((rows, d))
+    y = X_train @ rng.standard_normal(d) + rng.standard_normal(rows)
+    est.fit(X_train, y)
+    return est, rng
+
+
+def fit_sparse(d=400, rows=300, seed=0, **kwargs):
+    """Fit a sparse NormalRegressor on random data; returns ``(est, rng)``."""
+    rng = np.random.default_rng(seed)
+    est = NormalRegressor(alpha=1.0, beta=1.0, sparse=True, **kwargs)
+    X_train = sp.csc_array(
+        sp.random(rows, d, density=10 / d, random_state=1)  # type: ignore[call-arg]
+    )
+    est.fit(X_train, rng.standard_normal(rows))
+    return est, rng

--- a/tests/test_blas_helpers.py
+++ b/tests/test_blas_helpers.py
@@ -1,16 +1,12 @@
-"""Unit checks for ``lower_predictive_sqrt`` (including the zero padding a
-rank-deficient ``B`` needs) and ``affine_lower_factor``. The rest of the
-module is layout plumbing that the estimator-level identity checks cover.
+"""Unit check for ``lower_predictive_sqrt``, including the zero padding a
+rank-deficient ``B`` needs. The rest of the module is layout plumbing that
+the estimator-level identity checks cover.
 """
 
 import numpy as np
 import pytest
 
-from bayesianbandits._blas_helpers import (
-    affine_lower_factor,
-    lower_predictive_sqrt,
-    standard_normal_f,
-)
+from bayesianbandits._blas_helpers import lower_predictive_sqrt
 
 
 @pytest.mark.parametrize(
@@ -27,24 +23,3 @@ def test_reproduces_the_gram_matrix(n_features: int, n_rows: int):
     assert L.shape == (n_rows, n_rows)
     np.testing.assert_allclose(L @ L.T, B.T @ B, atol=1e-12)
     np.testing.assert_allclose(L, np.tril(L), atol=1e-15)
-
-
-def test_exact_for_duplicated_rows():
-    """Repeated prediction rows make ``Bᵀ B`` singular; the QR route
-    represents that exactly where a Cholesky would fail."""
-    rng = np.random.default_rng(2)
-    col = rng.standard_normal((6, 1))
-    B = np.hstack([col, col, rng.standard_normal((6, 1))])
-    L = lower_predictive_sqrt(B.copy(), 3)
-    np.testing.assert_allclose(L @ L.T, B.T @ B, atol=1e-12)
-
-
-def test_affine_lower_factor_matches_the_unfused_expression():
-    """The draw step: ``mean + z @ Lᵀ``, fused into one dgemm."""
-    rng = np.random.default_rng(6)
-    mean = rng.standard_normal(4)
-    z = standard_normal_f(rng, 9, 4)
-    L = np.tril(rng.standard_normal((4, 4)))
-    np.testing.assert_allclose(
-        affine_lower_factor(mean, z, L), mean + z @ L.T, atol=1e-13
-    )

--- a/tests/test_blas_helpers.py
+++ b/tests/test_blas_helpers.py
@@ -1,0 +1,55 @@
+"""Unit checks for the two BLAS wrappers that carry real logic.
+
+``lower_predictive_sqrt`` builds the square root the whole reduction
+rests on, including the zero padding a rank-deficient ``B`` needs, and
+``affine_lower_factor`` applies it to normals. The rest of the module is
+layout and dispatch plumbing whose only contract is that it agrees with
+the obvious numpy spelling, which the estimator-level identity checks
+already exercise.
+"""
+
+import numpy as np
+import pytest
+
+from bayesianbandits._blas_helpers import (
+    affine_lower_factor,
+    lower_predictive_sqrt,
+    standard_normal_f,
+)
+
+
+@pytest.mark.parametrize(
+    ("n_features", "n_rows"),
+    [(10, 1), (10, 4), (10, 10), (4, 10), (1, 3)],
+    ids=["single-row", "tall", "square", "wide", "degenerate"],
+)
+def test_reproduces_the_gram_matrix(n_features: int, n_rows: int):
+    """``L Lᵀ = Bᵀ B`` exactly, including when ``B`` has fewer rows than
+    columns and ``L`` must be zero-padded."""
+    rng = np.random.default_rng(0)
+    B = rng.standard_normal((n_features, n_rows))
+    L = lower_predictive_sqrt(B.copy(), n_rows)
+    assert L.shape == (n_rows, n_rows)
+    np.testing.assert_allclose(L @ L.T, B.T @ B, atol=1e-12)
+    np.testing.assert_allclose(L, np.tril(L), atol=1e-15)
+
+
+def test_exact_for_duplicated_rows():
+    """Repeated prediction rows make ``Bᵀ B`` singular; the QR route
+    represents that exactly where a Cholesky would fail."""
+    rng = np.random.default_rng(2)
+    col = rng.standard_normal((6, 1))
+    B = np.hstack([col, col, rng.standard_normal((6, 1))])
+    L = lower_predictive_sqrt(B.copy(), 3)
+    np.testing.assert_allclose(L @ L.T, B.T @ B, atol=1e-12)
+
+
+def test_affine_lower_factor_matches_the_unfused_expression():
+    """The draw step: ``mean + z @ Lᵀ``, fused into one dgemm."""
+    rng = np.random.default_rng(6)
+    mean = rng.standard_normal(4)
+    z = standard_normal_f(rng, 9, 4)
+    L = np.tril(rng.standard_normal((4, 4)))
+    np.testing.assert_allclose(
+        affine_lower_factor(mean, z, L), mean + z @ L.T, atol=1e-13
+    )

--- a/tests/test_blas_helpers.py
+++ b/tests/test_blas_helpers.py
@@ -1,11 +1,6 @@
-"""Unit checks for the two BLAS wrappers that carry real logic.
-
-``lower_predictive_sqrt`` builds the square root the whole reduction
-rests on, including the zero padding a rank-deficient ``B`` needs, and
-``affine_lower_factor`` applies it to normals. The rest of the module is
-layout and dispatch plumbing whose only contract is that it agrees with
-the obvious numpy spelling, which the estimator-level identity checks
-already exercise.
+"""Unit checks for ``lower_predictive_sqrt`` (including the zero padding a
+rank-deficient ``B`` needs) and ``affine_lower_factor``. The rest of the
+module is layout plumbing that the estimator-level identity checks cover.
 """
 
 import numpy as np

--- a/tests/test_empirical_bayes.py
+++ b/tests/test_empirical_bayes.py
@@ -13,8 +13,6 @@ from bayesianbandits._empirical_bayes import (
     _diagonal_trace_approx,
     _dirichlet_multinomial_log_evidence,
     _factorization_stats,
-    _takahashi_diagonal,
-    _takahashi_trace,
     accumulate_sufficient_stats,
     mackay_update_glm,
     mackay_update_nig,
@@ -26,6 +24,7 @@ from bayesianbandits._sparse_bayesian_linear_regression import (
     DenseFactor,
     create_sparse_factor,
     scale_factor,
+    takahashi_diagonal,
 )
 
 # ---------------------------------------------------------------------------
@@ -209,11 +208,11 @@ def small_spd_matrix() -> NDArray[np.float64]:
 
 
 # ---------------------------------------------------------------------------
-# 1. ScaledSparseFactor logdet
+# 1. Scaled factor logdet
 # ---------------------------------------------------------------------------
 
 
-class TestScaledSparseFactorLogdet:
+class TestScaledFactorLogdet:
     def test_scaled_logdet(self, small_spd_matrix: NDArray[np.float64]) -> None:
         """Verify log|sP| = p·log(s) + log|P|."""
         scale = 3.7
@@ -249,7 +248,7 @@ class TestTakahashiDiagonal:
 
         L_dense = np.linalg.cholesky(M)
         L_csc = csc_array(L_dense)
-        result_diag = _takahashi_diagonal(L_csc)
+        result_diag = takahashi_diagonal(L_csc)
 
         np.testing.assert_allclose(result_diag, expected_diag, atol=1e-10)
 
@@ -265,7 +264,7 @@ class TestTakahashiDiagonal:
 
         L_dense = np.linalg.cholesky(M_dense)
         L_csc = csc_array(L_dense)
-        result_diag = _takahashi_diagonal(L_csc)
+        result_diag = takahashi_diagonal(L_csc)
 
         np.testing.assert_allclose(result_diag, expected_diag, atol=1e-10)
 
@@ -274,7 +273,7 @@ class TestTakahashiDiagonal:
         """Takahashi on identity without SparseFactor: diag(I⁻¹) = ones."""
         p = 10
         L_csc = csc_array(np.eye(p))
-        result_diag = _takahashi_diagonal(L_csc)
+        result_diag = takahashi_diagonal(L_csc)
         np.testing.assert_allclose(result_diag, np.ones(p), atol=1e-14)
 
     def test_sparse_spd_cholmod_or_superlu(self) -> None:
@@ -289,7 +288,7 @@ class TestTakahashiDiagonal:
 
         sparse_M = csc_array(M)
         factor = create_sparse_factor(sparse_M)
-        result_trace = _takahashi_trace(factor)
+        result_trace = factor.trace_inv()
 
         np.testing.assert_allclose(result_trace, expected_trace, atol=1e-10)
 
@@ -305,7 +304,7 @@ class TestTakahashiDiagonal:
         sparse_M = csc_array(M_dense)
         factor = create_sparse_factor(sparse_M)
         L = factor.get_L_csc()
-        result_diag = _takahashi_diagonal(L)
+        result_diag = takahashi_diagonal(L)
 
         # Trace is permutation-invariant, so compare sorted diagonals
         np.testing.assert_allclose(
@@ -313,7 +312,7 @@ class TestTakahashiDiagonal:
         )
 
     def test_scaled_sparse_factor(self) -> None:
-        """Takahashi trace through ScaledSparseFactor."""
+        """Takahashi trace through a scaled factor."""
         rng = np.random.default_rng(99)
         p = 5
         A = rng.standard_normal((p, p))
@@ -325,7 +324,7 @@ class TestTakahashiDiagonal:
         sparse_M = csc_array(M)
         factor = create_sparse_factor(sparse_M)
         scaled = scale_factor(factor, s)
-        result_trace = _takahashi_trace(scaled)
+        result_trace = scaled.trace_inv()
 
         np.testing.assert_allclose(result_trace, expected_trace, atol=1e-10)
 
@@ -335,7 +334,7 @@ class TestTakahashiDiagonal:
         M = csc_array(np.eye(p))
         factor = create_sparse_factor(M)
         L = factor.get_L_csc()
-        result_diag = _takahashi_diagonal(L)
+        result_diag = takahashi_diagonal(L)
         np.testing.assert_allclose(result_diag, np.ones(p), atol=1e-14)
 
 

--- a/tests/test_joint_reduction.py
+++ b/tests/test_joint_reduction.py
@@ -46,9 +46,7 @@ def _sparse_X(rng, n_rows, d, nnz_per_row=20, n_distinct=None):
 
 
 def _route(est, X, size, d):
-    return build_joint_reduction(
-        est._precision_factor, X, d, size, est.sparse, est._precision_nnz
-    )
+    return build_joint_reduction(est._precision_factor, X, d, size, est.sparse)
 
 
 class TestRouteSelection:

--- a/tests/test_joint_reduction.py
+++ b/tests/test_joint_reduction.py
@@ -1,9 +1,8 @@
-"""The one decision: which reduction of ``Cov(Xw)`` a joint draw uses.
+"""Which reduction of ``Cov(Xw)`` a joint draw uses.
 
-Picking the wrong route is a performance bug, not a correctness one, so
-the decision table below is deliberately compact. The correctness
-property that does matter is that declining leaves the draw bit-for-bit
-unchanged, which is what keeps seeded Thompson sampling stable.
+A wrong route is a performance bug, not a correctness one, so the
+decision table is compact. What must hold exactly is that declining
+leaves the draw bit-for-bit unchanged (seeded Thompson sampling).
 """
 
 from unittest import mock

--- a/tests/test_joint_reduction.py
+++ b/tests/test_joint_reduction.py
@@ -1,0 +1,92 @@
+"""The one decision: which reduction of ``Cov(Xw)`` a joint draw uses.
+
+Picking the wrong route is a performance bug, not a correctness one, so
+the decision table below is deliberately compact. The correctness
+property that does matter is that declining leaves the draw bit-for-bit
+unchanged, which is what keeps seeded Thompson sampling stable.
+"""
+
+from unittest import mock
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+from bayesianbandits import NormalRegressor
+from bayesianbandits import _estimators as E
+from bayesianbandits._estimators import _RowSpaceDraw, build_joint_reduction
+from bayesianbandits._support_covariance import SupportDraw
+
+
+def _fit_dense(d, rows=None, seed=0):
+    rng = np.random.default_rng(seed)
+    est = NormalRegressor(alpha=1.0, beta=1.0, random_state=0)
+    n = rows or max(300, d // 2)
+    est.fit(rng.standard_normal((n, d)), rng.standard_normal(n))
+    return est, rng
+
+
+def _fit_sparse(d=20_000, nnz_per_row=20, rows=500, seed=0):
+    rng = np.random.default_rng(seed)
+    est = NormalRegressor(alpha=1.0, beta=1.0, random_state=0, sparse=True)
+    r = np.repeat(np.arange(rows), nnz_per_row)
+    c = rng.integers(0, d, size=r.size)
+    X = sp.csc_array((rng.standard_normal(r.size), (r, c)), shape=(rows, d))
+    est.fit(X, rng.standard_normal(rows))
+    return est, rng, d
+
+
+def _sparse_X(rng, n_rows, d, nnz_per_row=20, n_distinct=None):
+    cols = (
+        rng.integers(0, d, size=n_rows * nnz_per_row)
+        if n_distinct is None
+        else rng.choice(n_distinct, size=n_rows * nnz_per_row)
+    )
+    r = np.repeat(np.arange(n_rows), nnz_per_row)
+    return sp.csc_array((rng.standard_normal(r.size), (r, cols)), shape=(n_rows, d))
+
+
+def _route(est, X, size, d):
+    return build_joint_reduction(
+        est._precision_factor, X, d, size, est.sparse, est._precision_nnz
+    )
+
+
+class TestRouteSelection:
+    """``min(size, n_rows, |U|)`` and nothing else."""
+
+    def test_dense_decision_table(self):
+        est, rng = _fit_dense(1000)
+        # size=1 costs one solve, which no reduction can beat
+        assert _route(est, rng.standard_normal((10, 1000)), 1, 1000) is None
+        # few rows, many draws: the row side wins
+        assert isinstance(
+            _route(est, rng.standard_normal((10, 1000)), 1000, 1000), _RowSpaceDraw
+        )
+        # at n ~ d the row side does comparable work in many small calls
+        small, rng2 = _fit_dense(100)
+        assert _route(small, rng2.standard_normal((96, 100)), 10_000, 100) is None
+
+    def test_sparse_picks_the_smaller_of_the_two_reductions(self):
+        est, rng, d = _fit_sparse()
+        wide = _sparse_X(rng, n_rows=4, d=d)  # |U| ~ 80 > n_rows 4
+        narrow = _sparse_X(rng, n_rows=200, d=d, n_distinct=40)  # |U| ~ 40 < 200
+        assert isinstance(_route(est, wide, 5000, d), _RowSpaceDraw)
+        assert isinstance(_route(est, narrow, 5000, d), SupportDraw)
+
+
+class TestDeclineIsExactlyWeightSpace:
+    @pytest.mark.parametrize(
+        ("d", "n_rows", "size"), [(1000, 96, 1), (1000, 96, 100), (1000, 320, 1)]
+    )
+    def test_declined_draws_are_bit_for_bit_unchanged(self, d, n_rows, size):
+        est, rng = _fit_dense(d)
+        X = rng.standard_normal((n_rows, d))
+        assert _route(est, X, size, d) is None
+
+        est.random_state_ = np.random.default_rng(5)
+        routed = est.sample(X, size=size)
+        with mock.patch.object(E, "build_joint_reduction", return_value=None):
+            est.random_state_ = np.random.default_rng(5)
+            weight = est.sample(X, size=size)
+        assert np.array_equal(routed, weight)

--- a/tests/test_marginal_sampling.py
+++ b/tests/test_marginal_sampling.py
@@ -102,7 +102,7 @@ class TestMarginalSd:
         )
 
     def test_sparse_after_decay_uses_scaled_factor(self, sparse_solver):
-        """decay wraps the sparse factor in ScaledSparseFactor; the
+        """decay scales the cached sparse factor in place of refactoring; the
         marginal sd must solve through the scaling."""
         est, rng = _fit_sparse()
         X = sp.csc_array(

--- a/tests/test_mathematical_correctness.py
+++ b/tests/test_mathematical_correctness.py
@@ -375,7 +375,11 @@ class TestNormalInverseGammaRegressorMath:
         # Kurtosis is a weak-power check here (its estimator for t(7) has
         # infinite variance); the KS test against the exact Student t in
         # tests/test_marginal_sampling.py carries the tail-shape power.
-        assert_allclose(kurtosis(samples), expected_kurtosis, atol=0.2)
+        # The tolerance has to reflect that: measured across 12 seeds at
+        # this sample size the estimate has sd ~0.26, so atol=0.8 is
+        # roughly 3 sd. A tighter bound is seed-luck, not power -- at
+        # atol=0.2 this assertion failed for 5 of those 12 seeds.
+        assert_allclose(kurtosis(samples), expected_kurtosis, atol=0.8)
 
 
 # ===========================================================================

--- a/tests/test_mathematical_correctness.py
+++ b/tests/test_mathematical_correctness.py
@@ -375,10 +375,8 @@ class TestNormalInverseGammaRegressorMath:
         # Kurtosis is a weak-power check here (its estimator for t(7) has
         # infinite variance); the KS test against the exact Student t in
         # tests/test_marginal_sampling.py carries the tail-shape power.
-        # The tolerance has to reflect that: measured across 12 seeds at
-        # this sample size the estimate has sd ~0.26, so atol=0.8 is
-        # roughly 3 sd. A tighter bound is seed-luck, not power -- at
-        # atol=0.2 this assertion failed for 5 of those 12 seeds.
+        # The estimate has sd ~0.26 across seeds at this sample size, so
+        # atol=0.8 is ~3 sd; atol=0.2 failed 5 of 12 seeds.
         assert_allclose(kurtosis(samples), expected_kurtosis, atol=0.8)
 
 

--- a/tests/test_normal_estimators.py
+++ b/tests/test_normal_estimators.py
@@ -1529,11 +1529,12 @@ def test_normal_inverse_gamma_regressor_variance_update_with_weights(
 
 
 @pytest.mark.parametrize("sparse", [True, False])
-def test_normal_inverse_gamma_scaled_factor_colorize(sparse: bool) -> None:
-    """Test that NIG sampling uses ScaledSparseFactor.colorize.
+def test_normal_inverse_gamma_scaled_factor_sample(sparse: bool) -> None:
+    """NIG sampling draws through the scaled shape factor.
 
-    After fit, shape_ calls scale_factor(_factor, a_/b_), producing a
-    ScaledSparseFactor. Sampling then calls colorize on it.
+    After fit, shape_ is scale_factor(_precision_factor, a_/b_): the same
+    factorization with the scale composed in. Sampling calls sample_at
+    on it.
     """
     X, y = make_regression(n_samples=50, n_features=3, noise=1.0, random_state=0)
 
@@ -1545,8 +1546,9 @@ def test_normal_inverse_gamma_scaled_factor_colorize(sparse: bool) -> None:
 
     reg.fit(X_fit, y)
 
-    # a_/b_ != 1.0 after fit, so scale_factor creates a ScaledSparseFactor
+    # a_/b_ != 1.0 after fit, so shape_ carries a real scale
     assert reg.a_ / reg.b_ != 1.0
+    assert reg.shape_._scale != 1.0
 
     samples = reg.sample(X_fit, size=5)
     assert samples.shape == (5, 50)
@@ -1555,16 +1557,13 @@ def test_normal_inverse_gamma_scaled_factor_colorize(sparse: bool) -> None:
 
 @pytest.mark.parametrize("sparse", [True, False])
 def test_normal_inverse_gamma_scaled_factor_solve(sparse: bool) -> None:
-    """Test that ScaledSparseFactor.solve produces correct results.
-
-    solve is not called on ScaledSparseFactor in current production paths
-    (only colorize is used during sampling), so we test it directly by
-    comparing against a freshly factored scaled precision matrix.
-    """
-    if not sparse:
-        pytest.skip("ScaledSparseFactor only applies to sparse mode")
+    """A scaled factor solves, half-solves and reports logdet / trace_inv
+    as a fresh factorization of the scaled precision would, dense and
+    sparse alike -- one factorization, the scale composed in."""
+    from scipy.linalg import cho_factor
 
     from bayesianbandits._sparse_bayesian_linear_regression import (
+        DenseFactor,
         create_sparse_factor,
         scale_factor,
     )
@@ -1572,23 +1571,31 @@ def test_normal_inverse_gamma_scaled_factor_solve(sparse: bool) -> None:
     X, y = make_regression(n_samples=50, n_features=3, noise=1.0, random_state=0)
 
     reg = NormalInverseGammaRegressor(sparse=sparse, random_state=42)
-    reg.fit(sp.csc_array(X), y)
+    reg.fit(sp.csc_array(X) if sparse else X, y)
 
     scale = float(reg.a_ / reg.b_)
     scaled_factor = scale_factor(reg._precision_factor, scale)
 
     # Compare against direct factorization of the scaled precision
-    direct_factor = create_sparse_factor(reg.cov_inv_ * scale)
+    if sparse:
+        direct_factor = create_sparse_factor(reg.cov_inv_ * scale)
+    else:
+        U = cho_factor(reg.cov_inv_ * scale, lower=False, check_finite=False)[0]
+        direct_factor = DenseFactor(_U=U, _n_features=3)
 
     b = np.random.default_rng(0).standard_normal(3)
     assert_almost_equal(scaled_factor.solve(b), direct_factor.solve(b))
+    B = np.random.default_rng(1).standard_normal((3, 4))
+    hs, hd = scaled_factor.half_solve(B), direct_factor.half_solve(B)
+    assert_almost_equal(hs.T @ hs, hd.T @ hd)
+    assert_almost_equal(scaled_factor.logdet(), direct_factor.logdet())
+    assert_almost_equal(scaled_factor.trace_inv(), direct_factor.trace_inv())
 
 
 @pytest.mark.parametrize("sparse", [True, False])
 def test_normal_inverse_gamma_decay_then_sample(sparse: bool) -> None:
-    """Test ScaledSparseFactor composition: decay scales _factor, then sample
-    scales again via shape_, exercising the isinstance(factor, ScaledSparseFactor)
-    branch in scale_factor.
+    """Scales compose: decay scales the cached factor, then shape_ scales
+    it again for sampling; both ride on the one factorization.
     """
     X, y = make_regression(n_samples=50, n_features=3, noise=1.0, random_state=0)
 
@@ -1603,8 +1610,9 @@ def test_normal_inverse_gamma_decay_then_sample(sparse: bool) -> None:
     reg.fit(X_fit, y)
     pre_decay_pred = reg.predict(X_fit)
 
-    # Decay scales _factor by prior_decay (0.95^50), creating a ScaledSparseFactor
+    # Decay scales the cached factor by prior_decay (0.95^50)
     reg.decay(X_fit)
+    assert reg._precision_factor._scale == pytest.approx(0.95**50)
 
     # Predictions should be unchanged (decay only widens variance)
     assert_almost_equal(reg.predict(X_fit), pre_decay_pred)
@@ -1619,18 +1627,15 @@ def test_normal_inverse_gamma_decay_then_sample(sparse: bool) -> None:
 @pytest.mark.parametrize("sparse", [True, False])
 def test_normal_inverse_gamma_scale_factor_identity(sparse: bool) -> None:
     """Test scale_factor early return when scale == 1.0."""
-    if not sparse:
-        pytest.skip("ScaledSparseFactor only applies to sparse mode")
-
     X, y = make_regression(n_samples=50, n_features=3, noise=1.0, random_state=0)
 
     reg = NormalInverseGammaRegressor(sparse=sparse, random_state=42, learning_rate=1.0)
-    reg.fit(sp.csc_array(X), y)
+    reg.fit(sp.csc_array(X) if sparse else X, y)
 
     original_factor = reg._precision_factor
 
     # learning_rate=1.0 means prior_decay = 1.0^N = 1.0, so scale_factor
     # should return the original factor unchanged
-    reg.decay(sp.csc_array(X))
+    reg.decay(sp.csc_array(X) if sparse else X)
 
     assert reg._precision_factor is original_factor

--- a/tests/test_partitioned_factor.py
+++ b/tests/test_partitioned_factor.py
@@ -300,28 +300,6 @@ def test_refactorize_follows_the_new_matrix():
 # -- the property that made this worth doing ---------------------------------
 
 
-def test_never_observed_feature_is_shared_across_the_rows_that_touch_it():
-    """Through the estimator: rows reading the same never-observed
-    feature draw the same value, and a row reading twice as much of it
-    draws exactly twice as much. (Its variance is pinned by the stacked
-    contexts test below, through the full covariance.)"""
-    rng = np.random.default_rng(14)
-    p = 50
-    X = sp.csc_array(sp.random(30, p, density=0.1, random_state=14))
-    X = sp.csc_array(X[:, :10].toarray() @ np.eye(10, p))  # touches only 0..9
-    est = NormalRegressor(alpha=1.0, beta=1.0, sparse=True, random_state=0)
-    est.fit(X, rng.standard_normal(30))
-    j = 37  # never observed
-    assert j in trivial_columns(est.cov_inv_)
-
-    Xp = sp.csc_array(
-        sp.csr_array(([1.0, 1.0, 2.0], ([0, 1, 2], [j, j, j])), shape=(3, p))
-    )
-    draws = est.sample(Xp, size=1)[0]
-    assert draws[0] == draws[1]
-    assert draws[2] == 2.0 * draws[0]
-
-
 # -- stacked contexts ---------------------------------------------------------
 
 
@@ -464,12 +442,10 @@ def test_half_solve_sparse_rhs_splits_with_the_same_gram(m):
         assert_allclose(B.block, factor.half_solve(b.toarray()), rtol=1e-12)
 
 
-def test_marginal_sd_over_both_routes_matches_dense_truth():
-    """The marginal path over a partitioned factor, both ways: the
-    chunked half-solve (support route gated off, block budget forced
-    small so many chunks run, each handing the factor a sparse block of
-    rows), and the support route (many rows over few columns, some of
-    them never observed, so it fires and solves over the split)."""
+def test_marginal_sd_chunks_the_half_solve_over_the_block():
+    """The marginal path over a partitioned factor with the block budget
+    forced small: many chunks, each handing the factor a sparse block of
+    rows, and the result is dense truth."""
     from unittest import mock
 
     from bayesianbandits import _estimators as E
@@ -478,7 +454,7 @@ def test_marginal_sd_over_both_routes_matches_dense_truth():
 
     rng = np.random.default_rng(45)
     p = 80
-    precision, observed = make_precision(p, 32, rng)
+    precision, _ = make_precision(p, 32, rng)
     factor = create_sparse_factor(precision)
     inv = dense_inverse(precision)
 
@@ -496,22 +472,6 @@ def test_marginal_sd_over_both_routes_matches_dense_truth():
             got = _marginal_predictive_sd(factor, X)
     assert_allclose(got, np.sqrt(np.einsum("ij,jk,ik->i", Xd, inv, Xd)), rtol=1e-10)
     assert len(seen) == 13 and max(seen) == 3  # 37 rows in blocks of 3
-
-    cols = np.concatenate([observed[:5], np.setdiff1d(np.arange(p), observed)[:2]])
-    rows_, cols_, vals_ = [], [], []
-    for i in range(120):
-        for j in rng.choice(cols, 3, replace=False):
-            rows_.append(i)
-            cols_.append(j)
-            vals_.append(rng.standard_normal())
-    X = sp.csc_array(sp.csr_array((vals_, (rows_, cols_)), shape=(120, p)))
-    Xd = X.toarray()
-    with mock.patch.object(
-        sc, "support_covariance", wraps=sc.support_covariance
-    ) as sc_:
-        got = _marginal_predictive_sd(factor, X)
-    sc_.assert_called_once()
-    assert_allclose(got, np.sqrt(np.einsum("ij,jk,ik->i", Xd, inv, Xd)), rtol=1e-10)
 
 
 def test_a_feature_seen_alone_stays_trivial_and_seen_together_joins_the_block():

--- a/tests/test_partitioned_factor.py
+++ b/tests/test_partitioned_factor.py
@@ -1,0 +1,576 @@
+"""Tests for the observed / never-observed partition inside the sparse factors.
+
+``Λ = αI + Σ x_t x_tᵀ`` is exactly block diagonal between the features
+some ``x_t`` has touched and the ones none has: a never-observed feature
+stores only its diagonal, so it is an independent scalar and needs no
+factorization. The factors partition on that structure and factor only
+the observed block. Everything here checks the partitioned factor against
+dense linear algebra on the full matrix, so the partition has to be
+invisible to every caller of the factor protocol.
+"""
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+from numpy.testing import assert_allclose, assert_array_equal
+
+from bayesianbandits import NormalRegressor
+from bayesianbandits._sparse_bayesian_linear_regression import (
+    create_sparse_factor,
+    scale_factor,
+    takahashi_diagonal,
+    trivial_columns,
+)
+
+
+@pytest.fixture(autouse=True)
+def suitesparse_envvar(sparse_solver):
+    """Run every test in this module against both sparse backends."""
+    yield
+
+
+def make_precision(p, m, rng, block=4):
+    """SPD precision over ``p`` features of which ``m`` (a random subset)
+    are coupled in ``block``-sized groups; the rest carry only a
+    diagonal, with distinct values so per-entry scaling is exercised."""
+    m -= m % block
+    observed = np.sort(rng.choice(p, m, replace=False))
+    A = rng.standard_normal((m // block, block, block))
+    B = np.einsum("nij,nkj->nik", A, A) + block * np.eye(block)
+    grid = observed.reshape(-1, block)
+    r = np.repeat(grid[:, :, None], block, axis=2)
+    core = sp.coo_array(
+        (B.ravel(), (r.ravel(), r.transpose(0, 2, 1).ravel())), shape=(p, p)
+    )
+    diag = sp.diags(rng.uniform(1.0, 3.0, p))
+    return sp.csc_array(core + diag), observed
+
+
+def dense_inverse(precision):
+    return np.linalg.inv(precision.toarray())
+
+
+# -- detection ---------------------------------------------------------------
+
+
+def test_trivial_columns_are_exactly_the_uncoupled_ones():
+    rng = np.random.default_rng(0)
+    p = 60
+    precision, observed = make_precision(p, 24, rng)
+    expected = np.setdiff1d(np.arange(p), observed)
+    assert_array_equal(trivial_columns(precision), expected)
+
+
+def test_explicit_zero_off_diagonal_keeps_a_column_in_the_block():
+    """A stored zero is structure as far as the pattern knows; erring
+    toward the block costs speed, never correctness."""
+    rng = np.random.default_rng(1)
+    p = 30
+    precision, observed = make_precision(p, 12, rng)
+    j = np.setdiff1d(np.arange(p), observed)[0]
+    k = observed[0]
+    coo = sp.coo_array(precision)
+    coo = sp.coo_array(
+        (
+            np.append(coo.data, [0.0, 0.0]),
+            (np.append(coo.row, [j, k]), np.append(coo.col, [k, j])),
+        ),
+        shape=(p, p),
+    )
+    with_zero = sp.csc_array(coo)
+    assert with_zero.nnz == precision.nnz + 2
+    assert j not in trivial_columns(with_zero)
+
+
+def test_triangular_storage_is_never_partitioned():
+    """In upper-only storage a coupled column can hold just its diagonal;
+    the pattern check must see the coupling from the other side."""
+    p = 20
+    off = np.full(p - 1, -0.3)
+    tri = sp.diags([off, np.full(p, 2.0), off], [-1, 0, 1])
+    upper = sp.csc_array(sp.triu(tri))
+    assert (upper.indptr[1:] - upper.indptr[:-1] == 1).any()  # looks trivial
+    assert trivial_columns(upper).size == 0
+
+
+def test_nonpositive_trivial_diagonal_is_not_partitioned():
+    """Leave the non-SPD error behaviour to the backends, unchanged."""
+    p = 10
+    d = np.full(p, 2.0)
+    d[3] = -1.0
+    precision = sp.csc_array(sp.diags(d))
+    assert 3 not in trivial_columns(precision)
+
+
+# -- the protocol against dense truth ----------------------------------------
+
+
+@pytest.mark.parametrize("m", [24, 0, 60])
+def test_solve_matches_the_dense_inverse(m):
+    """m=24: partitioned; m=0: all trivial; m=60: nothing trivial."""
+    rng = np.random.default_rng(2)
+    p = 60
+    precision, _ = make_precision(p, m, rng)
+    factor = create_sparse_factor(precision)
+    inv = dense_inverse(precision)
+
+    b = rng.standard_normal(p)
+    assert_allclose(factor.solve(b), inv @ b, rtol=1e-10)
+    B = rng.standard_normal((p, 5))
+    assert_allclose(factor.solve(B), inv @ B, rtol=1e-10)
+
+
+@pytest.mark.parametrize("m", [24, 60])
+@pytest.mark.parametrize(
+    "fmt,index_dtype", [("csc", np.int32), ("csc", np.int64), ("csr", np.int32)]
+)
+def test_solve_with_a_sparse_rhs_matches_dense(m, fmt, index_dtype):
+    """A sparse right-hand side comes back sparse and correct, whatever
+    its format or index dtype: the backends never see it, so an
+    int64-indexed operand against an int32 factor cannot be misread
+    (which CHOLMOD's own sparse solve does silently), and the RVGA Gram
+    matrix's CSR ``Xᵀ`` is fine. Columns hit observed and never-observed
+    rows both."""
+    rng = np.random.default_rng(21)
+    p = 60
+    precision, observed = make_precision(p, m, rng)
+    factor = create_sparse_factor(precision)
+    unobserved = np.setdiff1d(np.arange(p), observed)
+    rows = (
+        np.concatenate([observed[:3], unobserved[:2]])
+        if unobserved.size
+        else observed[:5]
+    )
+    B = sp.csc_array(
+        (np.ones(rows.size), (rows, np.arange(rows.size))), shape=(p, rows.size)
+    )
+    B = sp.csc_array(
+        (B.data, B.indices.astype(index_dtype), B.indptr.astype(index_dtype)),
+        shape=B.shape,
+    )
+    B = B.tocsr() if fmt == "csr" else B
+    assert B.indices.dtype == index_dtype
+
+    out = factor.solve(B)
+    assert sp.issparse(out)
+    assert_allclose(out.toarray(), dense_inverse(precision) @ B.toarray(), rtol=1e-10)
+
+
+@pytest.mark.parametrize("dense_X", [False, True])
+def test_half_solve_gram_is_the_predictive_covariance(dense_X):
+    """Both a sparse X (rows outside its support are zero) and a dense X
+    (every row populated, including never-observed features)."""
+    rng = np.random.default_rng(6)
+    p = 48
+    precision, observed = make_precision(p, 20, rng)
+    factor = create_sparse_factor(precision)
+    if dense_X:
+        X = rng.standard_normal((7, p))
+    else:
+        X = sp.csc_array(sp.random(7, p, density=0.15, random_state=6))
+    B = np.asarray(factor.half_solve(np.asarray(X.T.toarray() if not dense_X else X.T)))
+    Xd = X.toarray() if not dense_X else X
+    assert_allclose(B.T @ B, Xd @ dense_inverse(precision) @ Xd.T, atol=1e-10)
+
+
+# -- sample_at ---------------------------------------------------------------
+
+
+def test_sample_at_covariance_is_the_inverse_submatrix():
+    """Mixed observed / never-observed features, unsorted."""
+    rng = np.random.default_rng(7)
+    p = 48
+    precision, observed = make_precision(p, 20, rng)
+    factor = create_sparse_factor(precision)
+    unobserved = np.setdiff1d(np.arange(p), observed)
+    features = np.array([observed[3], unobserved[5], unobserved[0], observed[0]])
+
+    G = factor.sample_at(features, 40_000, np.random.default_rng(0))
+    assert G.shape == (features.size, 40_000)
+    want = dense_inverse(precision)[np.ix_(features, features)]
+    assert_allclose(np.cov(G), want, atol=0.05 * np.abs(want).max())
+
+
+def test_sample_at_none_covers_every_feature():
+    rng = np.random.default_rng(17)
+    p = 30
+    precision, _ = make_precision(p, 12, rng)
+    factor = create_sparse_factor(precision)
+    G = factor.sample_at(None, 40_000, np.random.default_rng(0))
+    assert G.shape == (p, 40_000)
+    want = dense_inverse(precision)
+    assert_allclose(np.cov(G), want, atol=0.05 * np.abs(want).max())
+
+
+def test_sample_at_repeats_a_feature_exactly():
+    """One draw per feature: asking twice returns the same rows, for an
+    observed and a never-observed feature alike."""
+    rng = np.random.default_rng(27)
+    p = 48
+    precision, observed = make_precision(p, 20, rng)
+    factor = create_sparse_factor(precision)
+    j = np.setdiff1d(np.arange(p), observed)[2]
+    k = observed[4]
+    G = factor.sample_at(np.array([j, k, j, k]), 5, np.random.default_rng(0))
+    assert_array_equal(G[0], G[2])
+    assert_array_equal(G[1], G[3])
+
+
+@pytest.mark.parametrize("m", [24, 60])
+def test_sample_at_draws_only_the_normals_it_needs(m):
+    """``n_factored`` for the block plus one per distinct never-observed
+    feature asked for -- and not one per never-observed feature there
+    is: the generator advances by exactly that many. With nothing
+    trivial (``m == p``) that is every feature."""
+    rng = np.random.default_rng(37)
+    p = 60
+    precision, observed = make_precision(p, m, rng)
+    factor = create_sparse_factor(precision)
+    unobserved = np.setdiff1d(np.arange(p), observed)
+    if unobserved.size:
+        features = np.array([observed[1], unobserved[3], unobserved[3], unobserved[9]])
+        distinct_trivial = 2
+    else:
+        features = np.array([3, 1])
+        distinct_trivial = 0
+    size = 7
+
+    used, twin = np.random.default_rng(5), np.random.default_rng(5)
+    factor.sample_at(features, size, used)
+    twin.standard_normal(size * (factor.n_factored + distinct_trivial))
+    assert used.random() == twin.random()
+
+
+def test_logdet_and_trace_inv_match_dense():
+    rng = np.random.default_rng(8)
+    p = 48
+    precision, _ = make_precision(p, 20, rng)
+    factor = create_sparse_factor(precision)
+    _, ld = np.linalg.slogdet(precision.toarray())
+    assert_allclose(factor.logdet(), ld, rtol=1e-10)
+    assert_allclose(factor.trace_inv(), np.trace(dense_inverse(precision)), rtol=1e-10)
+
+
+def test_solve_cost_counts_only_the_block():
+    rng = np.random.default_rng(9)
+    p = 48
+    precision, observed = make_precision(p, 20, rng)
+    factor = create_sparse_factor(precision)
+    n_trivial = p - observed.size
+    assert factor.solve_cost == precision.nnz - n_trivial
+
+
+def test_get_L_csc_factors_a_permutation_of_the_matrix():
+    """``L Lᵀ = P Λ Pᵀ`` for some permutation ``P``: the eigenvalues and
+    the Takahashi trace agree with the full matrix, and the diagonal
+    reproduces the log-determinant."""
+    rng = np.random.default_rng(10)
+    p = 48
+    precision, _ = make_precision(p, 20, rng)
+    factor = create_sparse_factor(precision)
+    L = factor.get_L_csc()
+    LLt = (L @ L.T).toarray()
+    assert_allclose(
+        np.sort(np.linalg.eigvalsh(LLt)),
+        np.sort(np.linalg.eigvalsh(precision.toarray())),
+        rtol=1e-8,
+    )
+    assert_allclose(2.0 * np.sum(np.log(L.diagonal())), factor.logdet(), rtol=1e-10)
+    assert_allclose(np.sum(takahashi_diagonal(L)), factor.trace_inv(), rtol=1e-10)
+
+
+def test_scaled_factor_composes_over_the_partition():
+    rng = np.random.default_rng(11)
+    p = 48
+    precision, _ = make_precision(p, 20, rng)
+    s = 2.5
+    factor = scale_factor(create_sparse_factor(precision), s)
+    inv = dense_inverse(precision) / s
+
+    b = rng.standard_normal(p)
+    assert_allclose(factor.solve(b), inv @ b, rtol=1e-10)
+    Mt = np.asarray(factor.half_solve(np.eye(p)))
+    assert_allclose(Mt.T @ Mt, inv, atol=1e-10)
+    X = sp.csc_array(sp.random(6, p, density=0.2, random_state=44))
+    B = np.asarray(factor.half_solve(X.T))  # sparse rhs, compact result
+    assert_allclose(B.T @ B, X.toarray() @ inv @ X.toarray().T, atol=1e-10)
+    G = factor.sample_at(None, 40_000, np.random.default_rng(0))
+    assert_allclose(np.cov(G), inv, atol=0.05 * np.abs(inv).max())
+    _, ld = np.linalg.slogdet(s * precision.toarray())
+    assert_allclose(factor.logdet(), ld, rtol=1e-10)
+    assert_allclose(factor.trace_inv(), np.trace(inv), rtol=1e-10)
+
+
+# -- refactorization ---------------------------------------------------------
+
+
+def test_refactorize_when_the_observed_set_grows():
+    """A later update couples a feature that was trivial before."""
+    rng = np.random.default_rng(12)
+    p = 40
+    A1, observed = make_precision(p, 16, rng)
+    factor = create_sparse_factor(A1)
+    j = np.setdiff1d(np.arange(p), observed)[0]
+    k = observed[0]
+    A2 = sp.lil_array(A1)
+    A2[j, k] = 0.4
+    A2[k, j] = 0.4
+    A2[j, j] += 1.0
+    A2 = sp.csc_array(A2)
+
+    refactored = factor.refactorize(A2)
+    b = rng.standard_normal(p)
+    assert_allclose(refactored.solve(b), dense_inverse(A2) @ b, rtol=1e-10)
+    assert_allclose(refactored.trace_inv(), np.trace(dense_inverse(A2)), rtol=1e-10)
+
+
+def test_refactorize_with_the_same_observed_set():
+    """New values, same pattern: the trivial diagonal must be re-read."""
+    rng = np.random.default_rng(13)
+    p = 40
+    A1, _ = make_precision(p, 16, rng)
+    factor = create_sparse_factor(A1)
+    A2 = sp.csc_array(A1 * 1.7)  # scales every entry, block and trivial alike
+
+    refactored = factor.refactorize(A2)
+    b = rng.standard_normal(p)
+    assert_allclose(refactored.solve(b), dense_inverse(A2) @ b, rtol=1e-10)
+
+
+# -- the property that made this worth doing ---------------------------------
+
+
+def test_never_observed_feature_is_shared_across_the_rows_that_touch_it():
+    """Through the estimator: rows reading the same never-observed
+    feature draw the same value, and a row reading twice as much of it
+    draws exactly twice as much. (Its variance is pinned by the stacked
+    contexts test below, through the full covariance.)"""
+    rng = np.random.default_rng(14)
+    p = 50
+    X = sp.csc_array(sp.random(30, p, density=0.1, random_state=14))
+    X = sp.csc_array(X[:, :10].toarray() @ np.eye(10, p))  # touches only 0..9
+    est = NormalRegressor(alpha=1.0, beta=1.0, sparse=True, random_state=0)
+    est.fit(X, rng.standard_normal(30))
+    j = 37  # never observed
+    assert j in trivial_columns(est.cov_inv_)
+
+    Xp = sp.csc_array(
+        sp.csr_array(([1.0, 1.0, 2.0], ([0, 1, 2], [j, j, j])), shape=(3, p))
+    )
+    draws = est.sample(Xp, size=1)[0]
+    assert draws[0] == draws[1]
+    assert draws[2] == 2.0 * draws[0]
+
+
+# -- stacked contexts ---------------------------------------------------------
+
+
+def test_stacked_contexts_with_distinct_supports_have_the_right_joint_law():
+    """Several contexts stacked, each over its own features, some of them
+    never observed: a row must get nothing from a feature it does not
+    touch, rows touching one feature must share its draw, and the
+    covariance between contexts must be exactly ``X_a Λ⁻¹ X_bᵀ`` --
+    coupled through observed features, zero through never-observed ones.
+    Checked as the full ``n x n`` covariance of the weight-space draw
+    against dense truth."""
+    from unittest import mock
+
+    from bayesianbandits import _estimators as E
+
+    rng = np.random.default_rng(31)
+    p = 120
+    n_ctx, n_arms = 3, 4
+    # observed: 0..29; everything else never observed
+    X_fit = sp.csc_array(sp.random(50, 30, density=0.3, random_state=31))
+    X_fit = sp.csc_array(sp.hstack([X_fit, sp.csc_array((50, p - 30))]))
+    est = NormalRegressor(alpha=1.0, beta=1.0, sparse=True, random_state=0)
+    est.fit(X_fit, rng.standard_normal(50))
+    trivial = trivial_columns(est.cov_inv_)
+    assert 30 <= trivial.min()
+
+    rows, cols, vals = [], [], []
+    for c in range(n_ctx):
+        # two observed features shared by every context, two of its own,
+        # one never-observed feature of its own, and one never-observed
+        # feature shared by contexts 0 and 1 only
+        own = [0, 1, 10 + 2 * c, 11 + 2 * c, 50 + c] + ([90] if c < 2 else [])
+        for a in range(n_arms):
+            for j in own:
+                rows.append(c * n_arms + a)
+                cols.append(j)
+                vals.append(rng.standard_normal())
+    X = sp.csc_array(sp.csr_array((vals, (rows, cols)), shape=(n_ctx * n_arms, p)))
+
+    # force the weight-space path (the reductions are exact too, but this
+    # is the path under test)
+    with mock.patch.object(E, "build_joint_reduction", return_value=None):
+        est.random_state_ = np.random.default_rng(1)
+        draws = est.sample(X, size=40_000)
+
+    Xd = X.toarray()
+    want = Xd @ np.linalg.inv(est.cov_inv_.toarray()) @ Xd.T
+    assert_allclose(np.cov(draws.T), want, atol=0.05 * np.abs(want).max())
+    assert_allclose(draws.mean(axis=0), Xd @ est.coef_, atol=0.05 * np.abs(want).max())
+
+    # the structure the numbers above must carry: contexts 0 and 1 share
+    # never-observed feature 90, context 2 does not, and a never-observed
+    # feature couples nothing else
+    cov = np.cov(draws.T)
+    inv = np.linalg.inv(est.cov_inv_.toarray())
+    for j in (50, 51, 52, 90):
+        assert inv[j, j] == 1.0 / est.cov_inv_[j, j]
+        assert np.count_nonzero(inv[j]) == 1
+    # so cross-context covariance is the observed-feature part plus, for
+    # contexts 0 and 1 only, feature 90's shared draw
+    x0, x1, x2 = (Xd[c * n_arms : (c + 1) * n_arms] for c in range(n_ctx))
+    obs = np.arange(30)
+    for a, b, share_90 in ((x0, x1, True), (x0, x2, False), (x1, x2, False)):
+        expect = a[:, obs] @ inv[np.ix_(obs, obs)] @ b[:, obs].T
+        if share_90:
+            expect = expect + np.outer(a[:, 90], b[:, 90]) / est.cov_inv_[90, 90]
+        got = cov[
+            np.ix_(
+                range(n_arms * (0 if a is x0 else 1), n_arms * (1 if a is x0 else 2)),
+                range(n_arms * (1 if b is x1 else 2), n_arms * (2 if b is x1 else 3)),
+            )
+        ]
+        assert_allclose(got, expect, atol=0.05 * np.abs(want).max())
+
+
+# -- half_solve with a sparse right-hand side, and n_factored -----------------
+
+
+@pytest.mark.parametrize("m", [24, 60])
+def test_n_factored_is_what_the_factor_factors(m):
+    """The observed block for a sparse factor, unchanged by scaling;
+    every feature for a dense one."""
+    from scipy.linalg import cholesky
+
+    from bayesianbandits._sparse_bayesian_linear_regression import DenseFactor
+
+    rng = np.random.default_rng(41)
+    p = 60
+    precision, observed = make_precision(p, m, rng)
+    factor = create_sparse_factor(precision)
+    assert factor.n_factored == observed.size
+    assert scale_factor(factor, 2.0).n_factored == observed.size
+    U = cholesky(precision.toarray(), lower=False)
+    assert DenseFactor(_U=U, _n_features=p).n_factored == p
+
+
+@pytest.mark.parametrize("m", [24, 60])
+def test_half_solve_sparse_rhs_is_compact_with_the_same_gram(m):
+    """For a sparse ``b`` the result keeps the block rows and one row per
+    distinct never-observed feature ``b`` touches -- nothing else -- and
+    ``Bᵀ B`` is still ``bᵀ Λ⁻¹ b``. With nothing trivial it is the dense
+    half-solve of the same operand."""
+    rng = np.random.default_rng(43)
+    p = 60
+    precision, observed = make_precision(p, m, rng)
+    factor = create_sparse_factor(precision)
+    unobserved = np.setdiff1d(np.arange(p), observed)
+    # 5 columns; two of them share never-observed feature j, one touches
+    # another never-observed feature, the rest observed only
+    X = sp.random(5, p, density=0.15, random_state=43).tolil()
+    X[:, unobserved] = 0.0
+    if unobserved.size:
+        j, k = unobserved[1], unobserved[4]
+        X[0, j] = 0.7
+        X[3, j] = -1.1
+        X[2, k] = 0.4
+    X = sp.csc_array(X)
+    b = X.T  # (p, 5), sparse
+
+    B = np.asarray(factor.half_solve(b))
+    touched = 2 if unobserved.size else 0
+    assert B.shape == (factor.n_factored + touched, 5)
+    Xd = X.toarray()
+    assert_allclose(B.T @ B, Xd @ dense_inverse(precision) @ Xd.T, atol=1e-10)
+    if not unobserved.size:
+        assert_allclose(B, factor.half_solve(b.toarray()), rtol=1e-12)
+
+
+def test_marginal_sd_over_the_half_solve_path_in_several_chunks():
+    """The chunked half-solve path against dense truth, with the support
+    route gated off and the block budget forced small enough that many
+    chunks run, each handing the factor a sparse block of rows."""
+    from unittest import mock
+
+    from bayesianbandits import _estimators as E
+    from bayesianbandits import _support_covariance as sc
+    from bayesianbandits._estimators import _marginal_predictive_sd
+
+    rng = np.random.default_rng(45)
+    p = 80
+    precision, observed = make_precision(p, 32, rng)
+    factor = create_sparse_factor(precision)
+    X = sp.csc_array(sp.random(37, p, density=0.1, random_state=45))
+    Xd = X.toarray()
+    want = np.sqrt(np.einsum("ij,jk,ik->i", Xd, dense_inverse(precision), Xd))
+
+    with (
+        mock.patch.object(sc, "build", lambda *a, **k: None),
+        mock.patch.object(E, "_MARGINAL_SD_BLOCK_ELEMS", 3 * factor.n_factored),
+    ):
+        seen = []
+        real = factor.half_solve
+        with mock.patch.object(
+            factor, "half_solve", lambda b: seen.append(b.shape[1]) or real(b)
+        ):
+            got = _marginal_predictive_sd(factor, X)
+    assert_allclose(got, want, rtol=1e-10)
+    assert len(seen) == 13 and max(seen) == 3  # 37 rows in blocks of 3
+
+
+def test_marginal_sd_over_the_support_route_matches_dense_truth():
+    """Many rows over few columns: the support route fires."""
+    from bayesianbandits._estimators import _marginal_predictive_sd
+
+    rng = np.random.default_rng(46)
+    p = 80
+    precision, observed = make_precision(p, 32, rng)
+    factor = create_sparse_factor(precision)
+    cols = np.concatenate([observed[:5], np.setdiff1d(np.arange(p), observed)[:2]])
+    rows_, cols_, vals_ = [], [], []
+    for i in range(120):
+        for j in rng.choice(cols, 3, replace=False):
+            rows_.append(i)
+            cols_.append(j)
+            vals_.append(rng.standard_normal())
+    X = sp.csc_array(sp.csr_array((vals_, (rows_, cols_)), shape=(120, p)))
+    Xd = X.toarray()
+    want = np.sqrt(np.einsum("ij,jk,ik->i", Xd, dense_inverse(precision), Xd))
+    assert_allclose(_marginal_predictive_sd(factor, X), want, rtol=1e-10)
+
+
+def test_a_feature_seen_alone_stays_trivial_and_seen_together_joins_the_block():
+    """``Λ`` couples two features only when one observation touches
+    both. A feature observed on its own gains a diagonal entry and
+    nothing else, so it stays an independent scalar; observed together
+    with another, it joins the block. The partition follows exactly."""
+    rng = np.random.default_rng(51)
+    p = 40
+    X = sp.csc_array(sp.random(50, 12, density=0.4, random_state=51))
+    X = sp.csc_array(sp.hstack([X, sp.csc_array((50, p - 12))]))
+    est = NormalRegressor(alpha=1.0, beta=1.0, sparse=True, random_state=0)
+    est.fit(X, rng.standard_normal(50))
+    assert trivial_columns(est.cov_inv_).size == p - 12
+
+    alone = sp.csc_array(sp.csr_array(([1.0], ([0], [35])), shape=(1, p)))
+    est.partial_fit(alone, np.array([0.5]))
+    assert 35 in trivial_columns(est.cov_inv_)
+    assert est._precision_factor.n_factored == 12
+
+    together = sp.csc_array(
+        sp.csr_array(([1.0, 1.0], ([0, 0], [30, 31])), shape=(1, p))
+    )
+    est.partial_fit(together, np.array([0.5]))
+    still = trivial_columns(est.cov_inv_)
+    assert 30 not in still and 31 not in still and 35 in still
+    assert est._precision_factor.n_factored == 14
+    b = rng.standard_normal(p)
+    assert_allclose(
+        est._precision_factor.solve(b),
+        np.linalg.solve(est.cov_inv_.toarray(), b),
+        rtol=1e-8,
+    )

--- a/tests/test_partitioned_factor.py
+++ b/tests/test_partitioned_factor.py
@@ -16,6 +16,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 
 from bayesianbandits import NormalRegressor
 from bayesianbandits._sparse_bayesian_linear_regression import (
+    SparseHalfSolve,
     create_sparse_factor,
     scale_factor,
     takahashi_diagonal,
@@ -61,9 +62,13 @@ def test_trivial_columns_are_exactly_the_uncoupled_ones():
     assert_array_equal(trivial_columns(precision), expected)
 
 
-def test_explicit_zero_off_diagonal_keeps_a_column_in_the_block():
-    """A stored zero is structure as far as the pattern knows; erring
-    toward the block costs speed, never correctness."""
+def test_detection_errs_toward_the_block():
+    """Three ways a column can look trivial without being one, or be
+    trivial without being safe to treat so, each left in the block: a
+    stored explicit zero off the diagonal (structure as far as the
+    pattern knows), triangular storage (the coupling sits in the other
+    column), and a non-positive diagonal (left to the backends' non-SPD
+    behaviour, unchanged)."""
     rng = np.random.default_rng(1)
     p = 30
     precision, observed = make_precision(p, 12, rng)
@@ -81,25 +86,14 @@ def test_explicit_zero_off_diagonal_keeps_a_column_in_the_block():
     assert with_zero.nnz == precision.nnz + 2
     assert j not in trivial_columns(with_zero)
 
-
-def test_triangular_storage_is_never_partitioned():
-    """In upper-only storage a coupled column can hold just its diagonal;
-    the pattern check must see the coupling from the other side."""
-    p = 20
-    off = np.full(p - 1, -0.3)
-    tri = sp.diags([off, np.full(p, 2.0), off], [-1, 0, 1])
-    upper = sp.csc_array(sp.triu(tri))
+    off = np.full(19, -0.3)
+    upper = sp.csc_array(sp.triu(sp.diags([off, np.full(20, 2.0), off], [-1, 0, 1])))
     assert (upper.indptr[1:] - upper.indptr[:-1] == 1).any()  # looks trivial
     assert trivial_columns(upper).size == 0
 
-
-def test_nonpositive_trivial_diagonal_is_not_partitioned():
-    """Leave the non-SPD error behaviour to the backends, unchanged."""
-    p = 10
-    d = np.full(p, 2.0)
+    d = np.full(10, 2.0)
     d[3] = -1.0
-    precision = sp.csc_array(sp.diags(d))
-    assert 3 not in trivial_columns(precision)
+    assert 3 not in trivial_columns(sp.csc_array(sp.diags(d)))
 
 
 # -- the protocol against dense truth ----------------------------------------
@@ -156,50 +150,39 @@ def test_solve_with_a_sparse_rhs_matches_dense(m, fmt, index_dtype):
     assert_allclose(out.toarray(), dense_inverse(precision) @ B.toarray(), rtol=1e-10)
 
 
-@pytest.mark.parametrize("dense_X", [False, True])
-def test_half_solve_gram_is_the_predictive_covariance(dense_X):
-    """Both a sparse X (rows outside its support are zero) and a dense X
-    (every row populated, including never-observed features)."""
+def test_half_solve_dense_rhs_gram_is_the_predictive_covariance():
+    """A dense operand populates every row, never-observed features
+    included, and comes back dense in factor-row order."""
     rng = np.random.default_rng(6)
     p = 48
     precision, observed = make_precision(p, 20, rng)
     factor = create_sparse_factor(precision)
-    if dense_X:
-        X = rng.standard_normal((7, p))
-    else:
-        X = sp.csc_array(sp.random(7, p, density=0.15, random_state=6))
-    B = np.asarray(factor.half_solve(np.asarray(X.T.toarray() if not dense_X else X.T)))
-    Xd = X.toarray() if not dense_X else X
-    assert_allclose(B.T @ B, Xd @ dense_inverse(precision) @ Xd.T, atol=1e-10)
+    X = rng.standard_normal((7, p))
+    B = np.asarray(factor.half_solve(X.T))
+    assert B.shape == (p, 7)
+    assert_allclose(B.T @ B, X @ dense_inverse(precision) @ X.T, atol=1e-10)
 
 
 # -- sample_at ---------------------------------------------------------------
 
 
 def test_sample_at_covariance_is_the_inverse_submatrix():
-    """Mixed observed / never-observed features, unsorted."""
+    """Mixed observed / never-observed features, unsorted; and every
+    feature for ``None``."""
     rng = np.random.default_rng(7)
     p = 48
     precision, observed = make_precision(p, 20, rng)
     factor = create_sparse_factor(precision)
     unobserved = np.setdiff1d(np.arange(p), observed)
-    features = np.array([observed[3], unobserved[5], unobserved[0], observed[0]])
-
-    G = factor.sample_at(features, 40_000, np.random.default_rng(0))
-    assert G.shape == (features.size, 40_000)
-    want = dense_inverse(precision)[np.ix_(features, features)]
-    assert_allclose(np.cov(G), want, atol=0.05 * np.abs(want).max())
-
-
-def test_sample_at_none_covers_every_feature():
-    rng = np.random.default_rng(17)
-    p = 30
-    precision, _ = make_precision(p, 12, rng)
-    factor = create_sparse_factor(precision)
-    G = factor.sample_at(None, 40_000, np.random.default_rng(0))
-    assert G.shape == (p, 40_000)
-    want = dense_inverse(precision)
-    assert_allclose(np.cov(G), want, atol=0.05 * np.abs(want).max())
+    inv = dense_inverse(precision)
+    for features in (
+        np.array([observed[3], unobserved[5], unobserved[0], observed[0]]),
+        None,
+    ):
+        G = factor.sample_at(features, 40_000, np.random.default_rng(0))
+        want = inv if features is None else inv[np.ix_(features, features)]
+        assert G.shape == (want.shape[0], 40_000)
+        assert_allclose(np.cov(G), want, atol=0.05 * np.abs(want).max())
 
 
 def test_sample_at_repeats_a_feature_exactly():
@@ -241,7 +224,10 @@ def test_sample_at_draws_only_the_normals_it_needs(m):
     assert used.random() == twin.random()
 
 
-def test_logdet_and_trace_inv_match_dense():
+def test_logdet_trace_inv_and_get_L_csc_match_dense():
+    """``logdet`` and ``trace_inv`` against dense truth, and ``get_L_csc``
+    is a Cholesky factor of some permutation of the matrix: same
+    eigenvalues, and its diagonal and Takahashi trace reproduce the two."""
     rng = np.random.default_rng(8)
     p = 48
     precision, _ = make_precision(p, 20, rng)
@@ -249,33 +235,13 @@ def test_logdet_and_trace_inv_match_dense():
     _, ld = np.linalg.slogdet(precision.toarray())
     assert_allclose(factor.logdet(), ld, rtol=1e-10)
     assert_allclose(factor.trace_inv(), np.trace(dense_inverse(precision)), rtol=1e-10)
-
-
-def test_solve_cost_counts_only_the_block():
-    rng = np.random.default_rng(9)
-    p = 48
-    precision, observed = make_precision(p, 20, rng)
-    factor = create_sparse_factor(precision)
-    n_trivial = p - observed.size
-    assert factor.solve_cost == precision.nnz - n_trivial
-
-
-def test_get_L_csc_factors_a_permutation_of_the_matrix():
-    """``L Lᵀ = P Λ Pᵀ`` for some permutation ``P``: the eigenvalues and
-    the Takahashi trace agree with the full matrix, and the diagonal
-    reproduces the log-determinant."""
-    rng = np.random.default_rng(10)
-    p = 48
-    precision, _ = make_precision(p, 20, rng)
-    factor = create_sparse_factor(precision)
     L = factor.get_L_csc()
-    LLt = (L @ L.T).toarray()
     assert_allclose(
-        np.sort(np.linalg.eigvalsh(LLt)),
+        np.sort(np.linalg.eigvalsh((L @ L.T).toarray())),
         np.sort(np.linalg.eigvalsh(precision.toarray())),
         rtol=1e-8,
     )
-    assert_allclose(2.0 * np.sum(np.log(L.diagonal())), factor.logdet(), rtol=1e-10)
+    assert_allclose(2.0 * np.sum(np.log(L.diagonal())), ld, rtol=1e-10)
     assert_allclose(np.sum(takahashi_diagonal(L)), factor.trace_inv(), rtol=1e-10)
 
 
@@ -292,8 +258,10 @@ def test_scaled_factor_composes_over_the_partition():
     Mt = np.asarray(factor.half_solve(np.eye(p)))
     assert_allclose(Mt.T @ Mt, inv, atol=1e-10)
     X = sp.csc_array(sp.random(6, p, density=0.2, random_state=44))
-    B = np.asarray(factor.half_solve(X.T))  # sparse rhs, compact result
-    assert_allclose(B.T @ B, X.toarray() @ inv @ X.toarray().T, atol=1e-10)
+    B = factor.half_solve(X.T)  # sparse rhs, split result
+    assert isinstance(B, SparseHalfSolve)
+    gram = B.block.T @ B.block + (B.trivial.T @ B.trivial).toarray()
+    assert_allclose(gram, X.toarray() @ inv @ X.toarray().T, atol=1e-10)
     G = factor.sample_at(None, 40_000, np.random.default_rng(0))
     assert_allclose(np.cov(G), inv, atol=0.05 * np.abs(inv).max())
     _, ld = np.linalg.slogdet(s * precision.toarray())
@@ -304,37 +272,29 @@ def test_scaled_factor_composes_over_the_partition():
 # -- refactorization ---------------------------------------------------------
 
 
-def test_refactorize_when_the_observed_set_grows():
-    """A later update couples a feature that was trivial before."""
+def test_refactorize_follows_the_new_matrix():
+    """Same pattern with new values (the trivial diagonal must be
+    re-read), then a pattern where a later update couples a feature that
+    was trivial before (the partition must be redone)."""
     rng = np.random.default_rng(12)
     p = 40
     A1, observed = make_precision(p, 16, rng)
     factor = create_sparse_factor(A1)
-    j = np.setdiff1d(np.arange(p), observed)[0]
-    k = observed[0]
-    A2 = sp.lil_array(A1)
-    A2[j, k] = 0.4
-    A2[k, j] = 0.4
-    A2[j, j] += 1.0
-    A2 = sp.csc_array(A2)
-
-    refactored = factor.refactorize(A2)
     b = rng.standard_normal(p)
-    assert_allclose(refactored.solve(b), dense_inverse(A2) @ b, rtol=1e-10)
-    assert_allclose(refactored.trace_inv(), np.trace(dense_inverse(A2)), rtol=1e-10)
 
-
-def test_refactorize_with_the_same_observed_set():
-    """New values, same pattern: the trivial diagonal must be re-read."""
-    rng = np.random.default_rng(13)
-    p = 40
-    A1, _ = make_precision(p, 16, rng)
-    factor = create_sparse_factor(A1)
     A2 = sp.csc_array(A1 * 1.7)  # scales every entry, block and trivial alike
+    same = factor.refactorize(A2)
+    assert_allclose(same.solve(b), dense_inverse(A2) @ b, rtol=1e-10)
 
-    refactored = factor.refactorize(A2)
-    b = rng.standard_normal(p)
-    assert_allclose(refactored.solve(b), dense_inverse(A2) @ b, rtol=1e-10)
+    j, k = np.setdiff1d(np.arange(p), observed)[0], observed[0]
+    A3 = sp.lil_array(A1)
+    A3[j, k] = A3[k, j] = 0.4
+    A3[j, j] += 1.0
+    A3 = sp.csc_array(A3)
+    grown = factor.refactorize(A3)
+    assert grown.n_factored == observed.size + 1
+    assert_allclose(grown.solve(b), dense_inverse(A3) @ b, rtol=1e-10)
+    assert_allclose(grown.trace_inv(), np.trace(dense_inverse(A3)), rtol=1e-10)
 
 
 # -- the property that made this worth doing ---------------------------------
@@ -441,9 +401,10 @@ def test_stacked_contexts_with_distinct_supports_have_the_right_joint_law():
 
 
 @pytest.mark.parametrize("m", [24, 60])
-def test_n_factored_is_what_the_factor_factors(m):
+def test_n_factored_and_solve_cost_count_only_the_block(m):
     """The observed block for a sparse factor, unchanged by scaling;
-    every feature for a dense one."""
+    every feature for a dense one; the per-solve cost is the block's
+    stored entries."""
     from scipy.linalg import cholesky
 
     from bayesianbandits._sparse_bayesian_linear_regression import DenseFactor
@@ -453,17 +414,19 @@ def test_n_factored_is_what_the_factor_factors(m):
     precision, observed = make_precision(p, m, rng)
     factor = create_sparse_factor(precision)
     assert factor.n_factored == observed.size
+    assert factor.solve_cost == precision.nnz - (p - observed.size)
     assert scale_factor(factor, 2.0).n_factored == observed.size
     U = cholesky(precision.toarray(), lower=False)
     assert DenseFactor(_U=U, _n_features=p).n_factored == p
 
 
 @pytest.mark.parametrize("m", [24, 60])
-def test_half_solve_sparse_rhs_is_compact_with_the_same_gram(m):
-    """For a sparse ``b`` the result keeps the block rows and one row per
-    distinct never-observed feature ``b`` touches -- nothing else -- and
-    ``Bᵀ B`` is still ``bᵀ Λ⁻¹ b``. With nothing trivial it is the dense
-    half-solve of the same operand."""
+def test_half_solve_sparse_rhs_splits_with_the_same_gram(m):
+    """For a sparse ``b`` the result is the dense block half-solve plus a
+    sparse trivial part with one row per distinct never-observed feature
+    ``b`` touches -- nothing else, and no denser than ``b``'s trivial
+    entries -- and the two Grams add to ``bᵀ Λ⁻¹ b``. With nothing
+    trivial the block is the dense half-solve of the same operand."""
     rng = np.random.default_rng(43)
     p = 60
     precision, observed = make_precision(p, m, rng)
@@ -481,19 +444,32 @@ def test_half_solve_sparse_rhs_is_compact_with_the_same_gram(m):
     X = sp.csc_array(X)
     b = X.T  # (p, 5), sparse
 
-    B = np.asarray(factor.half_solve(b))
+    B = factor.half_solve(b)
+    assert isinstance(B, SparseHalfSolve)
     touched = 2 if unobserved.size else 0
-    assert B.shape == (factor.n_factored + touched, 5)
+    assert B.block.shape == (factor.n_factored, 5)
+    assert B.trivial.shape == (touched, 5)
+    assert B.trivial.nnz == (3 if unobserved.size else 0)
     Xd = X.toarray()
-    assert_allclose(B.T @ B, Xd @ dense_inverse(precision) @ Xd.T, atol=1e-10)
-    if not unobserved.size:
-        assert_allclose(B, factor.half_solve(b.toarray()), rtol=1e-12)
+    gram = B.block.T @ B.block + (B.trivial.T @ B.trivial).toarray()
+    assert_allclose(gram, Xd @ dense_inverse(precision) @ Xd.T, atol=1e-10)
+    if unobserved.size:
+        # trivial rows are value / sqrt(Λ_jj), ascending by feature
+        diag = precision.diagonal()
+        want = np.zeros((2, 5))
+        want[0, 0], want[0, 3] = 0.7 / np.sqrt(diag[j]), -1.1 / np.sqrt(diag[j])
+        want[1, 2] = 0.4 / np.sqrt(diag[k])
+        assert_allclose(B.trivial.toarray(), want, rtol=1e-12)
+    else:
+        assert_allclose(B.block, factor.half_solve(b.toarray()), rtol=1e-12)
 
 
-def test_marginal_sd_over_the_half_solve_path_in_several_chunks():
-    """The chunked half-solve path against dense truth, with the support
-    route gated off and the block budget forced small enough that many
-    chunks run, each handing the factor a sparse block of rows."""
+def test_marginal_sd_over_both_routes_matches_dense_truth():
+    """The marginal path over a partitioned factor, both ways: the
+    chunked half-solve (support route gated off, block budget forced
+    small so many chunks run, each handing the factor a sparse block of
+    rows), and the support route (many rows over few columns, some of
+    them never observed, so it fires and solves over the split)."""
     from unittest import mock
 
     from bayesianbandits import _estimators as E
@@ -504,10 +480,10 @@ def test_marginal_sd_over_the_half_solve_path_in_several_chunks():
     p = 80
     precision, observed = make_precision(p, 32, rng)
     factor = create_sparse_factor(precision)
+    inv = dense_inverse(precision)
+
     X = sp.csc_array(sp.random(37, p, density=0.1, random_state=45))
     Xd = X.toarray()
-    want = np.sqrt(np.einsum("ij,jk,ik->i", Xd, dense_inverse(precision), Xd))
-
     with (
         mock.patch.object(sc, "build", lambda *a, **k: None),
         mock.patch.object(E, "_MARGINAL_SD_BLOCK_ELEMS", 3 * factor.n_factored),
@@ -518,18 +494,9 @@ def test_marginal_sd_over_the_half_solve_path_in_several_chunks():
             factor, "half_solve", lambda b: seen.append(b.shape[1]) or real(b)
         ):
             got = _marginal_predictive_sd(factor, X)
-    assert_allclose(got, want, rtol=1e-10)
+    assert_allclose(got, np.sqrt(np.einsum("ij,jk,ik->i", Xd, inv, Xd)), rtol=1e-10)
     assert len(seen) == 13 and max(seen) == 3  # 37 rows in blocks of 3
 
-
-def test_marginal_sd_over_the_support_route_matches_dense_truth():
-    """Many rows over few columns: the support route fires."""
-    from bayesianbandits._estimators import _marginal_predictive_sd
-
-    rng = np.random.default_rng(46)
-    p = 80
-    precision, observed = make_precision(p, 32, rng)
-    factor = create_sparse_factor(precision)
     cols = np.concatenate([observed[:5], np.setdiff1d(np.arange(p), observed)[:2]])
     rows_, cols_, vals_ = [], [], []
     for i in range(120):
@@ -539,8 +506,12 @@ def test_marginal_sd_over_the_support_route_matches_dense_truth():
             vals_.append(rng.standard_normal())
     X = sp.csc_array(sp.csr_array((vals_, (rows_, cols_)), shape=(120, p)))
     Xd = X.toarray()
-    want = np.sqrt(np.einsum("ij,jk,ik->i", Xd, dense_inverse(precision), Xd))
-    assert_allclose(_marginal_predictive_sd(factor, X), want, rtol=1e-10)
+    with mock.patch.object(
+        sc, "support_covariance", wraps=sc.support_covariance
+    ) as sc_:
+        got = _marginal_predictive_sd(factor, X)
+    sc_.assert_called_once()
+    assert_allclose(got, np.sqrt(np.einsum("ij,jk,ik->i", Xd, inv, Xd)), rtol=1e-10)
 
 
 def test_a_feature_seen_alone_stays_trivial_and_seen_together_joins_the_block():

--- a/tests/test_reward_space_sampling.py
+++ b/tests/test_reward_space_sampling.py
@@ -51,103 +51,98 @@ def _relative_error(got: np.ndarray, want: np.ndarray) -> float:
 
 
 class TestPredictiveCholesky:
-    def test_factor_reproduces_the_predictive_covariance(self):
-        est, rng = _fit_dense()
-        X = rng.standard_normal((10, 40))
-        mean, L = est._predictive_cholesky(X)
-        assert _relative_error(L @ L.T, _reference_S(est, X)) < 1e-12
-        assert_allclose(mean, X @ est.coef_)
-
-    def test_blocked_factor_reproduces_the_diagonal_blocks(self):
+    @pytest.mark.parametrize("block_size", [None, 4])
+    def test_factor_reproduces_the_predictive_covariance(self, block_size):
         """Blocked mode is joint within a block and independent across
         blocks, which is exactly a block-diagonal covariance."""
         est, rng = _fit_dense()
         X = rng.standard_normal((12, 40))
-        mean, L = est._predictive_cholesky(X, block_size=4)
-        assert L.shape == (3, 4, 4)
-        S_ref = _reference_S(est, X)
-        got = _blocked_factor_covariance(L)
-        assert _relative_error(got, _block_diagonal(S_ref, 4)) < 1e-12
+        mean, draw = est._predictive_cholesky(X, block_size)
+        L = draw.L
+        assert draw.M.shape[1] == 0
+        want = _reference_S(est, X)
+        if block_size is None:
+            got = L @ L.T
+        else:
+            assert L.shape == (3, 4, 4)
+            got, want = _blocked_factor_covariance(L), _block_diagonal(want, 4)
+        assert _relative_error(got, want) < 1e-12
         assert_allclose(mean, X @ est.coef_)
 
     def test_rank_deficient_rows_are_exact_and_padded(self):
-        """Duplicate rows make the covariance singular. The QR route
-        represents that exactly, where a Cholesky of the explicit
-        covariance would fail, and pads R to a full ``(n, n)`` factor
-        when there are more rows than features."""
+        """Duplicate rows make the covariance singular; the QR route is
+        exact where a Cholesky would fail, pads R to ``(n, n)`` when rows
+        outnumber features, and repeated contexts share a draw."""
         est, rng = _fit_dense(d=4, rows=80)
         X = rng.standard_normal((12, 4))
         X[6:9] = X[0:3]
-        mean, L = est._predictive_cholesky(X)
-
+        mean, draw = est._predictive_cholesky(X)
+        L = draw.L
         assert L.shape == (12, 12)
         assert_allclose(L, np.tril(L), atol=0)
         target = X @ np.linalg.inv(cov_inv_dense(est)) @ X.T
         assert_allclose(L @ L.T, target, atol=1e-10)
         assert_allclose(mean, X @ est.coef_)
-
-    def test_duplicate_rows_draw_identically(self):
-        """The covariance identity above implies it, but this is the
-        user-visible consequence: repeated contexts share a draw."""
-        est, rng = _fit_dense()
-        X = np.tile(rng.standard_normal(40), (4, 1))
         draws = est.sample_reward_space(X, size=3)
-        assert draws.shape == (3, 4)
-        assert np.abs(draws - draws[:, [0]]).max() < 1e-8 * np.abs(draws).max()
+        assert_allclose(draws[:, 6:9], draws[:, 0:3], rtol=1e-8)
 
     def test_sparse_factor_matches_the_dense_reference(self, sparse_solver):
+        """Through the sparse factor: sparse ``X``, dense ``X`` handed to
+        a sparse model, and after ``decay`` (which scales the cached
+        factor rather than refactoring)."""
         est, rng = _fit_sparse()
         X = sp.csc_array(
             sp.random(10, 400, density=0.05, random_state=2)  # type: ignore[call-arg]
         )
-        mean, L = est._predictive_cholesky(X)
+        mean, draw = est._predictive_cholesky(X)
+        L = draw.L
         assert _relative_error(L @ L.T, _reference_S(est, X.toarray())) < 1e-9
         assert_allclose(mean, np.asarray(X @ est.coef_).ravel())
+        _, dense = est._predictive_cholesky(X.toarray())
+        assert dense.M.shape[1] == 0
+        assert_allclose(dense.L, L, atol=1e-10)
 
-    def test_sparse_after_decay_solves_through_the_scaling(self, sparse_solver):
-        """``decay`` scales the cached factor rather than refactoring."""
-        est, rng = _fit_sparse()
-        X = sp.csc_array(
-            sp.random(6, 400, density=0.05, random_state=3)  # type: ignore[call-arg]
-        )
         est.decay(X.toarray(), decay_rate=0.9)
-        _, L = est._predictive_cholesky(X)
-        assert _relative_error(L @ L.T, _reference_S(est, X.toarray())) < 1e-9
+        _, draw = est._predictive_cholesky(X)
+        assert _relative_error(draw.L @ draw.L.T, _reference_S(est, X.toarray())) < 1e-9
 
-    def test_blocked_sparse_chunks_give_the_same_factor(self, sparse_solver):
-        """Blocked mode chunks the dense half-solve scratch; a chunked run
-        must produce the same factors as an unchunked one."""
-        from unittest import mock
+    def test_degenerate_inputs(self):
+        """All-zero rows draw exactly the mean; ``size=0`` returns an
+        empty ``(0, n_rows)`` array on both paths."""
+        est, rng = _fit_dense()
+        assert np.all(est.sample_reward_space(np.zeros((3, 40)), size=5) == 0.0)
+        X = rng.standard_normal((6, 40))
+        for block_size in (None, 3):
+            assert est.sample_reward_space(X, 0, block_size=block_size).shape == (0, 6)
 
-        from bayesianbandits import _estimators
-
-        est, _ = _fit_sparse(d=400, rows=300)
-        X = sp.csc_array(
-            sp.random(24, 400, density=0.05, random_state=7)  # type: ignore[call-arg]
-        )
-        with mock.patch.object(_estimators, "_MARGINAL_SD_BLOCK_ELEMS", 8):
-            _, chunked = est._predictive_cholesky(X, 4)
-        _, whole = est._predictive_cholesky(X, 4)
-        assert chunked.shape == (6, 4, 4)
-        assert_allclose(chunked, whole, atol=1e-10)
-
-    def test_sparse_model_accepts_dense_X(self, sparse_solver):
-        """``accept_sparse`` only permits sparse input; a sparse model can
-        legitimately receive a dense ndarray."""
-        est, rng = _fit_sparse()
-        draws = est.sample_reward_space(rng.standard_normal((4, 400)), size=50)
-        assert draws.shape == (50, 4)
-        assert np.isfinite(draws).all()
-
-    def test_zero_rows_yield_exact_mean(self):
-        est, _ = _fit_dense()
-        draws = est.sample_reward_space(np.zeros((3, 40)), size=5)
-        assert np.all(draws == 0.0)
+    @pytest.mark.parametrize(
+        "cls, kwargs",
+        [
+            (NormalRegressor, dict(alpha=1.0, beta=1.0)),
+            (NormalInverseGammaRegressor, {}),
+            (BayesianGLM, {}),
+        ],
+    )
+    def test_wrong_feature_count_raises(self, cls, kwargs):
+        """A too-narrow or too-wide ``X`` raises from every sampling entry
+        point (the sparse weight-space path would otherwise read a narrow
+        ``X`` as if its missing features were zero)."""
+        rng = np.random.default_rng(0)
+        X_train, y = rng.standard_normal((30, 8)), rng.standard_normal(30)
+        for sparse in (False, True):
+            est = cls(sparse=sparse, random_state=0, **kwargs)
+            est.fit(sp.csc_array(X_train) if sparse else X_train, y)
+            for width in (6, 10):
+                Xq = rng.standard_normal((3, width))
+                for method in (est.sample, est.sample_reward_space):
+                    with pytest.raises(ValueError, match="expecting 8 features"):
+                        method(sp.csc_array(Xq) if sparse else Xq)
 
     def test_unfitted_model_uses_the_prior_predictive(self):
         est = NormalRegressor(alpha=2.0, beta=1.0, random_state=0)
         X = np.random.default_rng(0).standard_normal((5, 7))
-        _, L = est._predictive_cholesky(est._validated_for_sampling(X))
+        _, draw = est._predictive_cholesky(est._validated_for_sampling(X))
+        L = draw.L
         assert_allclose(L @ L.T, X @ X.T / 2.0, atol=1e-10)
 
     def test_block_size_must_divide_rows_and_be_positive(self):
@@ -171,8 +166,8 @@ class TestComposition:
         scale factor shows up only here."""
         est, rng = _fit_dense(cls=NormalInverseGammaRegressor, random_state=123)
         X = rng.standard_normal((6, 40))
-        _, L = est._predictive_cholesky(X)
-        assert_allclose(L @ L.T, _reference_S(est, X), atol=1e-8)
+        _, draw = est._predictive_cholesky(X)
+        assert_allclose(draw.L @ draw.L.T, _reference_S(est, X), atol=1e-8)
 
         a, b = float(est.a_), float(est.b_)
         draws = est.sample_reward_space(X, 40_000)
@@ -181,9 +176,9 @@ class TestComposition:
 
     @pytest.mark.parametrize("block_size", [None, 3])
     def test_glm_applies_the_link_to_eta_draws(self, block_size):
-        """The GLM draws the linear predictor through the shared factor
-        and applies the inverse link elementwise. With a log link the eta
-        draws come back exactly under ``log``."""
+        """The GLM draws eta through the shared draw and applies the
+        inverse link elementwise: with a log link, ``log`` recovers the
+        eta draws exactly."""
         rng = np.random.default_rng(0)
         est = BayesianGLM(alpha=1.0, link="log", random_state=123)
         est.fit(rng.standard_normal((100, 10)) * 0.3, rng.poisson(1.0, 100) * 1.0)
@@ -200,21 +195,6 @@ class TestComposition:
         assert z.max() < 5.0
         assert_allclose(np.cov(eta.T), want, atol=0.05 * np.abs(want).max())
 
-    def test_normal_blocked_draws_realize_the_block_diagonal(self):
-        """The base estimator puts no scaling on top of the factor, so its
-        blocked draws are the block-diagonal covariance directly. NIG and
-        the GLM both override ``sample_reward_space``, so this is the only
-        cover for the plain blocked draw."""
-        est, rng = _fit_dense(seed=5)
-        X = rng.standard_normal((6, 40))
-
-        draws = est.sample_reward_space(X, 40_000, block_size=3)
-        want = _block_diagonal(_reference_S(est, X), 3)
-        sd = np.sqrt(np.diag(want))
-        z = np.abs(draws.mean(axis=0) - X @ est.coef_) / (sd / np.sqrt(40_000))
-        assert z.max() < 5.0
-        assert_allclose(np.cov(draws.T), want, atol=0.05 * np.abs(want).max())
-
     def test_nig_blocks_mix_independent_chi_squares(self):
         """Within a block the draws share one chi-square; across blocks
         the mixing variables are independent. A shared-g implementation
@@ -225,3 +205,147 @@ class TestComposition:
         log_sq = np.log((draws - (X @ est.coef_)) ** 2 + 1e-300)
         assert np.corrcoef(log_sq[:, 0], log_sq[:, 1])[0, 1] > 0.9
         assert abs(np.corrcoef(log_sq[:, 0], log_sq[:, 2])[0, 1]) < 0.05
+
+
+# -- never-observed features stay a sparse map, not rows of the QR -----------
+
+
+def _fit_cold(cls=NormalRegressor, p=300, m=20, rows=60, seed=0, **kwargs):
+    """A sparse estimator whose training data touched only the first ``m``
+    of ``p`` features, so the factor partitions ``p - m`` as never-observed."""
+    rng = np.random.default_rng(seed)
+    X_train = sp.csc_array(
+        sp.hstack(
+            [
+                sp.random(rows, m, density=0.4, random_state=seed),  # type: ignore[call-arg]
+                sp.csc_array((rows, p - m)),
+            ]
+        )
+    )
+    if cls is NormalRegressor:
+        kwargs = dict(alpha=0.7, beta=1.0, **kwargs)
+    est = cls(sparse=True, random_state=seed, **kwargs)
+    est.fit(X_train, rng.standard_normal(rows))
+    assert est._precision_factor.n_factored == m
+    return est, rng
+
+
+def _query_touching_unobserved(rng, n_rows, p=300, m=20, nnz=6):
+    """Rows whose entries fall on both sides of the partition; several
+    rows share never-observed features so ``M`` must share their normal."""
+    X = sp.random(n_rows, p, density=nnz / p, random_state=rng).tolil()  # type: ignore[call-arg]
+    for i in range(0, n_rows, 2):
+        X[i, m + (i % 7)] = 1.0 + i / n_rows  # shared never-observed feature
+        X[i, i % m] = -0.5  # and an observed one
+    return sp.csc_array(X)
+
+
+def _two_part_covariance(draw):
+    L, M = draw.L, draw.M
+    S = L @ L.T if L.ndim == 2 else _blocked_factor_covariance(L)
+    return S + (M @ M.T).toarray()
+
+
+class TestNeverObservedFeatures:
+    @pytest.mark.parametrize("block_size", [None, 4])
+    def test_split_square_root_reproduces_the_covariance(
+        self, sparse_solver, block_size
+    ):
+        """``L Lᵀ + M Mᵀ = X Λ⁻¹ Xᵀ`` with ``L`` from the observed block
+        only and ``M`` exactly the never-observed part
+        ``X_T diag(1/Λ_jj) X_Tᵀ``, one column per distinct feature (per
+        block); chunking the blocked half-solve changes nothing."""
+        from unittest import mock
+
+        from bayesianbandits import _estimators
+
+        est, rng = _fit_cold()
+        X = _query_touching_unobserved(rng, 24)
+        Xd = X.toarray()
+        want = _reference_S(est, Xd)
+        Xt, diag_t = Xd[:, 20:], est.cov_inv_.diagonal()[20:]
+        want_M = (Xt / diag_t) @ Xt.T
+        n_pairs = np.count_nonzero(np.abs(Xt).sum(axis=0))
+        if block_size is not None:
+            want = _block_diagonal(want, block_size)
+            want_M = _block_diagonal(want_M, block_size)
+            n_pairs = sum(
+                np.count_nonzero(np.abs(Xt[b : b + block_size]).sum(axis=0))
+                for b in range(0, 24, block_size)
+            )
+        mean, draw = est._predictive_cholesky(X, block_size)
+        M = draw.M
+        assert M.shape == (24, n_pairs)
+        assert _relative_error(_two_part_covariance(draw), want) < 1e-9
+        assert_allclose((M @ M.T).toarray(), want_M, atol=1e-12)
+        assert_allclose(mean, Xd @ est.coef_)
+        if block_size is not None:
+            with mock.patch.object(_estimators, "_MARGINAL_SD_BLOCK_ELEMS", 8 * 20):
+                _, chunked = est._predictive_cholesky(X, block_size)
+            assert_allclose(chunked.L, draw.L, atol=1e-10)
+            assert_allclose((chunked.M @ chunked.M.T).toarray(), want_M, atol=1e-12)
+
+    @pytest.mark.parametrize("block_size", [None, 3])
+    def test_draws_scale_both_parts(self, block_size):
+        """The draws add the two parts, and NIG's per-draw (per
+        draw-and-block) chi-square scale multiplies the never-observed
+        part too."""
+        est, rng = _fit_cold(NormalInverseGammaRegressor)
+        X = _query_touching_unobserved(rng, 6)
+        draws = est.sample_reward_space(X, 60_000, block_size=block_size)
+        a, b = float(est.a_), float(est.b_)
+        want = (b / (a - 1.0)) * _reference_S(est, X.toarray())
+        if block_size is not None:
+            want = _block_diagonal(want, block_size)
+        assert_allclose(np.cov(draws.T), want, rtol=0.1, atol=0.05 * np.abs(want).max())
+        _, draw = est._predictive_cholesky(X, block_size)
+        M = draw.M
+        assert (M @ M.T).toarray().max() > 0.1 * want.max()  # part is not negligible
+
+    def test_row_route_carries_the_split_root(self):
+        """``sample`` at large ``size`` takes the row-side reduction, which
+        holds the same two parts."""
+        from unittest import mock
+
+        from bayesianbandits import _estimators
+        from bayesianbandits import _support_covariance as sc
+
+        est, rng = _fit_cold()
+        X = _query_touching_unobserved(rng, 4)
+        with mock.patch.object(sc, "build", lambda *a, **k: None):
+            draw = _estimators.build_joint_reduction(
+                est._precision_factor, X, 300, 40_000, True
+            )
+        assert isinstance(draw, _estimators._RowSpaceDraw)
+        want = _reference_S(est, X.toarray())
+        assert _relative_error(_two_part_covariance(draw), want) < 1e-9
+
+    def test_scratch_is_bounded_by_the_observed_block(self):
+        """Many rows each touching many never-observed features: the dense
+        scratch is ``n_factored`` by the rows, not ``n_factored + t``, on
+        the factor's return and end to end (``tracemalloc``)."""
+        import tracemalloc
+
+        from bayesianbandits._estimators import _marginal_predictive_sd
+
+        p, m = 20_000, 20
+        est, rng = _fit_cold(p=p, m=m, rows=40, seed=9)
+        n_rows = 1000
+        X = sp.csc_array(
+            sp.random(n_rows, p, density=30 / p, random_state=9)  # type: ignore[call-arg]
+        )
+        t = np.count_nonzero(np.diff(X.indptr)[m:])
+        assert t > 5 * n_rows  # the (t, n_rows) dense block would be > 40 MB
+        factor = est._precision_factor
+        half = factor.half_solve(X.T)
+        assert half.block.shape == (m, n_rows)
+        assert half.trivial.shape == (t, n_rows) and half.trivial.nnz <= X.nnz
+
+        # reference through the sparse solve, before measuring
+        want = np.sqrt(np.asarray(X.multiply(factor.solve(X.T).T).sum(axis=1)).ravel())
+        tracemalloc.start()
+        got = _marginal_predictive_sd(factor, X)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        assert_allclose(got, want, rtol=1e-10)
+        assert peak < 20 * 2**20, f"peak {peak / 2**20:.0f} MB"

--- a/tests/test_reward_space_sampling.py
+++ b/tests/test_reward_space_sampling.py
@@ -1,0 +1,218 @@
+"""Tests for ``sample_reward_space``: joint posterior predictive draws in reward space.
+
+The routes are exact reformulations, so the contract is an identity, not
+a distribution: the QR square root must satisfy ``L Lᵀ = X Λ⁻¹ Xᵀ``, and
+blocked mode must satisfy it block by block. That identity is checked
+directly against a dense reference, which subsumes any moment or
+goodness-of-fit check on the draws and cannot flake.
+
+What that identity does *not* cover, and what is therefore tested
+separately: applying the factor to normals, the per-estimator scaling
+composed on top of it (NIG's chi-square mixing, the GLM link), and the
+guards that raise.
+"""
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+from numpy.testing import assert_allclose
+
+from bayesianbandits import (
+    BayesianGLM,
+    NormalInverseGammaRegressor,
+    NormalRegressor,
+)
+from tests._helpers import cov_inv_dense
+from tests._helpers import fit_dense as _fit_dense
+from tests._helpers import fit_sparse as _fit_sparse
+
+
+def _reference_S(est, X_dense: np.ndarray) -> np.ndarray:
+    return X_dense @ np.linalg.solve(cov_inv_dense(est), X_dense.T)
+
+
+def _blocked_factor_covariance(L: np.ndarray) -> np.ndarray:
+    """Assemble the full covariance implied by per-block factors."""
+    n_blocks, k, _ = L.shape
+    out = np.zeros((n_blocks * k, n_blocks * k))
+    for b in range(n_blocks):
+        out[b * k : (b + 1) * k, b * k : (b + 1) * k] = L[b] @ L[b].T
+    return out
+
+
+def _block_diagonal(S: np.ndarray, block_size: int) -> np.ndarray:
+    out = np.zeros_like(S)
+    for start in range(0, S.shape[0], block_size):
+        stop = start + block_size
+        out[start:stop, start:stop] = S[start:stop, start:stop]
+    return out
+
+
+def _relative_error(got: np.ndarray, want: np.ndarray) -> float:
+    sd = np.sqrt(np.diag(want))
+    return float(np.abs((got - want) / np.outer(sd, sd)).max())
+
+
+# -- the exactness identity ---------------------------------------------------
+
+
+class TestPredictiveCholesky:
+    def test_factor_reproduces_the_predictive_covariance(self):
+        est, rng = _fit_dense()
+        X = rng.standard_normal((10, 40))
+        mean, L = est._predictive_cholesky(X)
+        assert _relative_error(L @ L.T, _reference_S(est, X)) < 1e-12
+        assert_allclose(mean, X @ est.coef_)
+
+    def test_blocked_factor_reproduces_the_diagonal_blocks(self):
+        """Blocked mode is joint within a block and independent across
+        blocks, which is exactly a block-diagonal covariance."""
+        est, rng = _fit_dense()
+        X = rng.standard_normal((12, 40))
+        mean, L = est._predictive_cholesky(X, block_size=4)
+        assert L.shape == (3, 4, 4)
+        S_ref = _reference_S(est, X)
+        got = _blocked_factor_covariance(L)
+        assert _relative_error(got, _block_diagonal(S_ref, 4)) < 1e-12
+        assert_allclose(mean, X @ est.coef_)
+
+    def test_rank_deficient_rows_are_exact_and_padded(self):
+        """Duplicate rows make the covariance singular. The QR route
+        represents that exactly, where a Cholesky of the explicit
+        covariance would fail, and pads R to a full ``(n, n)`` factor
+        when there are more rows than features."""
+        est, rng = _fit_dense(d=4, rows=80)
+        X = rng.standard_normal((12, 4))
+        X[6:9] = X[0:3]
+        mean, L = est._predictive_cholesky(X)
+
+        assert L.shape == (12, 12)
+        assert_allclose(L, np.tril(L), atol=0)
+        target = X @ np.linalg.inv(cov_inv_dense(est)) @ X.T
+        assert_allclose(L @ L.T, target, atol=1e-10)
+        assert_allclose(mean, X @ est.coef_)
+
+    def test_duplicate_rows_draw_identically(self):
+        """The covariance identity above implies it, but this is the
+        user-visible consequence: repeated contexts share a draw."""
+        est, rng = _fit_dense()
+        X = np.tile(rng.standard_normal(40), (4, 1))
+        draws = est.sample_reward_space(X, size=3)
+        assert draws.shape == (3, 4)
+        assert np.abs(draws - draws[:, [0]]).max() < 1e-8 * np.abs(draws).max()
+
+    def test_sparse_factor_matches_the_dense_reference(self, sparse_solver):
+        est, rng = _fit_sparse()
+        X = sp.csc_array(
+            sp.random(10, 400, density=0.05, random_state=2)  # type: ignore[call-arg]
+        )
+        mean, L = est._predictive_cholesky(X)
+        assert _relative_error(L @ L.T, _reference_S(est, X.toarray())) < 1e-9
+        assert_allclose(mean, np.asarray(X @ est.coef_).ravel())
+
+    def test_sparse_after_decay_solves_through_the_scaling(self, sparse_solver):
+        """``decay`` wraps the factor in ``ScaledSparseFactor``."""
+        est, rng = _fit_sparse()
+        X = sp.csc_array(
+            sp.random(6, 400, density=0.05, random_state=3)  # type: ignore[call-arg]
+        )
+        est.decay(X.toarray(), decay_rate=0.9)
+        _, L = est._predictive_cholesky(X)
+        assert _relative_error(L @ L.T, _reference_S(est, X.toarray())) < 1e-9
+
+    def test_blocked_sparse_chunks_give_the_same_factor(self, sparse_solver):
+        """Blocked mode chunks the dense half-solve scratch; a chunked run
+        must produce the same factors as an unchunked one."""
+        from unittest import mock
+
+        from bayesianbandits import _estimators
+
+        est, _ = _fit_sparse(d=400, rows=300)
+        X = sp.csc_array(
+            sp.random(24, 400, density=0.05, random_state=7)  # type: ignore[call-arg]
+        )
+        with mock.patch.object(_estimators, "_MARGINAL_SD_BLOCK_ELEMS", 8):
+            _, chunked = est._predictive_cholesky(X, 4)
+        _, whole = est._predictive_cholesky(X, 4)
+        assert chunked.shape == (6, 4, 4)
+        assert_allclose(chunked, whole, atol=1e-10)
+
+    def test_sparse_model_accepts_dense_X(self, sparse_solver):
+        """``accept_sparse`` only permits sparse input; a sparse model can
+        legitimately receive a dense ndarray."""
+        est, rng = _fit_sparse()
+        draws = est.sample_reward_space(rng.standard_normal((4, 400)), size=50)
+        assert draws.shape == (50, 4)
+        assert np.isfinite(draws).all()
+
+    def test_zero_rows_yield_exact_mean(self):
+        est, _ = _fit_dense()
+        draws = est.sample_reward_space(np.zeros((3, 40)), size=5)
+        assert np.all(draws == 0.0)
+
+    def test_unfitted_model_uses_the_prior_predictive(self):
+        est = NormalRegressor(alpha=2.0, beta=1.0, random_state=0)
+        X = np.random.default_rng(0).standard_normal((5, 7))
+        _, L = est._predictive_cholesky(est._validated_for_sampling(X))
+        assert_allclose(L @ L.T, X @ X.T / 2.0, atol=1e-10)
+
+    def test_block_size_must_divide_rows_and_be_positive(self):
+        est, rng = _fit_dense()
+        X = rng.standard_normal((10, 40))
+        with pytest.raises(ValueError, match="divide"):
+            est._predictive_cholesky(X, block_size=4)
+        with pytest.raises(ValueError, match="positive"):
+            est._predictive_cholesky(X, block_size=-2)
+
+
+# -- what the identity does not cover -----------------------------------------
+
+
+class TestComposition:
+    """Per-estimator scaling applied on top of the shared factor."""
+
+    def test_nig_scales_the_shape_matrix_by_b_over_a(self):
+        """``_predictive_cholesky`` returns the unscaled shape matrix;
+        ``sample_reward_space`` applies ``b/a`` itself, so a dropped
+        scale factor shows up only here."""
+        est, rng = _fit_dense(cls=NormalInverseGammaRegressor, random_state=123)
+        X = rng.standard_normal((6, 40))
+        _, L = est._predictive_cholesky(X)
+        assert_allclose(L @ L.T, _reference_S(est, X), atol=1e-8)
+
+        a, b = float(est.a_), float(est.b_)
+        draws = est.sample_reward_space(X, 40_000)
+        want = (b / (a - 1.0)) * _reference_S(est, X)
+        assert_allclose(np.cov(draws.T), want, rtol=0.1, atol=0.05 * np.abs(want).max())
+
+    @pytest.mark.parametrize("block_size", [None, 3])
+    def test_glm_applies_the_link_to_eta_draws(self, block_size):
+        """The GLM draws the linear predictor through the shared factor
+        and applies the inverse link elementwise. With a log link the eta
+        draws come back exactly under ``log``."""
+        rng = np.random.default_rng(0)
+        est = BayesianGLM(alpha=1.0, link="log", random_state=123)
+        est.fit(rng.standard_normal((100, 10)) * 0.3, rng.poisson(1.0, 100) * 1.0)
+        X = rng.standard_normal((6, 10)) * 0.3
+
+        draws = est.sample_reward_space(X, 40_000, block_size=block_size)
+        assert (draws > 0.0).all()  # the link's range
+        eta = np.log(draws)
+        want = _reference_S(est, X)
+        if block_size is not None:
+            want = _block_diagonal(want, block_size)
+        sd = np.sqrt(np.diag(want))
+        z = np.abs(eta.mean(axis=0) - X @ est.coef_) / (sd / np.sqrt(40_000))
+        assert z.max() < 5.0
+        assert_allclose(np.cov(eta.T), want, atol=0.05 * np.abs(want).max())
+
+    def test_nig_blocks_mix_independent_chi_squares(self):
+        """Within a block the draws share one chi-square; across blocks
+        the mixing variables are independent. A shared-g implementation
+        would silently couple contexts, and no factor check sees it."""
+        est, rng = _fit_dense(cls=NormalInverseGammaRegressor, random_state=3)
+        X = np.tile(rng.standard_normal(40), (4, 1))
+        draws = est.sample_reward_space(X, 20_000, block_size=2)
+        log_sq = np.log((draws - (X @ est.coef_)) ** 2 + 1e-300)
+        assert np.corrcoef(log_sq[:, 0], log_sq[:, 1])[0, 1] > 0.9
+        assert abs(np.corrcoef(log_sq[:, 0], log_sq[:, 2])[0, 1]) < 0.05

--- a/tests/test_reward_space_sampling.py
+++ b/tests/test_reward_space_sampling.py
@@ -200,6 +200,21 @@ class TestComposition:
         assert z.max() < 5.0
         assert_allclose(np.cov(eta.T), want, atol=0.05 * np.abs(want).max())
 
+    def test_normal_blocked_draws_realize_the_block_diagonal(self):
+        """The base estimator puts no scaling on top of the factor, so its
+        blocked draws are the block-diagonal covariance directly. NIG and
+        the GLM both override ``sample_reward_space``, so this is the only
+        cover for the plain blocked draw."""
+        est, rng = _fit_dense(seed=5)
+        X = rng.standard_normal((6, 40))
+
+        draws = est.sample_reward_space(X, 40_000, block_size=3)
+        want = _block_diagonal(_reference_S(est, X), 3)
+        sd = np.sqrt(np.diag(want))
+        z = np.abs(draws.mean(axis=0) - X @ est.coef_) / (sd / np.sqrt(40_000))
+        assert z.max() < 5.0
+        assert_allclose(np.cov(draws.T), want, atol=0.05 * np.abs(want).max())
+
     def test_nig_blocks_mix_independent_chi_squares(self):
         """Within a block the draws share one chi-square; across blocks
         the mixing variables are independent. A shared-g implementation

--- a/tests/test_reward_space_sampling.py
+++ b/tests/test_reward_space_sampling.py
@@ -105,7 +105,7 @@ class TestPredictiveCholesky:
         assert_allclose(mean, np.asarray(X @ est.coef_).ravel())
 
     def test_sparse_after_decay_solves_through_the_scaling(self, sparse_solver):
-        """``decay`` wraps the factor in ``ScaledSparseFactor``."""
+        """``decay`` scales the cached factor rather than refactoring."""
         est, rng = _fit_sparse()
         X = sp.csc_array(
             sp.random(6, 400, density=0.05, random_state=3)  # type: ignore[call-arg]

--- a/tests/test_reward_space_sampling.py
+++ b/tests/test_reward_space_sampling.py
@@ -1,15 +1,9 @@
-"""Tests for ``sample_reward_space``: joint posterior predictive draws in reward space.
+"""Tests for ``sample_reward_space``.
 
-The routes are exact reformulations, so the contract is an identity, not
-a distribution: the QR square root must satisfy ``L Lᵀ = X Λ⁻¹ Xᵀ``, and
-blocked mode must satisfy it block by block. That identity is checked
-directly against a dense reference, which subsumes any moment or
-goodness-of-fit check on the draws and cannot flake.
-
-What that identity does *not* cover, and what is therefore tested
-separately: applying the factor to normals, the per-estimator scaling
-composed on top of it (NIG's chi-square mixing, the GLM link), and the
-guards that raise.
+The contract is an identity, checked against a dense reference:
+``L Lᵀ = X Λ⁻¹ Xᵀ``, block by block in blocked mode. Tested separately
+is what the identity does not cover: the per-estimator scaling on top
+of the factor (NIG's chi-square mixing, the GLM link) and the guards.
 """
 
 import numpy as np

--- a/tests/test_sparse_bayesian_linear_regression.py
+++ b/tests/test_sparse_bayesian_linear_regression.py
@@ -14,29 +14,21 @@ from bayesianbandits._sparse_bayesian_linear_regression import (
     DenseFactor,
     SparseSolver,
     create_sparse_factor,
-    multivariate_normal_sample_from_sparse_precision,
-    multivariate_t_sample_from_precision,
     scale_factor,
 )
 
 
 @pytest.mark.parametrize("solver", [SparseSolver.SUPERLU, SparseSolver.CHOLMOD])
 @pytest.mark.parametrize("size", [1, 10])
-def test_multivariate_normal_sample_from_sparse_precision_ill_conditioned_matrices(
-    size, solver
-):
+def test_sample_at_ill_conditioned_matrices(size, solver):
     this_file_path = Path(__file__)
     test_data_dir = this_file_path.parent / "ill_conditioned_matrices"
     for file_path in test_data_dir.glob("*"):
         sparse_array = joblib.load(file_path)
         factor = create_sparse_factor(sparse_array, solver=solver)
-        samples = multivariate_normal_sample_from_sparse_precision(
-            mean=None, factor=factor, size=size
-        )
-        if size != 1:
-            assert samples.shape == (size, sparse_array.shape[0])
-        else:
-            assert samples.shape == (sparse_array.shape[0],)
+        samples = factor.sample_at(None, size, np.random.default_rng(0))
+        assert samples.shape == (sparse_array.shape[0], size)
+        assert np.isfinite(samples).all()
 
 
 class TestSparseFactor:
@@ -58,7 +50,7 @@ class TestSparseFactor:
             for file in Path(__file__).parent.glob("ill_conditioned_matrices/*")
         ],
     )
-    def test_colorize_ill_conditioned_matrices(self, matrix):
+    def test_sample_at_ill_conditioned_matrices(self, matrix):
         """
         These aren't actually going to be the same, but they should be close. We'll
         test by taking a large number of samples and checking that the variances are
@@ -71,9 +63,12 @@ class TestSparseFactor:
             sp.csc_array(matrix), solver=SparseSolver.CHOLMOD
         )
 
-        random_samples = np.random.default_rng(0).normal(size=(1000, matrix.shape[0]))
-        superlu_samples = superlu_factor.colorize(random_samples.T).T
-        cholmod_samples = cholmod_factor.colorize(random_samples.T).T
+        superlu_samples = superlu_factor.sample_at(
+            None, 1000, np.random.default_rng(0)
+        ).T
+        cholmod_samples = cholmod_factor.sample_at(
+            None, 1000, np.random.default_rng(0)
+        ).T
 
         assert_allclose(
             superlu_samples.var(axis=0), cholmod_samples.var(axis=0), rtol=0.5
@@ -104,9 +99,7 @@ class TestSparseFactor:
         factor = create_sparse_factor(sp.csc_array(precision_matrix), solver=solver)
         scipy_cov = Covariance.from_precision(precision_matrix)
 
-        sparse_samples = multivariate_normal_sample_from_sparse_precision(
-            mean=None, factor=factor, size=80000, random_state=0
-        )
+        sparse_samples = factor.sample_at(None, 80000, np.random.default_rng(0)).T
         scipy_samples = multivariate_normal.rvs(
             mean=None,
             cov=scipy_cov,  # type: ignore
@@ -172,9 +165,9 @@ class TestSparseFactor:
         factor = create_sparse_factor(sp.csc_array(precision_matrix), solver=solver)
         scipy_cov = Covariance.from_precision(precision_matrix)
 
-        sparse_samples = multivariate_t_sample_from_precision(
-            loc=None, factor=factor, size=80000, random_state=0, df=300
-        )
+        rng = np.random.default_rng(0)
+        x = rng.chisquare(300, 80000) / 300
+        sparse_samples = factor.sample_at(None, 80000, rng).T / np.sqrt(x)[:, None]
         scipy_samples = multivariate_t_sample_from_covariance(
             loc=None,
             shape=scipy_cov,
@@ -222,14 +215,17 @@ class TestRefactorize:
         assert_allclose(refactored.logdet(), fresh.logdet(), rtol=1e-12)
 
     @pytest.mark.parametrize("solver", [SparseSolver.SUPERLU, SparseSolver.CHOLMOD])
-    def test_refactorize_colorize(self, spd_matrices, solver):
+    def test_refactorize_sample_at(self, spd_matrices, solver):
         A1, A2 = spd_matrices
-        z = np.random.default_rng(1).standard_normal(A1.shape[0])
 
         fresh = create_sparse_factor(A2, solver=solver)
         refactored = create_sparse_factor(A1, solver=solver).refactorize(A2)
 
-        assert_allclose(refactored.colorize(z), fresh.colorize(z), rtol=1e-12)
+        assert_allclose(
+            refactored.sample_at(None, 3, np.random.default_rng(1)),
+            fresh.sample_at(None, 3, np.random.default_rng(1)),
+            rtol=1e-12,
+        )
 
     def test_superlu_refactorize_rejects_a_nonsymmetric_matrix(self):
         """``refactorize`` re-runs the factorization, so it repeats the
@@ -252,20 +248,28 @@ class TestRefactorize:
         factor.refactorize(A2)
         assert factor._precision is A2
 
-    def test_scaled_factor_refactorize_unwraps(self, spd_matrices):
-        """ScaledSparseFactor.refactorize delegates to inner factor."""
+    def test_scaled_factor_refactorize_resets_the_scale(self, spd_matrices):
+        """``refactorize`` yields a factor of the new matrix itself: the
+        scale a view carried is dropped, and the result agrees with a
+        fresh factorization."""
         A1, A2 = spd_matrices
-        factor = create_sparse_factor(A1, solver=SparseSolver.CHOLMOD)
-        scaled = scale_factor(factor, 2.0)
+        scaled = scale_factor(
+            create_sparse_factor(A1, solver=SparseSolver.CHOLMOD), 2.0
+        )
+        assert scaled._scale == 2.0
         refactored = scaled.refactorize(A2)
         assert isinstance(refactored, CholmodSparseFactor)
-        assert refactored is factor
+        assert refactored._scale == 1.0
+        fresh = create_sparse_factor(A2, solver=SparseSolver.CHOLMOD)
+        b = np.random.default_rng(0).standard_normal(A2.shape[0])
+        assert_allclose(refactored.solve(b), fresh.solve(b), rtol=1e-12)
 
 
 class TestHalfSolve:
-    """half_solve is the transpose of the colorize operator.
+    """half_solve is the transpose of the sampling operator.
 
-    If M is the colorize map (M @ M.T = inv(P)), half_solve applies M.T,
+    If M is the map sample_at applies to its normals (M @ M.T = inv(P)),
+    half_solve applies M.T,
     so B = half_solve(X.T) satisfies B.T @ B = X @ inv(P) @ X.T -- the
     projected covariance, computed with one triangular solve per column
     against the cached factor and without ever forming inv(P).
@@ -314,23 +318,26 @@ class TestHalfSolve:
         assert B.shape == (self.D, 8)
         self._assert_gram_matches(B, self._reference(precision, X))
 
-    def test_dense_colorize_accepts_a_vector(self, precision):
-        """Every factor in the ``PrecisionFactor`` union takes a 1-D ``z``
-        (``test_refactorize_colorize`` pins it for the sparse ones), so a
-        caller dispatching on the union must not break on the dense one.
-        ``dtrsm`` needs a 2-D right-hand side, hence the explicit reshape
-        the sparse implementations get for free."""
+    def test_dense_sample_at_is_u_inverse_of_the_stream(self, precision):
+        """The dense draw is ``U⁻¹ z`` for ``z`` drawn ``(size, p)`` and
+        transposed -- pinned, because it is what makes a dense
+        ``sample`` reproducible across releases for a given seed."""
         from scipy.linalg import cholesky, solve_triangular
 
         dense = DenseFactor(
             _U=cholesky(precision.toarray(), lower=False), _n_features=self.D
         )
-        z = np.random.default_rng(3).standard_normal(self.D)
+        z = np.random.default_rng(3).standard_normal((2, self.D))
 
-        got = dense.colorize(z)
-        assert got.shape == (self.D,)
-        assert_allclose(got, dense.colorize(z[:, None])[:, 0], rtol=1e-15)
-        assert_allclose(got, solve_triangular(dense._U, z, lower=False), rtol=1e-10)
+        got = dense.sample_at(None, 2, np.random.default_rng(3))
+        assert got.shape == (self.D, 2)
+        assert_allclose(got, solve_triangular(dense._U, z.T, lower=False), rtol=1e-10)
+        # gathering rows is a gather, not a different draw
+        assert_allclose(
+            dense.sample_at(np.array([2, 0]), 2, np.random.default_rng(3)),
+            got[[2, 0]],
+            rtol=0,
+        )
 
     def test_dense_trace_inv_rejects_a_singular_factor(self, precision):
         """``dtrtri`` reports singularity through ``info`` and leaves the

--- a/tests/test_sparse_bayesian_linear_regression.py
+++ b/tests/test_sparse_bayesian_linear_regression.py
@@ -332,6 +332,17 @@ class TestHalfSolve:
         assert_allclose(got, dense.colorize(z[:, None])[:, 0], rtol=1e-15)
         assert_allclose(got, solve_triangular(dense._U, z, lower=False), rtol=1e-10)
 
+    def test_dense_trace_inv_rejects_a_singular_factor(self, precision):
+        """``dtrtri`` reports singularity through ``info`` and leaves the
+        triangle untouched, so an unchecked result is ``U`` itself and
+        ``trace_inv`` a plausible number for a broken factor."""
+        from scipy.linalg import LinAlgError, cholesky
+
+        U = cholesky(precision.toarray(), lower=False)
+        U[1, 1] = 0.0
+        with pytest.raises(LinAlgError, match=r"U\[1, 1\]"):
+            DenseFactor(_U=U, _n_features=self.D).trace_inv()
+
     @pytest.mark.parametrize("solver", [SparseSolver.SUPERLU, SparseSolver.CHOLMOD])
     def test_single_column_rhs_keeps_2d_shape(self, precision, X, solver):
         factor = create_sparse_factor(precision, solver=solver)

--- a/tests/test_sparse_bayesian_linear_regression.py
+++ b/tests/test_sparse_bayesian_linear_regression.py
@@ -79,6 +79,19 @@ class TestSparseFactor:
             superlu_samples.var(axis=0), cholmod_samples.var(axis=0), rtol=0.5
         )
 
+    def test_superlu_solve_accepts_a_sparse_rhs(self, precision_matrix):
+        """A sparse ``b`` cannot go through the cached triangular factor,
+        so ``solve`` routes it to ``spsolve`` instead."""
+        precision = sp.csc_array(precision_matrix)
+        factor = create_sparse_factor(precision, solver=SparseSolver.SUPERLU)
+        n = precision.shape[0]
+        b = sp.csc_array(np.eye(n)[:, :2])
+
+        got = factor.solve(b)
+        got = np.asarray(got.todense() if sp.issparse(got) else got).reshape(n, 2)
+        want = np.linalg.solve(np.asarray(precision_matrix), b.toarray())
+        assert_allclose(got, want, atol=1e-8)
+
     def test_umfpack_and_superlu_errors_when_not_symmetric_and_positive_definite(
         self,
     ):
@@ -218,6 +231,15 @@ class TestRefactorize:
 
         assert_allclose(refactored.colorize(z), fresh.colorize(z), rtol=1e-12)
 
+    def test_superlu_refactorize_rejects_a_nonsymmetric_matrix(self):
+        """``refactorize`` re-runs the factorization, so it repeats the
+        symmetry check that ``create_sparse_factor`` makes."""
+        factor = create_sparse_factor(
+            sp.csc_array(np.eye(2) * 3.0), solver=SparseSolver.SUPERLU
+        )
+        with pytest.raises(ValueError, match="symmetric"):
+            factor.refactorize(sp.csc_array(np.array([[0.0, 2.0], [1.0, 0.0]])))
+
     def test_cholmod_refactorize_returns_same_object(self, spd_matrices):
         A1, A2 = spd_matrices
         factor = create_sparse_factor(A1, solver=SparseSolver.CHOLMOD)
@@ -291,6 +313,24 @@ class TestHalfSolve:
         B = factor.half_solve(X.T)
         assert B.shape == (self.D, 8)
         self._assert_gram_matches(B, self._reference(precision, X))
+
+    def test_dense_colorize_accepts_a_vector(self, precision):
+        """Every factor in the ``PrecisionFactor`` union takes a 1-D ``z``
+        (``test_refactorize_colorize`` pins it for the sparse ones), so a
+        caller dispatching on the union must not break on the dense one.
+        ``dtrsm`` needs a 2-D right-hand side, hence the explicit reshape
+        the sparse implementations get for free."""
+        from scipy.linalg import cholesky, solve_triangular
+
+        dense = DenseFactor(
+            _U=cholesky(precision.toarray(), lower=False), _n_features=self.D
+        )
+        z = np.random.default_rng(3).standard_normal(self.D)
+
+        got = dense.colorize(z)
+        assert got.shape == (self.D,)
+        assert_allclose(got, dense.colorize(z[:, None])[:, 0], rtol=1e-15)
+        assert_allclose(got, solve_triangular(dense._U, z, lower=False), rtol=1e-10)
 
     @pytest.mark.parametrize("solver", [SparseSolver.SUPERLU, SparseSolver.CHOLMOD])
     def test_single_column_rhs_keeps_2d_shape(self, precision, X, solver):

--- a/tests/test_support_covariance.py
+++ b/tests/test_support_covariance.py
@@ -74,25 +74,17 @@ def test_compact_columns_matches_fancy_indexing():
 
 
 def test_support_covariance_equals_the_principal_submatrix():
+    """Including ``|U| == 1``, the 1-D solve-output branch."""
     rng = np.random.default_rng(2)
     p = 300
     precision = make_precision(p, rng)
+    factor = create_sparse_factor(precision)
+    inv = np.linalg.inv(precision.toarray())
     _, support = make_design(p, 10, 15, rng)
-
-    S = sc.support_covariance(create_sparse_factor(precision), support, p)
-    expected = np.linalg.inv(precision.toarray())[np.ix_(support, support)]
-
-    assert_allclose(S, expected, atol=1e-10)
-
-
-def test_support_covariance_handles_a_single_column():
-    """``|U| == 1`` exercises the 1-D solve-output branch."""
-    rng = np.random.default_rng(4)
-    p = 200
-    precision = make_precision(p, rng)
-    S = sc.support_covariance(create_sparse_factor(precision), np.array([7]), p)
-    assert S.shape == (1, 1)
-    assert_allclose(S, np.linalg.inv(precision.toarray())[7:8, 7:8], atol=1e-10)
+    for U in (support, np.array([7])):
+        S = sc.support_covariance(factor, U, p)
+        assert S.shape == (U.size, U.size)
+        assert_allclose(S, inv[np.ix_(U, U)], atol=1e-10)
 
 
 def test_support_covariance_solves_against_a_sparse_rhs():
@@ -129,52 +121,26 @@ def test_draw_factor_reproduces_the_predictive_covariance():
     assert_allclose(XU_C @ XU_C.T, XU @ S @ XU.T, atol=1e-10)
 
 
-def test_sd_matches_the_half_solve_path():
-    rng = np.random.default_rng(8)
-    p = 400
-    precision = make_precision(p, rng)
-    factor = create_sparse_factor(precision)
-    X, _ = make_design(p, 60, 15, rng)
-
-    draw = sc.build(factor, X, p, budget=X.shape[0])
-    assert draw is not None
-    with gate_off():
-        expected = _marginal_predictive_sd(factor, X)
-
-    assert_allclose(draw.sd(), expected, rtol=1e-10)
-
-
-def test_marginal_predictive_sd_routes_through_the_support():
-    """The wiring in ``_marginal_predictive_sd``, not just the helper."""
+def test_marginal_predictive_sd_routes_by_the_gate():
+    """The wiring in ``_marginal_predictive_sd``: few columns under many
+    rows takes the support route and agrees with the half-solve path;
+    ``|U|`` just under ``n_rows`` saves nothing on solves and adds an
+    O(|U|³) Cholesky, so it declines and keeps its bounded scratch."""
     rng = np.random.default_rng(18)
-    p = 200
-    precision = make_precision(p, rng)
-    factor = create_sparse_factor(precision)
-    X, _ = make_design(p, 80, 12, rng)  # 12 columns, 80 rows: fires
-
-    routed = _marginal_predictive_sd(factor, X)
-    with gate_off():
-        direct = _marginal_predictive_sd(factor, X)
-
-    assert_allclose(routed, direct, rtol=1e-10)
-
-
-def test_marginal_predictive_sd_declines_a_support_it_barely_beats():
-    """|U| just under n_rows saves nothing on solves and adds an
-    O(|U|³) Cholesky, so the marginal path keeps its bounded scratch."""
-    rng = np.random.default_rng(19)
     p = 400
-    precision = make_precision(p, rng)
-    factor = create_sparse_factor(precision)
-    X, _ = make_design(p, 120, 100, rng)  # 100 columns, 120 rows
+    factor = create_sparse_factor(make_precision(p, rng))
+    fires, _ = make_design(p, 80, 12, rng)  # 12 columns, 80 rows
+    declines, _ = make_design(p, 120, 100, rng)  # 100 columns, 120 rows
 
-    with mock.patch.object(sc, "support_covariance") as never:
-        gated = _marginal_predictive_sd(factor, X)
-    never.assert_not_called()
-
-    with gate_off():
-        direct = _marginal_predictive_sd(factor, X)
-    assert_allclose(gated, direct, rtol=1e-10)
+    for X, n_calls in ((fires, 1), (declines, 0)):
+        with mock.patch.object(
+            sc, "support_covariance", wraps=sc.support_covariance
+        ) as spy:
+            routed = _marginal_predictive_sd(factor, X)
+        assert spy.call_count == n_calls
+        with gate_off():
+            direct = _marginal_predictive_sd(factor, X)
+        assert_allclose(routed, direct, rtol=1e-10)
 
 
 @pytest.mark.parametrize(
@@ -193,33 +159,24 @@ def test_marginal_support_gate(n_u, n_rows, nnz, expected):
 # -- rank deficiency ----------------------------------------------------------
 
 
-def test_duplicate_rows_are_perfectly_correlated_within_a_draw():
-    """Identical rows are the same linear functional of the same weights."""
+def test_duplicate_rows_are_exact():
+    """Identical rows are the same linear functional of the same weights,
+    so they draw identically; the ``n x n`` predictive covariance is
+    singular there while ``S`` is not, which is why the reduction is on
+    the feature side."""
     rng = np.random.default_rng(10)
-    p = 300
-    factor = create_sparse_factor(make_precision(p, rng))
-    X, _ = make_design(p, 4, 12, rng)
-    doubled = sp.csc_array(sp.vstack([X, X], format="csr"))
-
-    draw = sc.build(factor, doubled, p, budget=1000)
-    assert draw is not None
-    samples = draw.joint(64, np.random.default_rng(0))
-
-    assert_allclose(samples[:, :4], samples[:, 4:], atol=0)
-
-
-def test_duplicate_rows_leave_the_support_covariance_full_rank():
-    """The n x n predictive covariance is singular here; S is not. This
-    is why the reduction is on the feature side."""
-    rng = np.random.default_rng(11)
     p = 300
     factor = create_sparse_factor(make_precision(p, rng))
     X, support = make_design(p, 4, 12, rng)
     doubled = sp.csc_array(sp.vstack([X, X], format="csr"))
 
+    draw = sc.build(factor, doubled, p, budget=1000)
+    assert draw is not None
+    samples = draw.joint(64, np.random.default_rng(0))
+    assert_allclose(samples[:, :4], samples[:, 4:], atol=0)
+
     S = sc.support_covariance(factor, sc.support_of(doubled), p)
     XU = np.asarray(doubled[:, support].todense())
-
     assert np.linalg.matrix_rank(XU @ S @ XU.T) < doubled.shape[0]
     assert np.linalg.eigvalsh(S).min() > 0
 
@@ -227,25 +184,16 @@ def test_duplicate_rows_leave_the_support_covariance_full_rank():
 # -- the gate -----------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "X",
-    [np.ones((4, 100)), sp.csc_array((4, 100))],
-    ids=["dense", "empty"],
-)
-def test_build_declines_input_it_cannot_reduce(X):
-    rng = np.random.default_rng(5)
-    factor = create_sparse_factor(make_precision(100, rng))
-    assert sc.build(factor, X, 100, budget=1000) is None
-
-
-@pytest.mark.parametrize("budget,fires", [(12, False), (13, True)])
-def test_build_fires_exactly_when_support_is_smaller_than_budget(budget, fires):
+def test_build_fires_exactly_when_the_support_is_under_budget():
+    """``|U| < budget``; a dense or empty ``X`` has nothing to reduce."""
     rng = np.random.default_rng(7)
     p = 300
     factor = create_sparse_factor(make_precision(p, rng))
     X, _ = make_design(p, 40, 12, rng)
-
-    assert (sc.build(factor, X, p, budget=budget) is not None) is fires
+    assert sc.build(factor, X, p, budget=12) is None
+    assert sc.build(factor, X, p, budget=13) is not None
+    assert sc.build(factor, np.ones((4, p)), p, budget=1000) is None
+    assert sc.build(factor, sp.csc_array((4, p)), p, budget=1000) is None
 
 
 # -- estimator composition ----------------------------------------------------
@@ -289,19 +237,3 @@ def test_sample_moments_survive_the_route(make):
     z = np.abs(routed.mean(axis=0) - direct.mean(axis=0)) / (sd / np.sqrt(30_000))
     assert z.max() < 5.0
     assert_allclose(routed.std(axis=0), sd, rtol=0.1)
-
-
-def test_sparse_right_hand_side_still_uses_the_direct_solver(sparse_solver):
-    """``solve`` keeps its sparse-RHS path; only dense input goes through
-    the cached triangular factor."""
-    rng = np.random.default_rng(19)
-    p = 200
-    precision = make_precision(p, rng)
-    factor = create_sparse_factor(precision)
-    rhs = sp.csc_array(sp.random(p, 3, density=0.2, random_state=5))
-
-    got = np.asarray(factor.solve(rhs))
-    if got.ndim == 0:  # some backends return a sparse container
-        got = np.asarray(got.item().todense())
-    expected = np.linalg.solve(precision.toarray(), rhs.toarray())
-    assert_allclose(np.asarray(got).reshape(expected.shape), expected, atol=1e-8)

--- a/tests/test_support_covariance.py
+++ b/tests/test_support_covariance.py
@@ -92,18 +92,6 @@ def test_support_covariance_handles_a_single_column():
     assert_allclose(S, np.linalg.inv(precision.toarray())[7:8, 7:8], atol=1e-10)
 
 
-def test_factorize_falls_back_to_eigendecomposition():
-    """``S`` is SPD in exact arithmetic, so the guard exists only for a
-    numerically indefinite result. Force it to confirm it still returns
-    a valid square root."""
-    S = np.array([[4.0, 1.0], [1.0, 3.0]])
-    with mock.patch.object(
-        np.linalg, "cholesky", side_effect=np.linalg.LinAlgError("forced")
-    ):
-        C = sc._factorize(S)
-    assert_allclose(C @ C.T, S, atol=1e-12)
-
-
 def test_draw_factor_reproduces_the_predictive_covariance():
     """``(X_U C)(X_U C)ᵀ`` is the predictive covariance, exactly."""
     rng = np.random.default_rng(9)

--- a/tests/test_support_covariance.py
+++ b/tests/test_support_covariance.py
@@ -20,7 +20,10 @@ from bayesianbandits import (
     NormalRegressor,
 )
 from bayesianbandits import _support_covariance as sc
-from bayesianbandits._estimators import _marginal_predictive_sd
+from bayesianbandits._estimators import (
+    _marginal_predictive_sd,
+    _marginal_support_is_cheaper,
+)
 from bayesianbandits._sparse_bayesian_linear_regression import create_sparse_factor
 
 
@@ -128,13 +131,14 @@ def test_draw_factor_reproduces_the_predictive_covariance():
 def test_sd_matches_the_half_solve_path():
     rng = np.random.default_rng(8)
     p = 400
-    factor = create_sparse_factor(make_precision(p, rng))
+    precision = make_precision(p, rng)
+    factor = create_sparse_factor(precision)
     X, _ = make_design(p, 60, 15, rng)
 
     draw = sc.build(factor, X, p, budget=X.shape[0])
     assert draw is not None
     with gate_off():
-        expected = _marginal_predictive_sd(factor, X)
+        expected = _marginal_predictive_sd(factor, X, precision.nnz)
 
     assert_allclose(draw.sd(), expected, rtol=1e-10)
 
@@ -143,14 +147,46 @@ def test_marginal_predictive_sd_routes_through_the_support():
     """The wiring in ``_marginal_predictive_sd``, not just the helper."""
     rng = np.random.default_rng(18)
     p = 200
-    factor = create_sparse_factor(make_precision(p, rng))
-    X, _ = make_design(p, 80, 12, rng)  # 12 columns < 80 rows: fires
+    precision = make_precision(p, rng)
+    factor = create_sparse_factor(precision)
+    X, _ = make_design(p, 80, 12, rng)  # 12 columns, 80 rows: fires
 
-    routed = _marginal_predictive_sd(factor, X)
+    routed = _marginal_predictive_sd(factor, X, precision.nnz)
     with gate_off():
-        direct = _marginal_predictive_sd(factor, X)
+        direct = _marginal_predictive_sd(factor, X, precision.nnz)
 
     assert_allclose(routed, direct, rtol=1e-10)
+
+
+def test_marginal_predictive_sd_declines_a_support_it_barely_beats():
+    """|U| just under n_rows saves nothing on solves and adds an
+    O(|U|³) Cholesky, so the marginal path keeps its bounded scratch."""
+    rng = np.random.default_rng(19)
+    p = 400
+    precision = make_precision(p, rng)
+    factor = create_sparse_factor(precision)
+    X, _ = make_design(p, 120, 100, rng)  # 100 columns, 120 rows
+
+    with mock.patch.object(sc, "support_covariance") as never:
+        gated = _marginal_predictive_sd(factor, X, precision.nnz)
+    never.assert_not_called()
+
+    with gate_off():
+        direct = _marginal_predictive_sd(factor, X, precision.nnz)
+    assert_allclose(gated, direct, rtol=1e-10)
+
+
+@pytest.mark.parametrize(
+    "n_u,n_rows,nnz,expected",
+    [
+        (12, 80, 598, True),  # cheap on every axis
+        (100, 120, 1198, False),  # 4|U| > n_rows: no solves saved
+        (200, 4000, 100, False),  # Cholesky outruns the solves it saves
+        (4000, 100_000, 10**9, False),  # |U|² over the scratch budget
+    ],
+)
+def test_marginal_support_gate(n_u, n_rows, nnz, expected):
+    assert _marginal_support_is_cheaper(n_u, n_rows, nnz) is expected
 
 
 # -- rank deficiency ----------------------------------------------------------

--- a/tests/test_support_covariance.py
+++ b/tests/test_support_covariance.py
@@ -1,0 +1,270 @@
+"""Tests for the support-covariance route.
+
+``X = X_U E_Uᵀ`` exactly, so ``Cov(Xw) = X_U (Λ⁻¹)_{U,U} X_Uᵀ``. The
+route is therefore an identity, and the tests are identity checks
+against the paths it replaces: ``S`` against the explicit inverse's
+principal submatrix, and the per-row standard deviations against the
+half-solve path.
+
+Distributional checks on the draws are deliberately absent: they would
+be a weaker statistical restatement of identities already verified to
+floating point. What is checked on top is the composition each estimator
+applies after the reduction, which no factor identity can see.
+"""
+
+from contextlib import contextmanager
+from unittest import mock
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+from numpy.testing import assert_allclose
+
+from bayesianbandits import (
+    BayesianGLM,
+    NormalInverseGammaRegressor,
+    NormalRegressor,
+)
+from bayesianbandits import _support_covariance as sc
+from bayesianbandits._estimators import _marginal_predictive_sd
+from bayesianbandits._sparse_bayesian_linear_regression import create_sparse_factor
+
+
+@pytest.fixture(autouse=True)
+def suitesparse_envvar(sparse_solver):
+    """Run every test in this module against both sparse backends."""
+    yield
+
+
+@contextmanager
+def gate_off():
+    """Force the pre-existing path, for A/B comparison."""
+    with mock.patch.object(sc, "build", lambda *a, **k: None):
+        yield
+
+
+def make_precision(p, rng):
+    off = rng.uniform(-0.4, 0.4, p - 1)
+    return sp.diags([off, np.full(p, 2.0), off], [-1, 0, 1]).tocsc()
+
+
+def make_design(p, n_rows, n_u, rng, nnz_per_row=6):
+    """Sparse X whose columns are confined to a random support of size n_u."""
+    support = np.sort(rng.choice(p, n_u, replace=False))
+    rows, cols, vals = [], [], []
+    for i in range(n_rows):
+        pick = rng.choice(n_u, nnz_per_row, replace=False)
+        rows += [i] * nnz_per_row
+        cols += list(support[pick])
+        vals += list(rng.standard_normal(nnz_per_row))
+    X = sp.csr_array((vals, (rows, cols)), shape=(n_rows, p))
+    return sp.csc_array(X), support
+
+
+# -- the identity -------------------------------------------------------------
+
+
+def test_support_of_finds_exactly_the_touched_columns():
+    rng = np.random.default_rng(0)
+    X, support = make_design(400, 30, 12, rng)
+    assert np.array_equal(sc.support_of(X), support)
+
+
+def test_compact_columns_matches_fancy_indexing():
+    rng = np.random.default_rng(1)
+    X, support = make_design(400, 30, 12, rng)
+    assert_allclose(sc._compact_columns(X, support).todense(), X[:, support].todense())
+
+
+def test_support_covariance_equals_the_principal_submatrix():
+    rng = np.random.default_rng(2)
+    p = 300
+    precision = make_precision(p, rng)
+    _, support = make_design(p, 10, 15, rng)
+
+    S = sc.support_covariance(create_sparse_factor(precision), support, p)
+    expected = np.linalg.inv(precision.toarray())[np.ix_(support, support)]
+
+    assert_allclose(S, expected, atol=1e-10)
+
+
+def test_support_covariance_handles_a_single_column():
+    """``|U| == 1`` exercises the 1-D solve-output branch."""
+    rng = np.random.default_rng(4)
+    p = 200
+    precision = make_precision(p, rng)
+    S = sc.support_covariance(create_sparse_factor(precision), np.array([7]), p)
+    assert S.shape == (1, 1)
+    assert_allclose(S, np.linalg.inv(precision.toarray())[7:8, 7:8], atol=1e-10)
+
+
+def test_factorize_falls_back_to_eigendecomposition():
+    """``S`` is SPD in exact arithmetic, so the guard exists only for a
+    numerically indefinite result. Force it to confirm it still returns
+    a valid square root."""
+    S = np.array([[4.0, 1.0], [1.0, 3.0]])
+    with mock.patch.object(
+        np.linalg, "cholesky", side_effect=np.linalg.LinAlgError("forced")
+    ):
+        C = sc._factorize(S)
+    assert_allclose(C @ C.T, S, atol=1e-12)
+
+
+def test_draw_factor_reproduces_the_predictive_covariance():
+    """``(X_U C)(X_U C)ᵀ`` is the predictive covariance, exactly."""
+    rng = np.random.default_rng(9)
+    p = 300
+    factor = create_sparse_factor(make_precision(p, rng))
+    X, support = make_design(p, 5, 12, rng)
+
+    draw = sc.build(factor, X, p, budget=1000)
+    assert draw is not None
+    XU_C = np.asarray((draw._XU @ draw._C))
+    S = sc.support_covariance(factor, support, p)
+    XU = np.asarray(X[:, support].todense())
+    assert_allclose(XU_C @ XU_C.T, XU @ S @ XU.T, atol=1e-10)
+
+
+def test_sd_matches_the_half_solve_path():
+    rng = np.random.default_rng(8)
+    p = 400
+    factor = create_sparse_factor(make_precision(p, rng))
+    X, _ = make_design(p, 60, 15, rng)
+
+    draw = sc.build(factor, X, p, budget=X.shape[0])
+    assert draw is not None
+    with gate_off():
+        expected = _marginal_predictive_sd(factor, X)
+
+    assert_allclose(draw.sd(), expected, rtol=1e-10)
+
+
+def test_marginal_predictive_sd_routes_through_the_support():
+    """The wiring in ``_marginal_predictive_sd``, not just the helper."""
+    rng = np.random.default_rng(18)
+    p = 200
+    factor = create_sparse_factor(make_precision(p, rng))
+    X, _ = make_design(p, 80, 12, rng)  # 12 columns < 80 rows: fires
+
+    routed = _marginal_predictive_sd(factor, X)
+    with gate_off():
+        direct = _marginal_predictive_sd(factor, X)
+
+    assert_allclose(routed, direct, rtol=1e-10)
+
+
+# -- rank deficiency ----------------------------------------------------------
+
+
+def test_duplicate_rows_are_perfectly_correlated_within_a_draw():
+    """Identical rows are the same linear functional of the same weights."""
+    rng = np.random.default_rng(10)
+    p = 300
+    factor = create_sparse_factor(make_precision(p, rng))
+    X, _ = make_design(p, 4, 12, rng)
+    doubled = sp.csc_array(sp.vstack([X, X], format="csr"))
+
+    draw = sc.build(factor, doubled, p, budget=1000)
+    assert draw is not None
+    samples = draw.joint(64, np.random.default_rng(0))
+
+    assert_allclose(samples[:, :4], samples[:, 4:], atol=0)
+
+
+def test_duplicate_rows_leave_the_support_covariance_full_rank():
+    """The n x n predictive covariance is singular here; S is not. This
+    is why the reduction is on the feature side."""
+    rng = np.random.default_rng(11)
+    p = 300
+    factor = create_sparse_factor(make_precision(p, rng))
+    X, support = make_design(p, 4, 12, rng)
+    doubled = sp.csc_array(sp.vstack([X, X], format="csr"))
+
+    S = sc.support_covariance(factor, sc.support_of(doubled), p)
+    XU = np.asarray(doubled[:, support].todense())
+
+    assert np.linalg.matrix_rank(XU @ S @ XU.T) < doubled.shape[0]
+    assert np.linalg.eigvalsh(S).min() > 0
+
+
+# -- the gate -----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "X",
+    [np.ones((4, 100)), sp.csc_array((4, 100))],
+    ids=["dense", "empty"],
+)
+def test_build_declines_input_it_cannot_reduce(X):
+    rng = np.random.default_rng(5)
+    factor = create_sparse_factor(make_precision(100, rng))
+    assert sc.build(factor, X, 100, budget=1000) is None
+
+
+@pytest.mark.parametrize("budget,fires", [(12, False), (13, True)])
+def test_build_fires_exactly_when_support_is_smaller_than_budget(budget, fires):
+    rng = np.random.default_rng(7)
+    p = 300
+    factor = create_sparse_factor(make_precision(p, rng))
+    X, _ = make_design(p, 40, 12, rng)
+
+    assert (sc.build(factor, X, p, budget=budget) is not None) is fires
+
+
+# -- estimator composition ----------------------------------------------------
+
+
+def fit_sparse(estimator, p, rng, n_obs=60):
+    X = sp.csc_array(sp.random(n_obs, p, density=0.05, random_state=0))
+    y = rng.standard_normal(n_obs)
+    if isinstance(estimator, BayesianGLM):
+        y = rng.integers(0, 2, n_obs).astype(float)
+    estimator.fit(X, y)
+    return estimator
+
+
+@pytest.mark.parametrize(
+    "make",
+    [
+        lambda: NormalRegressor(alpha=1.0, beta=1.0, sparse=True, random_state=0),
+        lambda: NormalInverseGammaRegressor(sparse=True, random_state=0),
+        lambda: BayesianGLM(alpha=1.0, sparse=True, random_state=0, link="logit"),
+    ],
+    ids=["normal", "nig", "glm"],
+)
+def test_sample_moments_survive_the_route(make):
+    """Each estimator composes something on top of the reduction (the
+    t-mixing scale, the inverse link). A dropped factor there is
+    invisible to the identity checks above, so compare moments against
+    the path the route replaces."""
+    rng = np.random.default_rng(12)
+    p = 200
+    est = fit_sparse(make(), p, rng)
+    X, _ = make_design(p, 6, 10, rng)
+
+    est.random_state_ = np.random.default_rng(1)
+    routed = est.sample(X, size=30_000)
+    with gate_off():
+        est.random_state_ = np.random.default_rng(2)
+        direct = est.sample(X, size=30_000)
+
+    sd = direct.std(axis=0)
+    z = np.abs(routed.mean(axis=0) - direct.mean(axis=0)) / (sd / np.sqrt(30_000))
+    assert z.max() < 5.0
+    assert_allclose(routed.std(axis=0), sd, rtol=0.1)
+
+
+def test_sparse_right_hand_side_still_uses_the_direct_solver(sparse_solver):
+    """``solve`` keeps its sparse-RHS path; only dense input goes through
+    the cached triangular factor."""
+    rng = np.random.default_rng(19)
+    p = 200
+    precision = make_precision(p, rng)
+    factor = create_sparse_factor(precision)
+    rhs = sp.csc_array(sp.random(p, 3, density=0.2, random_state=5))
+
+    got = np.asarray(factor.solve(rhs))
+    if got.ndim == 0:  # some backends return a sparse container
+        got = np.asarray(got.item().todense())
+    expected = np.linalg.solve(precision.toarray(), rhs.toarray())
+    assert_allclose(np.asarray(got).reshape(expected.shape), expected, atol=1e-8)

--- a/tests/test_support_covariance.py
+++ b/tests/test_support_covariance.py
@@ -70,7 +70,7 @@ def test_support_of_finds_exactly_the_touched_columns():
 def test_compact_columns_matches_fancy_indexing():
     rng = np.random.default_rng(1)
     X, support = make_design(400, 30, 12, rng)
-    assert_allclose(sc._compact_columns(X, support).todense(), X[:, support].todense())
+    assert_allclose(sc.compact_columns(X, support).todense(), X[:, support].todense())
 
 
 def test_support_covariance_equals_the_principal_submatrix():
@@ -95,9 +95,10 @@ def test_support_covariance_handles_a_single_column():
     assert_allclose(S, np.linalg.inv(precision.toarray())[7:8, 7:8], atol=1e-10)
 
 
-def test_support_covariance_solves_against_a_fortran_ordered_rhs():
-    """CHOLMOD's dense format is column-major, so a C-ordered right-hand
-    side is copied in full before the solve begins."""
+def test_support_covariance_solves_against_a_sparse_rhs():
+    """``E_U`` is ``|U|`` ones; handing it over sparse lets a partitioned
+    factor work at its block rows only, never touching an
+    ``(n_features, k)`` dense buffer."""
     rng = np.random.default_rng(11)
     p = 300
     factor = create_sparse_factor(make_precision(p, rng))
@@ -106,7 +107,7 @@ def test_support_covariance_solves_against_a_fortran_ordered_rhs():
 
     real_solve = factor.solve
     with mock.patch.object(
-        factor, "solve", lambda b: seen.append(b.flags.f_contiguous) or real_solve(b)
+        factor, "solve", lambda b: seen.append(sp.issparse(b)) or real_solve(b)
     ):
         sc.support_covariance(factor, support, p)
 
@@ -138,7 +139,7 @@ def test_sd_matches_the_half_solve_path():
     draw = sc.build(factor, X, p, budget=X.shape[0])
     assert draw is not None
     with gate_off():
-        expected = _marginal_predictive_sd(factor, X, precision.nnz)
+        expected = _marginal_predictive_sd(factor, X)
 
     assert_allclose(draw.sd(), expected, rtol=1e-10)
 
@@ -151,9 +152,9 @@ def test_marginal_predictive_sd_routes_through_the_support():
     factor = create_sparse_factor(precision)
     X, _ = make_design(p, 80, 12, rng)  # 12 columns, 80 rows: fires
 
-    routed = _marginal_predictive_sd(factor, X, precision.nnz)
+    routed = _marginal_predictive_sd(factor, X)
     with gate_off():
-        direct = _marginal_predictive_sd(factor, X, precision.nnz)
+        direct = _marginal_predictive_sd(factor, X)
 
     assert_allclose(routed, direct, rtol=1e-10)
 
@@ -168,11 +169,11 @@ def test_marginal_predictive_sd_declines_a_support_it_barely_beats():
     X, _ = make_design(p, 120, 100, rng)  # 100 columns, 120 rows
 
     with mock.patch.object(sc, "support_covariance") as never:
-        gated = _marginal_predictive_sd(factor, X, precision.nnz)
+        gated = _marginal_predictive_sd(factor, X)
     never.assert_not_called()
 
     with gate_off():
-        direct = _marginal_predictive_sd(factor, X, precision.nnz)
+        direct = _marginal_predictive_sd(factor, X)
     assert_allclose(gated, direct, rtol=1e-10)
 
 

--- a/tests/test_support_covariance.py
+++ b/tests/test_support_covariance.py
@@ -1,15 +1,9 @@
 """Tests for the support-covariance route.
 
-``X = X_U E_Uᵀ`` exactly, so ``Cov(Xw) = X_U (Λ⁻¹)_{U,U} X_Uᵀ``. The
-route is therefore an identity, and the tests are identity checks
-against the paths it replaces: ``S`` against the explicit inverse's
-principal submatrix, and the per-row standard deviations against the
-half-solve path.
-
-Distributional checks on the draws are deliberately absent: they would
-be a weaker statistical restatement of identities already verified to
-floating point. What is checked on top is the composition each estimator
-applies after the reduction, which no factor identity can see.
+``Cov(Xw) = X_U (Λ⁻¹)_{U,U} X_Uᵀ`` is an identity, so the tests are
+identity checks against the paths the route replaces (``S`` against the
+explicit inverse, per-row sd against the half-solve path), plus the
+composition each estimator applies after the reduction.
 """
 
 from contextlib import contextmanager

--- a/tests/test_support_covariance.py
+++ b/tests/test_support_covariance.py
@@ -92,6 +92,24 @@ def test_support_covariance_handles_a_single_column():
     assert_allclose(S, np.linalg.inv(precision.toarray())[7:8, 7:8], atol=1e-10)
 
 
+def test_support_covariance_solves_against_a_fortran_ordered_rhs():
+    """CHOLMOD's dense format is column-major, so a C-ordered right-hand
+    side is copied in full before the solve begins."""
+    rng = np.random.default_rng(11)
+    p = 300
+    factor = create_sparse_factor(make_precision(p, rng))
+    _, support = make_design(p, 10, 15, rng)
+    seen = []
+
+    real_solve = factor.solve
+    with mock.patch.object(
+        factor, "solve", lambda b: seen.append(b.flags.f_contiguous) or real_solve(b)
+    ):
+        sc.support_covariance(factor, support, p)
+
+    assert seen and all(seen)
+
+
 def test_draw_factor_reproduces_the_predictive_covariance():
     """``(X_U C)(X_U C)ᵀ`` is the predictive covariance, exactly."""
     rng = np.random.default_rng(9)


### PR DESCRIPTION
Splits the reduction work out of #263 so it can land without waiting on the IDS questions. The policy-facing half follows in a stacked PR. Supersedes #266.

A set of performance changes to posterior sampling on `NormalRegressor`, `NormalInverseGammaRegressor` and `BayesianGLM`. None changes a distribution; every route is exact and checked as an identity against a dense reference.

- **`sample` reduces through the cheapest exact route.** `Cov(Xw) = X Λ⁻¹ Xᵀ` has a square root on each side, and the routes differ only in triangular solves against the cached factor: weight space costs `size`, the row side `n_rows` (a QR of the half-solve, exact for repeated rows), the column side `|U|` for a sparse `X` touching `|U|` columns. `sample` picks `min(size, n_rows, |U|)`; `size = 1` never reduces.
- **`sample_reward_space`** (new): the row-side route as a public method, with `block_size` for joint-within / independent-across groups of rows.
- **Sparse factors factor only the observed block.** A feature no observation has touched holds only its diagonal in `Λ`, so CHOLMOD/SuperLU get the observed principal block and the rest is carried as a diagonal. Every operation, sampling included, is sized by that block, and the never-observed part of a sparse half-solve stays sparse, so memory no longer grows with the never-observed features a query touches.
- **Dense sampling solves against `U`** instead of rebuilding `U⁻¹` on every update; `dtrtri` only for `trace_inv`, with `info` checked.
- Scaling is a field on every factor (no `ScaledSparseFactor` wrapper); factors draw their own normals via `sample_at`, replacing `colorize`; the sampling paths stay inside one BLAS thread pool and stop copying `X`.

## Measured, production model (2²⁰ features, 26k observed), master vs this branch

| | master | branch |
| --- | ---: | ---: |
| factorization | 3.5 s | 0.75 s |
| `partial_fit`, 32 rows | 3.6 s | 0.72 s |
| `sample(size=1)`, 96 arms | 26 ms | 6.6 ms |
| `sample(size=8)`, 96 arms | 274 ms | 8.8 ms |
| `sample(size=500)`, 96 arms | 37 s | 93 ms |
| `sample_marginal(500)`, 96 arms | 2.3 s | 99 ms |
| `sample_marginal(500)`, 960 rows | 22 s | 0.96 s |

Dense: `size = 1` pull-plus-update at `d = 1000` 106 ms → 11 ms; large-`size` joint draws up to ~45x on the swept shapes (one region past the sweep, many rows near `d` at large `size`, runs ~0.8x; the guard is left without a fitted constant on purpose).

## Seeded streams

Distributions are unchanged everywhere (per-row KS tests). Seeded `sample` trajectories change where a reduction applies, on partitioned sparse factors (one normal per observed feature plus one per distinct never-observed feature the query touches), and in the last bits on dense models. Thompson sampling on a sparse model whose every feature has been observed is bit-for-bit unchanged.

## Tests

Identities against dense references to 1e-12 rather than moment comparisons wherever the contract is an identity; what the identity cannot see (applying the factor to normals, NIG's `b/a` scaling, the GLM link, rank-deficient rows, the guards that raise, memory bounded by the observed block) is tested separately.
