### PR TITLE
Add information-directed sampling and the DrawKind draw contract

### DIFF
--- a/benchmarks/test_bench_ids_select.py
+++ b/benchmarks/test_bench_ids_select.py
@@ -1,0 +1,99 @@
+"""Benchmarks for ``InformationDirectedSampling.select``.
+
+Sampling is not the bottleneck for IDS: at realistic arm counts the
+decision itself dominates a pull, so this file benchmarks ``select``
+directly on a pre-drawn tensor.
+
+Two things drive its cost. The first is *layout*: agents hand a policy
+the learner's ``(size, n_rows)`` output as a transposed view, which
+leaves the draw axis with the largest stride, and the conditional-mean
+contraction falls off BLAS entirely in that layout. The ``_view`` and
+``_carray`` pairs measure what that costs and what the internal copy
+buys back. The second is the *pair scan*, which grows as ``n_arms^2``
+per context and is what the ``96_arms`` cases stress.
+
+``top_k`` re-solves the subgame once per slot, so its cost is linear in
+the slate size; ``top_k_4`` guards that multiplier.
+"""
+
+import numpy as np
+import pytest
+
+from bayesianbandits import InformationDirectedSampling
+
+
+class _Arm:
+    """Stand-in: ``select`` only ever indexes the arm list."""
+
+
+def _draws(n_arms, n_contexts, size, seed=0):
+    """A pre-drawn tensor in the layout an agent actually produces.
+
+    ``LipschitzContextualAgent`` reshapes ``(size, n_contexts * n_arms)``
+    and transposes, so the draw axis ends up outermost in memory.
+    """
+    drawn = np.random.default_rng(seed).standard_normal((size, n_arms, n_contexts))
+    return drawn.transpose(1, 2, 0)
+
+
+@pytest.fixture(scope="module")
+def arms_96():
+    return [_Arm() for _ in range(96)]
+
+
+@pytest.fixture(scope="module")
+def arms_20():
+    return [_Arm() for _ in range(20)]
+
+
+@pytest.fixture(scope="module")
+def policy():
+    return InformationDirectedSampling(samples=1000)
+
+
+# -- 96 arms, 8 contexts, size=1000 -------------------------------------------
+
+
+def test_select_96_arms_8_contexts_view(benchmark, policy, arms_96):
+    samples = _draws(96, 8, 1000)
+    rng = np.random.default_rng(0)
+    benchmark(policy.select, samples, arms_96, rng)
+
+
+def test_select_96_arms_8_contexts_carray(benchmark, policy, arms_96):
+    samples = np.ascontiguousarray(_draws(96, 8, 1000))
+    rng = np.random.default_rng(0)
+    benchmark(policy.select, samples, arms_96, rng)
+
+
+# -- 96 arms, 64 contexts, size=1000 (pair scan and copy both bite) -----------
+
+
+def test_select_96_arms_64_contexts_view(benchmark, policy, arms_96):
+    samples = _draws(96, 64, 1000)
+    rng = np.random.default_rng(0)
+    benchmark(policy.select, samples, arms_96, rng)
+
+
+def test_select_96_arms_64_contexts_carray(benchmark, policy, arms_96):
+    samples = np.ascontiguousarray(_draws(96, 64, 1000))
+    rng = np.random.default_rng(0)
+    benchmark(policy.select, samples, arms_96, rng)
+
+
+# -- 20 arms, 8 contexts, size=1000 (the small end stays cheap) ---------------
+
+
+def test_select_20_arms_8_contexts_view(benchmark, policy, arms_20):
+    samples = _draws(20, 8, 1000)
+    rng = np.random.default_rng(0)
+    benchmark(policy.select, samples, arms_20, rng)
+
+
+# -- slates -------------------------------------------------------------------
+
+
+def test_select_96_arms_8_contexts_top_k_4(benchmark, policy, arms_96):
+    samples = _draws(96, 8, 1000)
+    rng = np.random.default_rng(0)
+    benchmark(policy.select, samples, arms_96, rng, 4)

--- a/benchmarks/test_bench_ids_select.py
+++ b/benchmarks/test_bench_ids_select.py
@@ -1,19 +1,11 @@
 """Benchmarks for ``InformationDirectedSampling.select``.
 
-Sampling is not the bottleneck for IDS: at realistic arm counts the
-decision itself dominates a pull, so this file benchmarks ``select``
-directly on a pre-drawn tensor.
-
-Two things drive its cost. The first is *layout*: agents hand a policy
-the learner's ``(size, n_rows)`` output as a transposed view, which
-leaves the draw axis with the largest stride, and the conditional-mean
-contraction falls off BLAS entirely in that layout. The ``_view`` and
-``_carray`` pairs measure what that costs and what the internal copy
-buys back. The second is the *pair scan*, which grows as ``n_arms^2``
-per context and is what the ``96_arms`` cases stress.
-
-``top_k`` re-solves the subgame once per slot, so its cost is linear in
-the slate size; ``top_k_4`` guards that multiplier.
+The decision, not sampling, dominates an IDS pull at realistic arm
+counts, so these run ``select`` on a pre-drawn tensor. The ``_view`` /
+``_carray`` pairs measure the layout normalization (agents hand policies
+a transposed view whose draw axis would otherwise carry the largest
+stride); the ``96_arms`` cases stress the pair scan; ``top_k_4`` guards
+the per-slot multiplier.
 """
 
 import numpy as np
@@ -27,11 +19,7 @@ class _Arm:
 
 
 def _draws(n_arms, n_contexts, size, seed=0):
-    """A pre-drawn tensor in the layout an agent actually produces.
-
-    ``LipschitzContextualAgent`` reshapes ``(size, n_contexts * n_arms)``
-    and transposes, so the draw axis ends up outermost in memory.
-    """
+    """A pre-drawn tensor in the draw-major view layout."""
     drawn = np.random.default_rng(seed).standard_normal((size, n_arms, n_contexts))
     return drawn.transpose(1, 2, 0)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -26,7 +26,17 @@ Policy Functions
    bayesianbandits.EpsilonGreedy
    bayesianbandits.ThompsonSampling
    bayesianbandits.UpperConfidenceBound
+   bayesianbandits.InformationDirectedSampling
    bayesianbandits.EXP3A
+
+Every policy declares the weakest posterior draws it can correctly
+consume. An agent supplies anything at least that strong and picks
+whichever is cheapest, so a policy never names a sampling method.
+
+.. autosummary::
+   :toctree: generated/
+
+   bayesianbandits.DrawKind
 
 Pipelines
 ---------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -102,6 +102,115 @@ Unreleased
 
 **Performance**
 
+- ``InformationDirectedSampling.select`` no longer reads its draws
+  through the agent's transposed view. Agents hand a policy the learner's
+  ``(size, n_rows)`` output reshaped and transposed, which leaves the draw
+  axis with the largest stride. Every statistic IDS forms reduces or
+  contracts over draws, and the conditional-mean contraction, a batched
+  ``(n_arms, size) x (size, n_arms)`` product per context, falls off BLAS
+  entirely in that layout: at 96 arms, 8 contexts and ``samples=1000`` it
+  took 907 ms through the view and 0.8 ms on the same numbers in C order.
+  ``select`` now materializes C order first, one slab of draws at a time
+  so the transpose itself stays cache-resident.
+
+  Both halves of the decision are also reduced, exactly. The regret and
+  information-gain estimates condition only on arms that win at least one
+  draw: :math:`p(A^* = b) = 0` for every other arm, so its term in
+  :math:`v_a` is identically zero, and the conditional-mean contraction
+  runs over the :math:`M` ever-optimal arms per context rather than all
+  :math:`K` (:math:`M` is typically single digits at 96 arms once the
+  posterior has any shape). The optimal-arm *indicator* is likewise taken
+  straight from a comparison against the per-draw maximum, rather than an
+  ``argmax`` over the leading axis and a one-hot expansion of it; its
+  count reduction accumulates in ``uint16`` (exact below 2^16 draws)
+  instead of promoting each boolean to ``int64``, which is 4x. Two
+  further passes over the tensor vanish algebraically: the conditional
+  sums' columns partition the draws, so their row sums are the arms' full
+  draw sums (the means) and their winning-arm entries total
+  :math:`\mathbb{E}[\max]` -- and because an always-optimal arm's two
+  recoveries read the same float, its regret is *exactly* zero, keeping
+  the zero-regret ratio classification exact rather than
+  summation-order-dependent.
+
+  The pair scan evaluated four candidate mixing weights over all
+  :math:`K^2` ordered pairs; three of the four are redundant and most
+  pairs cannot win. The endpoints ``q = 0`` and ``q = 1`` are the
+  single-arm ratios, whose minimum is an :math:`O(K)` sweep; the
+  zero-regret root can never land strictly inside ``(0, 1)`` once regret
+  is clipped at zero, so it is always one of those endpoints; only the
+  Pareto frontier of the :math:`(v_a, \Delta_a)` points can support an
+  optimal mixture, since moving weight from a dominated arm to its
+  dominator never increases the ratio; and
+  ``f(q; a, b) = f(1 - q; b, a)`` halves the remaining scan. What
+  survives is one interior stationary point per unordered frontier pair,
+  evaluated over a ragged per-context pair list (frontier sizes are
+  heavy-tailed, so one wide context must not inflate the scan for the
+  rest): :math:`O(K \log K + m^2)` per context with :math:`m` the
+  frontier size, typically single digits, in place of
+  :math:`O(K^2 \cdot 4)`. No reduction excludes a candidate that could
+  be the optimum, so the selected mixture is identical.
+
+  End to end on a dense 96-arm agent at ``samples=1000``, a pull goes
+  from 612 ms to 13 ms at 8 contexts and from 4.4 s to 75 ms at 64
+  contexts, and a ``top_k=4`` slate at 8 contexts from 1.50 s to 20 ms.
+  A 20-arm, 8-context pull goes from 6.1 ms to 1.6 ms. What remains in
+  ``select`` is one slabbed transpose copy plus three single passes and
+  one GEMM read over the draw tensor, each running at measured
+  single-threaded numpy bandwidth -- further gains would need threaded
+  or fused native passes, not a better algorithm. Only IDS is affected:
+  the other policies read per-arm, per-context statistics that the
+  view's layout does not penalize, so nothing else pays for the copy
+  (#270)
+
+- Joint ``sample`` draws now reduce through whichever exact route is
+  cheapest. :math:`\operatorname{Cov}(Xw) = X \Lambda^{-1} X^T` has rank at
+  most :math:`\min(n_{\text{rows}}, |U|, p)`, and there is a reduction to a
+  small square root on each side, so the three routes differ only in how
+  many triangular solves against the cached factor they cost:
+
+  .. list-table::
+     :header-rows: 1
+
+     * - route
+       - solves
+       - square root
+     * - weight space
+       - ``size``
+       - :math:`p \times p`, cached
+     * - row side
+       - ``n_rows``
+       - :math:`n_{\text{rows}} \times n_{\text{rows}}`
+     * - column side
+       - :math:`|U|`
+       - :math:`|U| \times |U|`
+
+  The choice is therefore :math:`\min(\text{size}, n_{\text{rows}}, |U|)`,
+  three exactly known integers, and the gate holds no calibration
+  constants. Weight space is the one whose square root is *cached* -- it
+  factors :math:`\Lambda`, which does not depend on ``X`` -- so it builds
+  nothing and pays per draw, while the other two refactor on every call.
+  That is why neither can win at small ``size``: there is nothing to
+  amortize. ``size = 1`` therefore always stays on weight space, and
+  Thompson sampling is bit-for-bit unchanged.
+
+  Previously the column side was chosen inside ``sample`` and the row side
+  out at the agent behind a policy flag, so neither could account for what
+  the other would have picked. Measured end-to-end over 36 dense shapes
+  (:math:`p` in {100, 1000}, ``n_rows`` in {1, 10, 32, 96, 320}, ``size``
+  in {1, 100, 500, 1000}): no regressions, and speedups to 45.9x. Sparse
+  gains reach 860x (:math:`p` = 100,000, one row, ``size`` = 1000: 6.0 s to
+  7.0 ms) (#269)
+
+- Every step of the reward-space path after the half-solve is taken from
+  ``scipy.linalg`` rather than ``numpy`` (``dgeqrf`` for the QR, ``dgemm``
+  for the draws, ``dgemv`` for the predictive mean). ``numpy`` and
+  ``scipy`` bind separate copies of OpenBLAS, each with its own thread
+  pool, and alternating between them within one call parks and unparks
+  both. On a 28-core box that cost more than every flop on the path: a
+  100x100 QR took 81 ms through ``numpy.linalg.qr`` and 0.9 ms through
+  ``dgeqrf``. Reward-space sampling is up to 102x faster than before this
+  routing (#269)
+
 - A number of performance updates to posterior sampling on
   ``NormalRegressor``, ``NormalInverseGammaRegressor`` and ``BayesianGLM``,
   none of which changes a distribution. Joint ``sample`` draws go through

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,45 +6,22 @@ Unreleased
 
 **Breaking changes**
 
-- Policies declare what they *consume* rather than which sampling methods
-  they tolerate. The ``marginal_ok`` and ``reward_space_ok`` flags on
-  ``PolicyProtocol`` are replaced by a single ``consumes: DrawKind``,
-  naming the weakest draws a policy can correctly consume over a totally
-  ordered lattice::
+- ``PolicyProtocol`` gains a ``consumes: DrawKind`` attribute, naming the
+  weakest draws a policy can correctly consume over a totally ordered
+  lattice::
 
       MARGINAL_ONLY  <  CONTEXT_JOINT  <  JOINT
 
   Agents satisfy it with anything at least that strong and pick whichever
-  is cheapest, so no policy names a sampling method any more. Supplying
-  more structure than asked is always sound, so an agent may widen the
-  requirement silently and can never narrow it: ``max`` is the only
-  combinator, and ``JOINT`` is the default, meaning a policy that does not
-  consider this gets correctness rather than speed.
+  is cheapest (see ``DrawKind`` for the semantics). Custom, structurally
+  typed policies should declare a ``consumes`` attribute;
+  ``PolicyDefaultUpdate`` and the agents default it to ``JOINT``, which
+  is always correct and never the cheapest.
 
-  Migration is mechanical: ``marginal_ok = True`` becomes
-  ``consumes = DrawKind.MARGINAL_ONLY``, ``reward_space_ok = True``
-  becomes ``consumes = DrawKind.CONTEXT_JOINT``, and both ``False``
-  becomes ``consumes = DrawKind.JOINT``.
-
-  The flags could not express ``CONTEXT_JOINT`` at all. Per-context
-  reward-space blocks are joint across the arms of one context and
-  independent across contexts, which is strictly between marginal and
-  fully joint draws; it is what ``InformationDirectedSampling`` needs, and
-  it was previously implied by a method name rather than stated. The two
-  booleans were also independent over levels that are not, so they could
-  be set to combinations with no coherent meaning (#270)
-
-- The ``elementwise`` opt-out on batch reward functions is removed, along
-  with ``is_elementwise_batch_reward``. A supplied
-  ``batch_reward_function`` now always widens the agent's requirement to
-  at least ``CONTEXT_JOINT``. The attribute was an unverifiable promise
-  that a function mapped each draw cell independently, and a wrong one
-  silently manufactured spread that quantile-based policies read as
-  uncertainty. Joint draws are no longer expensive enough to be worth that
-  risk, now that they reduce through the cheapest of three exact routes.
-  Agents supplying no reward function, or per-arm reward functions only,
-  are unaffected: those normalize to ``batch_identity``, which combines
-  nothing and does not widen (#270)
+  ``CONTEXT_JOINT`` is new: per-context reward-space blocks are joint
+  across the arms of one context and independent across contexts, which
+  is strictly between marginal and fully joint draws. It is what
+  ``InformationDirectedSampling`` needs (#270)
 
 - ``ContextualAgent`` and ``Agent`` now require each arm to have its own
   learner, and raise from ``add_arm`` (so also from the constructor) when
@@ -52,10 +29,10 @@ Unreleased
   features, so arms sharing a learner were statistically
   indistinguishable; worse, the policies on that path sample one arm at a
   time, which draws a separate weight vector per arm and silently
-  discards the dependence a shared posterior implies. A policy declaring
-  ``marginal_ok = False`` could therefore ask for joint draws and receive
-  independent ones: on arms sharing a learner, measured cross-arm
-  correlation was 0.00 where the true value was 1.00. Sharing one model
+  discards the dependence a shared posterior implies. A policy requiring
+  joint draws could therefore ask for them and receive independent ones:
+  on arms sharing a learner, measured cross-arm correlation was 0.00
+  where the true value was 1.00. Sharing one model
   across arms is ``LipschitzContextualAgent``'s job -- it distinguishes
   arms with an ``arm_featurizer`` and samples the shared learner once for
   all of them -- and the error says so. Two distinct ``LearnerPipeline``

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,46 @@ Unreleased
 
 **Breaking changes**
 
+- Policies declare what they *consume* rather than which sampling methods
+  they tolerate. The ``marginal_ok`` and ``reward_space_ok`` flags on
+  ``PolicyProtocol`` are replaced by a single ``consumes: DrawKind``,
+  naming the weakest draws a policy can correctly consume over a totally
+  ordered lattice::
+
+      MARGINAL_ONLY  <  CONTEXT_JOINT  <  JOINT
+
+  Agents satisfy it with anything at least that strong and pick whichever
+  is cheapest, so no policy names a sampling method any more. Supplying
+  more structure than asked is always sound, so an agent may widen the
+  requirement silently and can never narrow it: ``max`` is the only
+  combinator, and ``JOINT`` is the default, meaning a policy that does not
+  consider this gets correctness rather than speed.
+
+  Migration is mechanical: ``marginal_ok = True`` becomes
+  ``consumes = DrawKind.MARGINAL_ONLY``, ``reward_space_ok = True``
+  becomes ``consumes = DrawKind.CONTEXT_JOINT``, and both ``False``
+  becomes ``consumes = DrawKind.JOINT``.
+
+  The flags could not express ``CONTEXT_JOINT`` at all. Per-context
+  reward-space blocks are joint across the arms of one context and
+  independent across contexts, which is strictly between marginal and
+  fully joint draws; it is what ``InformationDirectedSampling`` needs, and
+  it was previously implied by a method name rather than stated. The two
+  booleans were also independent over levels that are not, so they could
+  be set to combinations with no coherent meaning (#270)
+
+- The ``elementwise`` opt-out on batch reward functions is removed, along
+  with ``is_elementwise_batch_reward``. A supplied
+  ``batch_reward_function`` now always widens the agent's requirement to
+  at least ``CONTEXT_JOINT``. The attribute was an unverifiable promise
+  that a function mapped each draw cell independently, and a wrong one
+  silently manufactured spread that quantile-based policies read as
+  uncertainty. Joint draws are no longer expensive enough to be worth that
+  risk, now that they reduce through the cheapest of three exact routes.
+  Agents supplying no reward function, or per-arm reward functions only,
+  are unaffected: those normalize to ``batch_identity``, which combines
+  nothing and does not widen (#270)
+
 - ``ContextualAgent`` and ``Agent`` now require each arm to have its own
   learner, and raise from ``add_arm`` (so also from the constructor) when
   two arms share one. Neither agent gives arms a way to differ in
@@ -31,6 +71,15 @@ Unreleased
   law, so the remaining path needs no batching (#267)
 
 **New features**
+
+- ``InformationDirectedSampling``: a variance-based information-directed
+  sampling (IDS) policy after Russo & Van Roy (2018). Each round it
+  estimates every arm's expected regret and variance-based information
+  gain from joint Monte Carlo posterior draws and samples from the
+  two-arm distribution minimizing the information ratio
+  :math:`\Delta(\pi)^2 / v(\pi)`, exploiting cross-arm correlation under
+  shared learners. ``top_k`` returns sequential IDS draws without
+  replacement, each slot re-solving the subgame of remaining arms (#270)
 
 - ``sample_reward_space`` on ``NormalRegressor``,
   ``NormalInverseGammaRegressor``, and ``BayesianGLM``: joint draws from
@@ -80,13 +129,13 @@ Unreleased
   through the marginal path (they consume only per-arm, per-context
   statistics, for which marginal draws are exact), giving large speedups
   for their Monte Carlo estimates, dense and sparse alike.
-  ``ThompsonSampling`` is unchanged, byte-for-byte.
-  Custom policies can opt in by setting ``marginal_ok = True`` (declared
-  on ``PolicyProtocol``), and subclasses of the built-in policies can
-  opt out with ``marginal_ok = False``, which their ``__call__`` and the
-  agents both honor. The marginal path is never used for a learner whose
-  class overrides ``sample`` without also overriding ``sample_marginal``,
-  so customized joint sampling is not silently bypassed (#258)
+  ``ThompsonSampling`` is unchanged, byte-for-byte. Custom policies opt in
+  by declaring ``consumes = DrawKind.MARGINAL_ONLY``, and subclasses of the
+  built-in policies opt out with ``consumes = DrawKind.JOINT``, which their
+  ``__call__`` and the agents both honor. The marginal path is never used
+  for a learner whose class overrides ``sample`` without also overriding
+  ``sample_marginal``, so customized joint sampling is not silently
+  bypassed (#258)
 
 - The marginal path is likewise never used when a
   ``LipschitzContextualAgent`` carries a user-supplied
@@ -94,12 +143,10 @@ Unreleased
   may combine arms within it (share of total, cannibalization, softmax
   over a slate), which requires the arms of a draw to be jointly
   distributed; iid marginal draws leave such a reward's mean intact but
-  manufacture spread that a quantile-based policy reads as uncertainty.
-  A batch function that maps each ``(arm, context, draw)`` cell
-  independently can opt back into the faster path by carrying a truthy
-  ``elementwise`` attribute. Per-arm ``Arm.reward_function``s are applied
-  one arm at a time and never affect sampling, so the common cases --
-  no reward function, or per-arm functions only -- keep the speedup (#258)
+  manufacture spread that a quantile-based policy reads as uncertainty. A
+  per-arm ``Arm.reward_function`` is applied one arm at a time and never
+  affects sampling, so the common cases -- no reward function, or per-arm
+  functions only -- keep the speedup (#258)
 
 - ``sample`` and ``sample_marginal`` no longer copy ``X`` while validating
   it. Neither mutates the validated array nor retains a reference to it,
@@ -109,14 +156,14 @@ Unreleased
 **Behavioral changes**
 
 - Seeded agent trajectories under ``UpperConfidenceBound``, ``EXP3A``, and
-  ``EpsilonGreedy`` change: the marginal path consumes different amounts
-  of randomness than joint sampling. Per-row marginals are identical
-  (verified by KS tests) and decisions converge to the same choices as
-  ``samples`` grows, but for arms sharing one model the per-arm Monte
-  Carlo estimates no longer share weight draws, so finite-sample
-  selection noise among near-tied arms increases; raise ``samples`` to
-  compensate (marginal draws are much cheaper per draw), or opt the
-  policy out with ``marginal_ok = False`` (#258)
+  ``EpsilonGreedy`` change: the marginal path consumes different amounts of
+  randomness than joint sampling. Per-row marginals are identical (verified
+  by KS tests) and decisions converge to the same choices as ``samples``
+  grows, but for arms sharing one model the per-arm Monte Carlo estimates
+  no longer share weight draws, so finite-sample selection noise among
+  near-tied arms increases; raise ``samples`` to compensate (marginal draws
+  are much cheaper per draw), or opt the policy out with
+  ``consumes = DrawKind.JOINT`` (#258)
 
 - Seeded ``sample`` trajectories change: a reduced draw consumes
   ``n_rows`` or :math:`|U|` normals rather than one per feature, a

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -102,65 +102,20 @@ Unreleased
 
 **Performance**
 
-- ``InformationDirectedSampling.select`` no longer reads its draws
-  through the agent's transposed view. Agents hand a policy the learner's
-  ``(size, n_rows)`` output reshaped and transposed, which leaves the draw
-  axis with the largest stride. Every statistic IDS forms reduces or
-  contracts over draws, and the conditional-mean contraction, a batched
-  ``(n_arms, size) x (size, n_arms)`` product per context, falls off BLAS
-  entirely in that layout: at 96 arms, 8 contexts and ``samples=1000`` it
-  took 907 ms through the view and 0.8 ms on the same numbers in C order.
-  ``select`` now materializes C order first, one slab of draws at a time
-  so the transpose itself stays cache-resident.
-
-  Both halves of the decision are also reduced, exactly. The regret and
-  information-gain estimates condition only on arms that win at least one
-  draw: :math:`p(A^* = b) = 0` for every other arm, so its term in
-  :math:`v_a` is identically zero, and the conditional-mean contraction
-  runs over the :math:`M` ever-optimal arms per context rather than all
-  :math:`K` (:math:`M` is typically single digits at 96 arms once the
-  posterior has any shape). The optimal-arm *indicator* is likewise taken
-  straight from a comparison against the per-draw maximum, rather than an
-  ``argmax`` over the leading axis and a one-hot expansion of it; its
-  count reduction accumulates in ``uint16`` (exact below 2^16 draws)
-  instead of promoting each boolean to ``int64``, which is 4x. Two
-  further passes over the tensor vanish algebraically: the conditional
-  sums' columns partition the draws, so their row sums are the arms' full
-  draw sums (the means) and their winning-arm entries total
-  :math:`\mathbb{E}[\max]` -- and because an always-optimal arm's two
-  recoveries read the same float, its regret is *exactly* zero, keeping
-  the zero-regret ratio classification exact rather than
-  summation-order-dependent.
-
-  The pair scan evaluated four candidate mixing weights over all
-  :math:`K^2` ordered pairs; three of the four are redundant and most
-  pairs cannot win. The endpoints ``q = 0`` and ``q = 1`` are the
-  single-arm ratios, whose minimum is an :math:`O(K)` sweep; the
-  zero-regret root can never land strictly inside ``(0, 1)`` once regret
-  is clipped at zero, so it is always one of those endpoints; only the
-  Pareto frontier of the :math:`(v_a, \Delta_a)` points can support an
-  optimal mixture, since moving weight from a dominated arm to its
-  dominator never increases the ratio; and
-  ``f(q; a, b) = f(1 - q; b, a)`` halves the remaining scan. What
-  survives is one interior stationary point per unordered frontier pair,
-  evaluated over a ragged per-context pair list (frontier sizes are
-  heavy-tailed, so one wide context must not inflate the scan for the
-  rest): :math:`O(K \log K + m^2)` per context with :math:`m` the
-  frontier size, typically single digits, in place of
-  :math:`O(K^2 \cdot 4)`. No reduction excludes a candidate that could
-  be the optimum, so the selected mixture is identical.
-
-  End to end on a dense 96-arm agent at ``samples=1000``, a pull goes
-  from 612 ms to 13 ms at 8 contexts and from 4.4 s to 75 ms at 64
-  contexts, and a ``top_k=4`` slate at 8 contexts from 1.50 s to 20 ms.
-  A 20-arm, 8-context pull goes from 6.1 ms to 1.6 ms. What remains in
-  ``select`` is one slabbed transpose copy plus three single passes and
-  one GEMM read over the draw tensor, each running at measured
-  single-threaded numpy bandwidth -- further gains would need threaded
-  or fused native passes, not a better algorithm. Only IDS is affected:
-  the other policies read per-arm, per-context statistics that the
-  view's layout does not penalize, so nothing else pays for the copy
-  (#270)
+- ``InformationDirectedSampling.select`` is 50-100x faster, exactly.
+  It normalizes its draw tensor to draw-contiguous layout first (the
+  agents' transposed views left the draw axis with the largest stride,
+  which alone made the conditional-mean GEMM 1000x slower), conditions
+  only on the arms that win at least one draw (every other arm's
+  :math:`p(A^* = b)` term is identically zero), recovers the means and
+  :math:`\mathbb{E}[\max]` from that GEMM's own entries instead of
+  separate passes, and scans only the Pareto frontier of the
+  :math:`(v_a, \Delta_a)` points for the optimal pair (moving weight
+  from a dominated arm to its dominator never increases the ratio), one
+  interior root per unordered frontier pair. No step excludes a possible
+  optimum, so the selected mixture is identical. A dense 96-arm pull at
+  ``samples=1000`` goes from 612 ms to 13 ms at 8 contexts and 4.4 s to
+  75 ms at 64; ``top_k=4`` from 1.50 s to 20 ms (#270)
 
 - Joint ``sample`` draws now reduce through whichever exact route is
   cheapest. :math:`\operatorname{Cov}(Xw) = X \Lambda^{-1} X^T` has rank at

--- a/docs/generated/bayesianbandits.DrawKind.rst
+++ b/docs/generated/bayesianbandits.DrawKind.rst
@@ -1,0 +1,11 @@
+﻿bayesianbandits.DrawKind
+========================
+
+.. currentmodule:: bayesianbandits
+
+.. autoclass:: DrawKind
+   :members:
+   :special-members: __init__
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: set_fit_request, set_partial_fit_request, set_score_request, set_predict_request, get_metadata_routing

--- a/docs/generated/bayesianbandits.InformationDirectedSampling.rst
+++ b/docs/generated/bayesianbandits.InformationDirectedSampling.rst
@@ -1,0 +1,11 @@
+﻿bayesianbandits.InformationDirectedSampling
+===========================================
+
+.. currentmodule:: bayesianbandits
+
+.. autoclass:: InformationDirectedSampling
+   :members:
+   :special-members: __init__
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: set_fit_request, set_partial_fit_request, set_score_request, set_predict_request, get_metadata_routing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,10 @@ where = ["src"]
 bayesianbandits = ["*.pyx"]
 
 [tool.pytest.ini_options]
+# Bare `pytest` must never collect benchmarks/: pytest-benchmark runs them
+# as tests without any flag, and the slow 1M-feature cases allocate enough
+# to OOM a development VM. Run them explicitly per the README/CLAUDE.md.
+testpaths = ["tests", "src"]
 addopts = "--doctest-modules -v"
 filterwarnings = "ignore::DeprecationWarning"
 markers = [

--- a/src/bayesianbandits/__init__.py
+++ b/src/bayesianbandits/__init__.py
@@ -37,6 +37,7 @@ policies of your bandit as your needs change.
     EpsilonGreedy
     ThompsonSampling
     UpperConfidenceBound
+    InformationDirectedSampling
     EXP3A
     Arm
 
@@ -125,6 +126,7 @@ total is what dropping the object would free.
 
 from ._arm import Arm
 from ._arm_featurizer import ArmFeaturizer
+from ._draw_kind import DrawKind
 from ._eb_estimators import (
     EmpiricalBayesDirichletClassifier,
     EmpiricalBayesGammaRegressor,
@@ -149,11 +151,12 @@ from .api import (
 )
 from .featurizers import ArmColumnFeaturizer, FunctionArmFeaturizer
 from .pipelines import AgentPipeline, LearnerPipeline
-from .policies import EXP3A
+from .policies import EXP3A, InformationDirectedSampling
 
 __all__ = [
     "Arm",
     "ArmFeaturizer",
+    "DrawKind",
     "ArmColumnFeaturizer",
     "FunctionArmFeaturizer",
     "BayesianGLM",
@@ -174,6 +177,7 @@ __all__ = [
     "EpsilonGreedy",
     "ThompsonSampling",
     "UpperConfidenceBound",
+    "InformationDirectedSampling",
     "EXP3A",
     "AgentPipeline",
     "LearnerPipeline",

--- a/src/bayesianbandits/_arm.py
+++ b/src/bayesianbandits/_arm.py
@@ -660,8 +660,9 @@ def _sample_context_major_blocks(
     Permutes the arm-major stack (row ``a * n_contexts + c``)
     context-major so each context's arm rows form one consecutive
     jointly-drawn block, samples, and restores the (arm, context) axes.
-    Returns shape ``(n_arms, n_contexts, size)``, a zero-copy view of
-    the drawn array.
+    Returns shape ``(n_arms, n_contexts, size)``: a zero-copy
+    draw-contiguous view for a contract-conforming sampler, one reshape
+    copy otherwise.
     """
     if n_arms == 1 or n_contexts == 1:
         # the permutation is the identity; skip the gather-copy
@@ -670,7 +671,7 @@ def _sample_context_major_blocks(
         perm = _context_major_permutation(n_arms, n_contexts)
         X_ctx_major = _take_rows(X_stacked, perm)
     drawn = joint_sampler(X_ctx_major, size=size)
-    return drawn.reshape(size, n_contexts, n_arms).transpose(2, 1, 0)
+    return drawn.T.reshape(n_contexts, n_arms, size).transpose(1, 0, 2)
 
 
 def posterior_identity(learner: Any) -> Any:

--- a/src/bayesianbandits/_arm.py
+++ b/src/bayesianbandits/_arm.py
@@ -20,6 +20,7 @@ import numpy as np
 from numpy.typing import NDArray
 from typing_extensions import Concatenate, ParamSpec, Self, TypeGuard
 
+from ._blas_helpers import draw_contiguous
 from ._memory import MemoryUsageMixin
 
 HAS_PANDAS = importlib.util.find_spec("pandas") is not None
@@ -602,15 +603,12 @@ def resolve_reward_space_sampler(
 
     Returns a ``(X, size) -> samples`` callable bound to the learner's
     ``sample_reward_space`` with ``block_size`` applied, only when it is
-    safe *and* profitable to use: ``sample_reward_space`` must be
-    defined at or above any ``sample`` override (see
-    :func:`_defines_before_sample` -- the two are distributionally
-    identical for the built-in learners, but not necessarily for a
-    subclass), and the learner's ``_use_reward_space`` flop model must
-    prefer reward space for this ``(n_rows, size)`` shape. A learner
-    that defines ``sample_reward_space`` without the ``_use_reward_space``
-    gate is never routed to reward space. Returns None otherwise;
-    callers fall back to ``sample``, which is always correct.
+    safe *and* profitable: safe means defined at or above any ``sample``
+    override (:func:`_defines_before_sample`), profitable means the
+    learner's ``_use_reward_space`` flop model prefers reward space for
+    this ``(n_rows, size)`` shape; without that gate a learner is never
+    routed here. Returns None otherwise; callers fall back to
+    ``sample``, which is always correct.
     """
     if not _defines_before_sample(learner, "sample_reward_space"):
         return None
@@ -660,9 +658,10 @@ def _sample_context_major_blocks(
     Permutes the arm-major stack (row ``a * n_contexts + c``)
     context-major so each context's arm rows form one consecutive
     jointly-drawn block, samples, and restores the (arm, context) axes.
-    Returns shape ``(n_arms, n_contexts, size)``: a zero-copy
-    draw-contiguous view for a contract-conforming sampler, one reshape
-    copy otherwise.
+    Returns shape ``(n_arms, n_contexts, size)`` with a unit-stride draw
+    axis: a zero-copy view for a contract-conforming sampler, one
+    normalizing copy (:func:`~bayesianbandits._blas_helpers.draw_contiguous`)
+    otherwise.
     """
     if n_arms == 1 or n_contexts == 1:
         # the permutation is the identity; skip the gather-copy
@@ -671,7 +670,7 @@ def _sample_context_major_blocks(
         perm = _context_major_permutation(n_arms, n_contexts)
         X_ctx_major = _take_rows(X_stacked, perm)
     drawn = joint_sampler(X_ctx_major, size=size)
-    return drawn.T.reshape(n_contexts, n_arms, size).transpose(1, 0, 2)
+    return draw_contiguous(drawn.T.reshape(n_contexts, n_arms, size).transpose(1, 0, 2))
 
 
 def posterior_identity(learner: Any) -> Any:

--- a/src/bayesianbandits/_arm.py
+++ b/src/bayesianbandits/_arm.py
@@ -187,29 +187,6 @@ def batch_identity(
     return samples
 
 
-def is_elementwise_batch_reward(func: Any) -> bool:
-    """Is ``func`` known to map each draw cell independently?
-
-    A batch reward function receives the whole
-    ``(n_arms, n_contexts, size)`` tensor, so it may combine arms
-    *within* a draw (share-of-total, cannibalization, softmax over a
-    slate). Such a function is only meaningful when the rows of one
-    draw are jointly distributed, which rules out the iid marginal
-    sampling path -- there, ``samples[:, c, m]`` is not a coherent
-    sample of the arm-reward vector, and the derived reward picks up
-    spurious spread even though its mean is unchanged.
-
-    ``None`` and :func:`batch_identity` are elementwise by
-    construction. Anything else is assumed to couple arms unless it
-    carries a truthy ``elementwise`` attribute, so the conservative
-    default is the correct one and users who know better can opt back
-    into the faster path.
-    """
-    if func is None or func is batch_identity:
-        return True
-    return bool(getattr(func, "elementwise", False))
-
-
 def apply_reward_function(
     reward_function: RewardFunction,
     samples: NDArray[np.float64],
@@ -590,23 +567,110 @@ class Arm(MemoryUsageMixin, Generic[ContextType, TokenType]):
         )
 
 
+def _defines_before_sample(learner: Any, method: str) -> bool:
+    """Walking the MRO from the most-derived class, is ``method`` defined
+    at or above the first ``sample`` override?
+
+    The first class defining either name decides, so a class that
+    overrides ``sample`` without also overriding ``method`` (e.g. to
+    clip or transform draws) never has its custom sampling bypassed.
+    """
+    for klass in type(learner).__mro__:
+        if method in vars(klass):
+            return True
+        if "sample" in vars(klass):
+            return False
+    return False
+
+
 def resolve_marginal_sampler(learner: Any) -> Callable[..., NDArray[np.float64]]:
     """Resolve a learner's marginal sampler, falling back to joint ``sample``.
 
     Returns the learner's ``sample_marginal`` only when it is safe to
-    use: walking the MRO from the most-derived class, the first class
-    that defines either method decides. A class that overrides
-    ``sample`` without also overriding ``sample_marginal`` (e.g. to
-    clip or transform draws) gets the fallback, so its custom sampling
-    behavior is never bypassed; per-row marginals are identical either
-    way, the fallback is merely slower.
+    use (see :func:`_defines_before_sample`); per-row marginals are
+    identical either way, the fallback is merely slower.
     """
-    for klass in type(learner).__mro__:
-        if "sample_marginal" in vars(klass):
-            return cast(Callable[..., NDArray[np.float64]], learner.sample_marginal)
-        if "sample" in vars(klass):
-            break
+    if _defines_before_sample(learner, "sample_marginal"):
+        return cast(Callable[..., NDArray[np.float64]], learner.sample_marginal)
     return cast(Callable[..., NDArray[np.float64]], learner.sample)
+
+
+def resolve_reward_space_sampler(
+    learner: Any, n_rows: int, size: int, block_size: Optional[int] = None
+) -> Optional[Callable[..., NDArray[np.float64]]]:
+    """Resolve a learner's reward-space joint sampler, or None to use ``sample``.
+
+    Returns a ``(X, size) -> samples`` callable bound to the learner's
+    ``sample_reward_space`` with ``block_size`` applied, only when it is
+    safe *and* profitable to use: ``sample_reward_space`` must be
+    defined at or above any ``sample`` override (see
+    :func:`_defines_before_sample` -- the two are distributionally
+    identical for the built-in learners, but not necessarily for a
+    subclass), and the learner's ``_use_reward_space`` flop model must
+    prefer reward space for this ``(n_rows, size)`` shape. A learner
+    that defines ``sample_reward_space`` without the ``_use_reward_space``
+    gate is never routed to reward space. Returns None otherwise;
+    callers fall back to ``sample``, which is always correct.
+    """
+    if not _defines_before_sample(learner, "sample_reward_space"):
+        return None
+    gate = getattr(learner, "_use_reward_space", None)
+    if gate is None or not gate(n_rows, size, block_size):
+        return None
+
+    def sampler(X: Any, size: int = 1, _learner: Any = learner) -> NDArray[np.float64]:
+        return cast(
+            NDArray[np.float64],
+            _learner.sample_reward_space(X, size, block_size=block_size),
+        )
+
+    return sampler
+
+
+def _context_major_permutation(n_arms: int, n_contexts: int) -> NDArray[np.intp]:
+    """Row order gathering each context's arm rows into one consecutive block.
+
+    Stacked arm features are arm-major (row ``a * n_contexts + c``); the
+    blocked reward-space sampler needs each context's rows adjacent so a
+    block is jointly drawn per context.
+    """
+    return np.arange(n_arms * n_contexts).reshape(n_arms, n_contexts).T.ravel()
+
+
+def _take_rows(X: Any, indices: NDArray[np.intp]) -> Any:
+    """Positionally select rows from an array, sparse matrix, or DataFrame.
+
+    Plain ``X[indices]`` selects *columns by label* on a DataFrame, so
+    DataFrames must go through ``iloc``.
+    """
+    if hasattr(X, "iloc"):
+        return X.iloc[indices]
+    return X[indices]
+
+
+def _sample_context_major_blocks(
+    joint_sampler: Callable[..., NDArray[np.float64]],
+    X_stacked: Any,
+    n_arms: int,
+    n_contexts: int,
+    size: int,
+) -> NDArray[np.float64]:
+    """Draw per-context joint blocks from arm-major stacked feature rows.
+
+    Permutes the arm-major stack (row ``a * n_contexts + c``)
+    context-major so each context's arm rows form one consecutive
+    jointly-drawn block, samples, and restores the (arm, context) axes.
+    Returns shape ``(n_arms, n_contexts, size)``, a zero-copy view of
+    the drawn array.
+    """
+    if n_arms == 1 or n_contexts == 1:
+        # the permutation is the identity; skip the gather-copy
+        X_ctx_major = X_stacked
+    else:
+        perm = _context_major_permutation(n_arms, n_contexts)
+        X_ctx_major = _take_rows(X_stacked, perm)
+    drawn = joint_sampler(X_ctx_major, size=size)
+    return drawn.reshape(size, n_contexts, n_arms).transpose(2, 1, 0)
 
 
 def posterior_identity(learner: Any) -> Any:

--- a/src/bayesianbandits/_blas_helpers.py
+++ b/src/bayesianbandits/_blas_helpers.py
@@ -147,3 +147,32 @@ def affine_lower_factor(
         NDArray[np.float64],
         dgemm(1.0, z, L, trans_b=1, beta=1.0, c=out, overwrite_c=True),
     )
+
+
+#: Slab byte budget for :func:`draw_contiguous`: keeps a slab's source
+#: block L2-resident while it is scattered out.
+_COPY_SLAB_BYTES = 1 << 20
+
+
+def draw_contiguous(samples: NDArray[np.float64]) -> NDArray[np.float64]:
+    """``samples`` with a unit-stride draw (last) axis, copying if needed.
+
+    The sampling layout contract (``tests/test_sample_layout.py``): the
+    ``(size, n)`` entry points return draws with ``samples.T``
+    C-contiguous -- their final projections are dgemm outputs or
+    transposed products, so this costs nothing -- and agents hand
+    policies tensors whose draw axis is unit-stride, normalizing here
+    for learners that only promise shape. Conforming input passes
+    through untouched. Copies slab-wise: numpy's own strided copy walks
+    the draw axis outermost and runs ~3x slower on large tensors.
+    """
+    if samples.dtype == np.float64 and samples.strides[-1] == samples.itemsize:
+        return samples
+    n_leading = int(np.prod(samples.shape[:-1]))
+    n_draws = samples.shape[-1]
+    out = np.empty(samples.shape, dtype=np.float64)
+    slab = max(1, min(n_draws, _COPY_SLAB_BYTES // max(1, n_leading * 8)))
+    for start in range(0, n_draws, slab):
+        stop = start + slab
+        out[..., start:stop] = samples[..., start:stop]
+    return out

--- a/src/bayesianbandits/_blas_helpers.py
+++ b/src/bayesianbandits/_blas_helpers.py
@@ -153,25 +153,35 @@ def affine_lower_factor(
 #: block L2-resident while it is scattered out.
 _COPY_SLAB_BYTES = 1 << 20
 
+#: Fewest draws per slab worth slabbing for. Below this each output row
+#: is re-touched once per draw and numpy's own strided copy, which walks
+#: the draw axis outermost, is the faster of the two.
+_MIN_SLAB_DRAWS = 64
+
 
 def draw_contiguous(samples: NDArray[np.float64]) -> NDArray[np.float64]:
     """``samples`` with a unit-stride draw (last) axis, copying if needed.
 
     The sampling layout contract (``tests/test_sample_layout.py``): the
     ``(size, n)`` entry points return draws with ``samples.T``
-    C-contiguous -- their final projections are dgemm outputs or
-    transposed products, so this costs nothing -- and agents hand
-    policies tensors whose draw axis is unit-stride, normalizing here
-    for learners that only promise shape. Conforming input passes
-    through untouched. Copies slab-wise: numpy's own strided copy walks
-    the draw axis outermost and runs ~3x slower on large tensors.
+    C-contiguous, and agents hand policies tensors whose draw axis is
+    unit-stride, normalizing here for learners that only promise shape.
+    Conforming input passes through untouched, whatever its float
+    width. Copies slab-wise while a slab holds at least
+    :data:`_MIN_SLAB_DRAWS` draws (numpy's own strided copy walks the
+    draw axis outermost, ~3x slower there); below that the slab loop
+    would re-touch every output row per draw, and numpy's copy takes
+    over.
     """
-    if samples.dtype == np.float64 and samples.strides[-1] == samples.itemsize:
+    if samples.dtype.kind == "f" and samples.strides[-1] == samples.itemsize:
         return samples
+    dtype = samples.dtype if samples.dtype.kind == "f" else np.dtype(np.float64)
     n_leading = int(np.prod(samples.shape[:-1]))
     n_draws = samples.shape[-1]
-    out = np.empty(samples.shape, dtype=np.float64)
-    slab = max(1, min(n_draws, _COPY_SLAB_BYTES // max(1, n_leading * 8)))
+    slab = min(n_draws, _COPY_SLAB_BYTES // max(1, n_leading * dtype.itemsize))
+    if slab < min(n_draws, _MIN_SLAB_DRAWS):
+        return np.ascontiguousarray(samples, dtype=dtype)
+    out = np.empty(samples.shape, dtype=dtype)
     for start in range(0, n_draws, slab):
         stop = start + slab
         out[..., start:stop] = samples[..., start:stop]

--- a/src/bayesianbandits/_draw_kind.py
+++ b/src/bayesianbandits/_draw_kind.py
@@ -1,0 +1,72 @@
+"""What a policy needs of its posterior draws.
+
+A policy consumes draws; an agent supplies them. The two are matched by
+a single value describing the *weakest* draws a policy can correctly
+consume, rather than by flags naming the sampling methods it will
+tolerate. That inversion is the point: a policy states what it needs,
+an agent picks the cheapest exact way to provide it, and neither has to
+know the other's implementation.
+"""
+
+from enum import IntEnum
+
+__all__ = ["DrawKind"]
+
+
+class DrawKind(IntEnum):
+    """How much joint structure a policy's decisions depend on.
+
+    The three levels are totally ordered by how much dependence they
+    preserve, so they compare and combine with ``<`` and :func:`max`:
+
+    .. code-block:: text
+
+        MARGINAL_ONLY  <  CONTEXT_JOINT  <  JOINT
+
+    Supplying *more* structure than a policy asks for is always sound:
+    the requested statistics keep the same distribution, only the
+    dependence a policy does not read gets preserved anyway. Supplying
+    less never is. So an agent may always widen, and must never narrow.
+    Widening silently is fine; narrowing must be impossible, which is
+    what stating the requirement (rather than permitting a method)
+    buys.
+
+    Cheapness runs the other way, ``MARGINAL_ONLY`` being cheapest, so a
+    policy that overstates its needs only pays for it, and one that
+    understates them is wrong. When in doubt, use ``JOINT``.
+    """
+
+    MARGINAL_ONLY = 0
+    """Only per-(arm, context) statistics are read.
+
+    Each cell may be drawn independently, so ``sample_marginal`` serves.
+    Correct for policies scoring every arm on its own -- a quantile, a
+    mean, an upper confidence bound -- and wrong for any that compares
+    arms *within* a draw, since independent cells carry no such
+    comparison.
+    """
+
+    CONTEXT_JOINT = 1
+    """Arms are compared within a context, but contexts never interact.
+
+    Draws must be jointly distributed across the arms of one context
+    and may be independent across contexts. This is what
+    ``sample_reward_space(block_size=n_arms)`` produces, and what
+    information-directed sampling needs: it reads the covariance
+    between arms under a shared posterior, but solves each context's
+    decision on its own.
+
+    Note that a ``NormalInverseGammaRegressor`` under ``JOINT`` shares
+    one noise-scale draw across contexts, and under ``CONTEXT_JOINT``
+    does not. Both are exact for their own level; only a policy that
+    couples contexts can tell them apart.
+    """
+
+    JOINT = 2
+    """Every arm and context shares one posterior draw.
+
+    The strongest requirement and the safe default: one weight vector
+    per draw, so every dependence the posterior implies is present.
+    Thompson sampling needs it, and so does any reward transform that
+    combines arms before the policy sees them.
+    """

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -1247,6 +1247,35 @@ class _RewardSpacePredictiveMixin:
             self._precision_factor, X, block_size
         )
 
+    def _use_reward_space(
+        self, n: int, size: int, block_size: Optional[int] = None
+    ) -> bool:
+        """Solve-count test: is the row-side reduction cheaper here?
+
+        Only the *blocked* reward-space path consults this. Full-mode
+        row-side draws are chosen inside ``sample`` by
+        :func:`build_joint_reduction`, which weighs them against the
+        column-side reduction as well; a caller reaching here has
+        already committed to per-block draws, which no other route
+        produces.
+        """
+        if not hasattr(self, "n_features_"):
+            # Unfitted: no cached factor or dimensions to reason about
+            # yet, and the prior predictive is cheap either way
+            return False
+        # The full-mode guards of :func:`_reward_space_is_cheaper` with
+        # the per-block work substituted: each QR and draw runs over
+        # ``block_size`` rows, so the budget terms scale by ``k`` rather
+        # than ``n``.
+        factor = self._precision_factor
+        d = factor.n_factored
+        k = n if block_size is None else block_size
+        if 2 * n > size:
+            return False
+        if self.sparse:
+            return k * d <= _MARGINAL_SD_BLOCK_ELEMS and 2 * n * k <= factor.solve_cost
+        return n <= d and 2 * n * k <= d * d
+
     def _validated_for_sampling(
         self, X: Union[NDArray[Any], csc_array]
     ) -> Union[NDArray[Any], csc_array]:

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -984,26 +984,34 @@ def _weight_space_rows(
 
 
 def _reward_space_is_cheaper(
-    n: int, d: int, size: int, sparse: bool, precision_nnz: int
+    n: int,
+    d: int,
+    size: int,
+    sparse: bool,
+    precision_nnz: int,
+    block_size: Optional[int] = None,
 ) -> bool:
     """Is the row-side reduction cheaper than weight space for this call?
 
     Both pay in triangular solves against the cached factor: ``n`` for
     the row side, ``size`` for weight space. Requiring ``2n <= size``
     leaves the other half of the weight-space budget to cover the row
-    side's QR (``n²·d``) and draws (``n²·size``), which the remaining
+    side's QR (``n·k·d``) and draws (``n·k·size``), which the remaining
     guards check against what weight space spends per solve: ``d²``
     dense, ``nnz`` sparse. Dense also needs ``n <= d`` (fewer normals per
-    draw); sparse also caps the ``(d, n)`` half-solve scratch at the
+    draw); sparse also caps the ``(d, k)`` half-solve scratch at the
     marginal path's element budget. ``d`` is what the factor factors --
     ``factor.n_factored`` -- which for a sparse factor is its observed
-    block, the true row count of that scratch.
+    block, the true row count of that scratch. ``k`` is the rows per
+    jointly drawn block: ``block_size`` for the blocked path, ``n``
+    itself for full-mode draws, recovering the ``n²`` terms.
     """
+    k = n if block_size is None else block_size
     if 2 * n > size:
         return False
     if sparse:
-        return n * d <= _MARGINAL_SD_BLOCK_ELEMS and 2 * n * n <= precision_nnz
-    return n <= d and 2 * n * n <= d * d
+        return k * d <= _MARGINAL_SD_BLOCK_ELEMS and 2 * n * k <= precision_nnz
+    return n <= d and 2 * n * k <= d * d
 
 
 class _RowSpaceDraw:
@@ -1265,18 +1273,10 @@ class _RewardSpacePredictiveMixin:
             # Unfitted: no cached factor or dimensions to reason about
             # yet, and the prior predictive is cheap either way
             return False
-        # The full-mode guards of :func:`_reward_space_is_cheaper` with
-        # the per-block work substituted: each QR and draw runs over
-        # ``block_size`` rows, so the budget terms scale by ``k`` rather
-        # than ``n``.
         factor = self._precision_factor
-        d = factor.n_factored
-        k = n if block_size is None else block_size
-        if 2 * n > size:
-            return False
-        if self.sparse:
-            return k * d <= _MARGINAL_SD_BLOCK_ELEMS and 2 * n * k <= factor.solve_cost
-        return n <= d and 2 * n * k <= d * d
+        return _reward_space_is_cheaper(
+            n, factor.n_factored, size, self.sparse, factor.solve_cost, block_size
+        )
 
     def _validated_for_sampling(
         self, X: Union[NDArray[Any], csc_array]

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -1184,14 +1184,16 @@ def _blocked_colorize(
 ) -> NDArray[np.float64]:
     """``L_b @ z_{s,b}`` for every block ``b`` and draw ``s``.
 
-    ``L``: ``(n_blocks, k, k)``; ``z``: ``(n_blocks, size, k)``; returns
-    ``(size, n_blocks * k)``, written directly in C order.
+    ``L`` has shape ``(n_blocks, k, k)``, ``z`` has shape
+    ``(n_blocks, size, k)``; returns shape ``(size, n_blocks * k)``,
+    draw-contiguous per the sampling layout contract (see
+    :func:`~bayesianbandits._blas_helpers.draw_contiguous`).
     """
     n_blocks, size, k = z.shape
-    out = np.empty((size, n_blocks, k))
-    np.matmul(z, L.transpose(0, 2, 1), out=out.transpose(1, 0, 2))
-    # explicit column count: reshape(size, -1) is ambiguous when size == 0
-    return out.reshape(size, n_blocks * k)
+    out = np.empty((n_blocks, k, size))
+    np.matmul(L, z.transpose(0, 2, 1), out=out)
+    # explicit column count: reshape(-1, size) is ambiguous when size == 0
+    return out.reshape(n_blocks * k, size).T
 
 
 class _RewardSpacePredictiveMixin:
@@ -1725,7 +1727,8 @@ scipy.sparse.csc_array
         Returns
         -------
         samples : ndarray of shape (size, n_samples)
-            Predicted values for each posterior draw.
+            Predicted values for each posterior draw. Draw-contiguous
+            (``samples.T`` is C-contiguous).
 
         See Also
         --------
@@ -1767,7 +1770,8 @@ scipy.sparse.csc_array
         Returns
         -------
         samples : ndarray of shape (size, n_samples)
-            Independent marginal draws for each row.
+            Independent marginal draws for each row. Draw-contiguous
+            (``samples.T`` is C-contiguous).
 
         See Also
         --------
@@ -1775,7 +1779,7 @@ scipy.sparse.csc_array
         predict : Point predictions using the posterior mean.
         """
         mean, sd = _validated_marginal_mean_sd(self, X)
-        z = self.random_state_.standard_normal((size, mean.shape[0]))
+        z = standard_normal_f(self.random_state_, size, mean.shape[0])
         return cast(NDArray[np.float64], mean + sd * z)
 
     def sample_reward_space(
@@ -1826,7 +1830,8 @@ scipy.sparse.csc_array
         Returns
         -------
         samples : ndarray of shape (size, n_samples)
-            Predicted values for each posterior draw.
+            Predicted values for each posterior draw. Draw-contiguous
+            (``samples.T`` is C-contiguous).
 
         See Also
         --------
@@ -2223,7 +2228,8 @@ scipy.sparse.csc_array
         Returns
         -------
         samples : ndarray of shape (size, n_samples)
-            Predicted values for each posterior draw.
+            Predicted values for each posterior draw. Draw-contiguous
+            (``samples.T`` is C-contiguous).
 
         See Also
         --------
@@ -2266,7 +2272,8 @@ scipy.sparse.csc_array
         Returns
         -------
         samples : ndarray of shape (size, n_samples)
-            Independent marginal draws for each row.
+            Independent marginal draws for each row. Draw-contiguous
+            (``samples.T`` is C-contiguous).
 
         See Also
         --------
@@ -2275,10 +2282,11 @@ scipy.sparse.csc_array
         """
         mean, sd = _validated_marginal_mean_sd(self, X)
         df = 2.0 * self.a_
-        z = self.random_state_.standard_normal((size, mean.shape[0]))
+        z = standard_normal_f(self.random_state_, size, mean.shape[0])
         # one chi-square per (draw, row) cell: rows must be fully
-        # independent, not merely marginally exact
-        g = self.random_state_.chisquare(df, size=(size, mean.shape[0]))
+        # independent, not merely marginally exact; transposed fill for
+        # the draw-contiguous layout
+        g = self.random_state_.chisquare(df, size=(mean.shape[0], size)).T
         # the (b/a) scale factor and the df/g mixing fold into one
         # per-cell scale
         scale = np.sqrt((self.b_ / self.a_) * df / g)
@@ -2320,7 +2328,8 @@ scipy.sparse.csc_array
         Returns
         -------
         samples : ndarray of shape (size, n_samples)
-            Predicted values for each posterior draw.
+            Predicted values for each posterior draw. Draw-contiguous
+            (``samples.T`` is C-contiguous).
 
         See Also
         --------
@@ -2918,7 +2927,8 @@ scipy.sparse.csc_array
         samples : ndarray of shape (size, n_samples)
             Predicted values for each posterior sample. For
             ``link='logit'``, probabilities in [0, 1]. For
-            ``link='log'``, expected counts (positive reals).
+            ``link='log'``, expected counts (positive reals). Draw-contiguous
+            (``samples.T`` is C-contiguous).
 
         See Also
         --------
@@ -2957,7 +2967,8 @@ scipy.sparse.csc_array
         -------
         samples : ndarray of shape (size, n_samples)
             Independent marginal draws for each row, on the response
-            scale of the link.
+            scale of the link. Draw-contiguous
+            (``samples.T`` is C-contiguous).
 
         See Also
         --------
@@ -2965,7 +2976,7 @@ scipy.sparse.csc_array
         predict : Point predictions using the posterior mean.
         """
         mean, sd = _validated_marginal_mean_sd(self, X)
-        z = self.random_state_.standard_normal((size, mean.shape[0]))
+        z = standard_normal_f(self.random_state_, size, mean.shape[0])
         return self._inverse_link(mean + sd * z)
 
     def sample_reward_space(
@@ -3001,7 +3012,8 @@ scipy.sparse.csc_array
         -------
         samples : ndarray of shape (size, n_samples)
             Predicted values for each posterior sample, on the response
-            scale of the link.
+            scale of the link. Draw-contiguous
+            (``samples.T`` is C-contiguous).
 
         See Also
         --------

--- a/src/bayesianbandits/_support_covariance.py
+++ b/src/bayesianbandits/_support_covariance.py
@@ -148,24 +148,26 @@ class SupportDraw:
         ``scale`` multiplies the zero-mean part per draw, ``(size,)``, for
         the NIG multivariate-t mixing; ``mean`` is broadcast into the
         output buffer rather than added by the caller, which would cost
-        a second ``(size, n_rows)`` array.
+        a second ``(size, n_rows)`` array. Projected transposed so the
+        result is draw-contiguous (see
+        :func:`~bayesianbandits._blas_helpers.draw_contiguous`).
         """
         Z = standard_normal_f(rng, size, self._C.shape[0])
         if scale is not None:
             Z *= scale[:, np.newaxis]
         ZC = dgemm(1.0, Z, self._C, trans_b=1)
-        out = np.empty((size, self._n_rows), dtype=np.float64)
+        out = np.empty((self._n_rows, size), dtype=np.float64)
         if mean is not None:
-            out[:] = mean
+            out[:] = mean[:, np.newaxis]
         block = self._row_block()
         for start in range(0, self._n_rows, block):
             stop = min(self._n_rows, start + block)
-            drawn = dgemm(1.0, ZC, self._dense_rows(start, stop))
+            drawn = dgemm(1.0, self._dense_rows(start, stop), ZC, trans_a=1, trans_b=1)
             if mean is None:
-                out[:, start:stop] = drawn
+                out[start:stop] = drawn
             else:
-                out[:, start:stop] += drawn
-        return out
+                out[start:stop] += drawn
+        return out.T
 
     def sd(self) -> NDArray[np.float64]:
         """Per-row predictive standard deviations, shape ``(n_rows,)``."""

--- a/src/bayesianbandits/api.py
+++ b/src/bayesianbandits/api.py
@@ -50,6 +50,7 @@ Policy Functions
     EpsilonGreedy
     ThompsonSampling
     UpperConfidenceBound
+    InformationDirectedSampling
 
 """
 
@@ -79,35 +80,43 @@ from ._arm import (
     Learner,
     TokenType,
     _accepts_context_batch,
+    _sample_context_major_blocks,
     batch_identity,
-    is_elementwise_batch_reward,
     is_identity_function,
     posterior_identity,
     resolve_marginal_sampler,
+    resolve_reward_space_sampler,
 )
 from ._arm_featurizer import ArmFeaturizer
+from ._draw_kind import DrawKind
 from ._memory import MemoryUsageMixin
 from .policies import (  # noqa: F401
     EpsilonGreedy,
+    InformationDirectedSampling,
     ThompsonSampling,
     UpperConfidenceBound,
 )
 
 
 class PolicyProtocol(Protocol[ContextType, TokenType]):
-    marginal_ok: bool
-    """Whether iid per-row marginal draws (``sample_marginal``) may
-    replace joint ``sample`` draws for this policy. Set ``True`` only
-    when decisions consume per-(arm, context) statistics alone, for
-    which marginal draws are exact and much cheaper; policies that
-    compare arms within a shared posterior draw (e.g. Thompson
-    sampling) must keep it ``False``.
+    consumes: DrawKind
+    """The weakest posterior draws this policy can correctly consume.
 
-    This flag describes the policy only. Agents additionally require
-    the reward transform between sampler and policy to be elementwise,
-    so a ``LipschitzContextualAgent`` carrying an arm-combining
-    ``batch_reward_function`` keeps joint draws regardless of this
-    flag (see :func:`~bayesianbandits._arm.is_elementwise_batch_reward`)."""
+    Declaring a requirement rather than permitting a sampling method is
+    what keeps the choice of method entirely on the agent's side: it
+    may satisfy this with anything at least this strong (see
+    :class:`~bayesianbandits.DrawKind`), and picks whichever is
+    cheapest for the learner and draw count at hand.
+
+    An agent may *widen* this. A ``LipschitzContextualAgent`` carrying
+    a ``batch_reward_function`` widens to at least ``CONTEXT_JOINT``,
+    because that function runs before the policy and may combine arms
+    within a draw. It is never narrowed.
+
+    Defaults to ``JOINT`` on :class:`PolicyDefaultUpdate`, which is
+    always correct and never the cheapest; a policy scoring each arm
+    on its own should say ``MARGINAL_ONLY``.
+    """
 
     @overload
     def __call__(
@@ -888,21 +897,14 @@ class LipschitzContextualAgent(MemoryUsageMixin, Generic[TokenType]):
 
         Because the function sees a whole draw at once, it may combine
         arms *within* one draw -- share of total, cannibalization,
-        softmax over a slate. Supplying one therefore disables the
-        cheaper iid marginal sampling path that ``marginal_ok``
-        policies (:class:`EpsilonGreedy`,
-        :class:`UpperConfidenceBound`, ``EXP3A``) would otherwise use,
-        since those draws are not jointly distributed across arms. A
-        function that maps each ``(arm, context, draw)`` cell
-        independently can opt back into the faster path by carrying a
-        truthy ``elementwise`` attribute::
+        softmax over a slate. Supplying one therefore widens the
+        agent's draw requirement to at least
+        :attr:`~bayesianbandits.DrawKind.CONTEXT_JOINT`, whatever the
+        policy itself reads, so the arms of a draw are jointly
+        distributed when the function runs.
 
-            def revenue(samples, action_tokens):
-                return samples * multipliers[:, None, None]
-            revenue.elementwise = True
-
-        Per-arm ``Arm.reward_function``s are always applied one arm at
-        a time and never affect sampling.
+        A per-arm ``Arm.reward_function`` is always applied one arm at
+        a time and never affects sampling.
     random_seed : int, np.random.Generator, or None, default=None
         Controls the random number generator shared by the policy and
         the learner. Pass an int for reproducible results across calls.
@@ -1314,22 +1316,52 @@ class LipschitzContextualAgent(MemoryUsageMixin, Generic[TokenType]):
         # 3. Get samples from learner (SINGLE MODEL CALL). Policies that
         # consume only per-(arm, context) statistics opt into iid
         # marginal draws, which are exact for them and much cheaper.
-        # A batch reward function that combines arms within a draw needs
-        # those arms jointly distributed, which the marginal path does
-        # not provide -- the policy's own statistics are per-(arm,
-        # context), but the reward function runs before it (step 5)
-        marginal_ok = getattr(self.policy, "marginal_ok", False) and (
-            is_elementwise_batch_reward(self.batch_reward_function)
-        )
-        if marginal_ok:
+        # Policies that consume each context independently but need
+        # joint draws across arms (e.g. IDS) opt into per-context
+        # reward-space blocks instead.
+        n_arms, n_contexts = len(self.arms), len(X)
+        samples = None
+        reshaped = None
+        # A batch reward function runs before the policy (step 5) and
+        # sees a whole draw, so it may combine arms within one -- share
+        # of total, cannibalization, a softmax over a slate. That needs
+        # the arms of a draw jointly distributed whatever the policy
+        # itself reads, so widen. ``batch_identity`` combines nothing.
+        required = self.policy.consumes
+        if self.batch_reward_function not in (None, batch_identity):
+            required = max(required, DrawKind.CONTEXT_JOINT)
+
+        if required == DrawKind.MARGINAL_ONLY:
             sampler = resolve_marginal_sampler(self.learner)
-        else:
-            sampler = self.learner.sample
-        samples = sampler(X_enriched, size=self.policy.samples_needed)
-        # Shape: (size, n_contexts * n_arms) or (size, n_contexts * n_arms, n_classes)
+            samples = sampler(X_enriched, size=self.policy.samples_needed)
+        elif required == DrawKind.CONTEXT_JOINT:
+            joint_sampler = resolve_reward_space_sampler(
+                self.learner,
+                n_rows=n_arms * n_contexts,
+                size=self.policy.samples_needed,
+                block_size=n_arms,
+            )
+            if joint_sampler is not None:
+                # Already in the (n_arms, n_contexts, size) layout of
+                # step 4, so the unified reshape is skipped
+                reshaped = _sample_context_major_blocks(
+                    joint_sampler,
+                    X_enriched,
+                    n_arms,
+                    n_contexts,
+                    self.policy.samples_needed,
+                )
 
         # 4. Unified reshape
-        samples = self._reshape_samples(samples, len(self.arms), len(X))
+        if reshaped is None:
+            if samples is None:
+                samples = self.learner.sample(
+                    X_enriched, size=self.policy.samples_needed
+                )
+            # Shape: (size, n_contexts * n_arms) or
+            # (size, n_contexts * n_arms, n_classes)
+            reshaped = self._reshape_samples(samples, n_arms, n_contexts)
+        samples = reshaped
         # Shape: (n_arms, n_contexts, size, ...)
 
         # 5. Apply reward functions

--- a/src/bayesianbandits/api.py
+++ b/src/bayesianbandits/api.py
@@ -103,23 +103,13 @@ class PolicyProtocol(Protocol[ContextType, TokenType]):
     consumes: DrawKind
     """The weakest posterior draws this policy can correctly consume.
 
-    Declaring a requirement rather than permitting a sampling method is
-    what keeps the choice of method entirely on the agent's side: it
-    may satisfy this with anything at least this strong (see
-    :class:`~bayesianbandits.DrawKind`), and picks whichever is
-    cheapest for the learner and draw count at hand.
-
-    An agent may *widen* this. A ``LipschitzContextualAgent`` carrying
-    a ``batch_reward_function`` widens to at least ``CONTEXT_JOINT``,
-    because that function runs before the policy and may combine arms
-    within a draw. It is never narrowed.
-
-    Defaults to ``JOINT`` on :class:`PolicyDefaultUpdate`, which is
-    always correct and never the cheapest; a policy scoring each arm
-    on its own should say ``MARGINAL_ONLY``.
-
-    The agents also keep a layout contract: the tensor handed to
-    ``select`` always has a unit-stride draw axis.
+    An agent satisfies this with anything at least as strong, picking
+    whichever method is cheapest, and may widen it but never narrow it
+    (see :class:`~bayesianbandits.DrawKind` for the semantics).
+    Defaults to ``JOINT`` on :class:`PolicyDefaultUpdate`, always
+    correct and never the cheapest. The agents also keep a layout
+    contract: the tensor handed to ``select`` always has a unit-stride
+    draw axis.
     """
 
     @overload
@@ -902,10 +892,10 @@ class LipschitzContextualAgent(MemoryUsageMixin, Generic[TokenType]):
         Because the function sees a whole draw at once, it may combine
         arms *within* one draw -- share of total, cannibalization,
         softmax over a slate. Supplying one therefore widens the
-        agent's draw requirement to at least
-        :attr:`~bayesianbandits.DrawKind.CONTEXT_JOINT`, whatever the
-        policy itself reads, so the arms of a draw are jointly
-        distributed when the function runs.
+        agent's draw requirement to
+        :attr:`~bayesianbandits.DrawKind.JOINT`, whatever the policy
+        itself reads, so the whole draw is jointly distributed when
+        the function runs.
 
         A per-arm ``Arm.reward_function`` is always applied one arm at
         a time and never affects sampling.
@@ -1319,23 +1309,19 @@ class LipschitzContextualAgent(MemoryUsageMixin, Generic[TokenType]):
         X_enriched = self.arm_featurizer.transform(X, action_tokens=action_tokens)
         # Shape: (n_contexts * n_arms, n_features_enriched)
 
-        # 3. Get samples from learner (SINGLE MODEL CALL). Policies that
-        # consume only per-(arm, context) statistics opt into iid
-        # marginal draws, which are exact for them and much cheaper.
-        # Policies that consume each context independently but need
-        # joint draws across arms (e.g. IDS) opt into per-context
-        # reward-space blocks instead.
+        # 3. Get samples from learner (SINGLE MODEL CALL), by the
+        # cheapest method at least as strong as the policy's
+        # ``consumes`` (see DrawKind).
         n_arms, n_contexts = len(self.arms), len(X)
         samples = None
         reshaped = None
         # A batch reward function runs before the policy (step 5) and
-        # sees a whole draw, so it may combine arms within one -- share
-        # of total, cannibalization, a softmax over a slate. That needs
-        # the arms of a draw jointly distributed whatever the policy
-        # itself reads, so widen. ``batch_identity`` combines nothing.
-        required = self.policy.consumes
+        # may combine anything within a draw, so widen all the way;
+        # ``batch_identity`` combines nothing. Structurally typed
+        # policies that predate ``consumes`` get the safe default.
+        required = getattr(self.policy, "consumes", DrawKind.JOINT)
         if self.batch_reward_function not in (None, batch_identity):
-            required = max(required, DrawKind.CONTEXT_JOINT)
+            required = DrawKind.JOINT
 
         if required == DrawKind.MARGINAL_ONLY:
             sampler = resolve_marginal_sampler(self.learner)
@@ -1392,7 +1378,9 @@ class LipschitzContextualAgent(MemoryUsageMixin, Generic[TokenType]):
                     f"batch_reward_function returned wrong shape. "
                     f"Expected shape[:3]={expected_shape}, got shape={result.shape}"
                 )
-            samples = result
+            # the function may hand back any layout; re-establish the
+            # unit-stride draw axis the policy is promised
+            samples = draw_contiguous(result) if result.ndim == 3 else result
         else:
             # Fall back to individual arm functions
             from ._arm import apply_reward_function

--- a/src/bayesianbandits/api.py
+++ b/src/bayesianbandits/api.py
@@ -88,6 +88,7 @@ from ._arm import (
     resolve_reward_space_sampler,
 )
 from ._arm_featurizer import ArmFeaturizer
+from ._blas_helpers import draw_contiguous
 from ._draw_kind import DrawKind
 from ._memory import MemoryUsageMixin
 from .policies import (  # noqa: F401
@@ -116,6 +117,9 @@ class PolicyProtocol(Protocol[ContextType, TokenType]):
     Defaults to ``JOINT`` on :class:`PolicyDefaultUpdate`, which is
     always correct and never the cheapest; a policy scoring each arm
     on its own should say ``MARGINAL_ONLY``.
+
+    The agents also keep a layout contract: the tensor handed to
+    ``select`` always has a unit-stride draw axis.
     """
 
     @overload
@@ -1159,8 +1163,10 @@ class LipschitzContextualAgent(MemoryUsageMixin, Generic[TokenType]):
             Reshaped array with shape (n_arms, n_contexts, size, ...)
         """
         if samples.ndim == 2:
-            # 2D case: (size, n_contexts*n_arms) -> (n_arms, n_contexts, size)
-            return samples.T.reshape(n_arms, n_contexts, -1)
+            # 2D case: (size, n_contexts*n_arms) -> (n_arms, n_contexts, size);
+            # draw_contiguous no-ops for contract-conforming learners and
+            # normalizes the layout otherwise
+            return draw_contiguous(samples.T.reshape(n_arms, n_contexts, -1))
         else:
             # 3D+ case: (size, n_contexts*n_arms, ...) -> (n_arms, n_contexts, size, ...)
             samples_moved = np.moveaxis(samples, 0, 1)  # Move size to position 1

--- a/src/bayesianbandits/pipelines/_learner.py
+++ b/src/bayesianbandits/pipelines/_learner.py
@@ -12,7 +12,12 @@ import numpy as np
 from numpy.typing import NDArray
 from typing_extensions import Self
 
-from .._arm import Learner, resolve_marginal_sampler, resolve_reward_space_sampler
+from .._arm import (
+    Learner,
+    _defines_before_sample,
+    resolve_marginal_sampler,
+    resolve_reward_space_sampler,
+)
 from .._memory import MemoryUsageMixin
 
 X_contra = TypeVar("X_contra", contravariant=True)
@@ -300,13 +305,13 @@ class LearnerPipeline(MemoryUsageMixin, Generic[X_contra]):
     ) -> NDArray[np.float64]:
         """Sample joint draws in reward space from the posterior predictive.
 
-        Forwards to the learner's ``sample_reward_space`` when it is
-        safe and profitable (see
-        :func:`bayesianbandits._arm.resolve_reward_space_sampler`),
-        falling back to joint ``sample`` otherwise. The fallback is
-        fully joint across all rows -- a superset of the per-block
-        joint guarantee -- so callers consuming per-block statistics
-        stay correct either way.
+        Forwards to the learner's ``sample_reward_space`` whenever that
+        is safe to call (defined at or above any ``sample`` override),
+        so a pipeline answers exactly as its wrapped estimator would.
+        Whether reward space is *profitable* for a shape is the
+        caller's question (:meth:`_use_reward_space`), not this
+        method's. The unsafe case falls back to fully joint ``sample``,
+        a superset of the per-block guarantee.
 
         Parameters
         ----------
@@ -325,11 +330,14 @@ class LearnerPipeline(MemoryUsageMixin, Generic[X_contra]):
             Joint samples for each row
         """
         X_transformed = self._apply_transformers(X)
-        n_rows = int(X_transformed.shape[0])
-        sampler = resolve_reward_space_sampler(self._learner, n_rows, size, block_size)
-        if sampler is None:
+        if not _defines_before_sample(self._learner, "sample_reward_space"):
             return self._learner.sample(X_transformed, size)
-        return sampler(X_transformed, size)
+        return cast(
+            NDArray[np.float64],
+            cast(Any, self._learner).sample_reward_space(
+                X_transformed, size, block_size=block_size
+            ),
+        )
 
     def partial_fit(
         self,

--- a/src/bayesianbandits/pipelines/_learner.py
+++ b/src/bayesianbandits/pipelines/_learner.py
@@ -12,7 +12,7 @@ import numpy as np
 from numpy.typing import NDArray
 from typing_extensions import Self
 
-from .._arm import Learner, resolve_marginal_sampler
+from .._arm import Learner, resolve_marginal_sampler, resolve_reward_space_sampler
 from .._memory import MemoryUsageMixin
 
 X_contra = TypeVar("X_contra", contravariant=True)
@@ -286,6 +286,50 @@ class LearnerPipeline(MemoryUsageMixin, Generic[X_contra]):
         """
         X_transformed = self._apply_transformers(X)
         return resolve_marginal_sampler(self._learner)(X_transformed, size)
+
+    def _use_reward_space(
+        self, n: int, size: int, block_size: Optional[int] = None
+    ) -> bool:
+        """Forward the reward-space flop gate to the wrapped learner."""
+        return (
+            resolve_reward_space_sampler(self._learner, n, size, block_size) is not None
+        )
+
+    def sample_reward_space(
+        self, X: X_contra, size: int = 1, *, block_size: Optional[int] = None
+    ) -> NDArray[np.float64]:
+        """Sample joint draws in reward space from the posterior predictive.
+
+        Forwards to the learner's ``sample_reward_space`` when it is
+        safe and profitable (see
+        :func:`bayesianbandits._arm.resolve_reward_space_sampler`),
+        falling back to joint ``sample`` otherwise. The fallback is
+        fully joint across all rows -- a superset of the per-block
+        joint guarantee -- so callers consuming per-block statistics
+        stay correct either way.
+
+        Parameters
+        ----------
+        X : X_contra
+            Input data (enriched features from ArmFeaturizer)
+        size : int, default=1
+            Number of samples to draw
+        block_size : int, optional
+            Forwarded to the learner: rows are drawn jointly within
+            consecutive blocks of this many rows and independently
+            across blocks.
+
+        Returns
+        -------
+        samples : NDArray[np.float64]
+            Joint samples for each row
+        """
+        X_transformed = self._apply_transformers(X)
+        n_rows = int(X_transformed.shape[0])
+        sampler = resolve_reward_space_sampler(self._learner, n_rows, size, block_size)
+        if sampler is None:
+            return self._learner.sample(X_transformed, size)
+        return sampler(X_transformed, size)
 
     def partial_fit(
         self,

--- a/src/bayesianbandits/policies/__init__.py
+++ b/src/bayesianbandits/policies/__init__.py
@@ -1,11 +1,13 @@
 from ._epsilon_greedy import EpsilonGreedy
 from ._exp3a import EXP3A
+from ._information_directed_sampling import InformationDirectedSampling
 from ._thompson_sampling import ThompsonSampling
 from ._upper_confidence_bound import UpperConfidenceBound
 
 __all__ = [
     "EXP3A",
     "EpsilonGreedy",
+    "InformationDirectedSampling",
     "ThompsonSampling",
     "UpperConfidenceBound",
 ]

--- a/src/bayesianbandits/policies/_base.py
+++ b/src/bayesianbandits/policies/_base.py
@@ -46,18 +46,18 @@ class PolicyDefaultUpdate(Generic[ContextType, TokenType]):
         samples that learner once for all arms rather than coming
         through here.
         """
-        samples = np.array(
+        # Stacking transposed builds (n_arms, n_contexts, size) in one
+        # copy with the draw axis contiguous (the layout contract).
+        return np.array(
             [
                 (
                     arm.sample_marginal
                     if self.consumes == DrawKind.MARGINAL_ONLY
                     else arm.sample
-                )(X, size)
+                )(X, size).T
                 for arm in arms
             ]
         )
-        # Convert from (n_arms, size, n_contexts) to (n_arms, n_contexts, size)
-        return samples.transpose(0, 2, 1)
 
     def update(
         self,

--- a/src/bayesianbandits/policies/_base.py
+++ b/src/bayesianbandits/policies/_base.py
@@ -12,14 +12,14 @@ import numpy as np
 from numpy.typing import NDArray
 
 from .._arm import Arm, ContextType, TokenType
+from .._draw_kind import DrawKind
 
 
 class PolicyDefaultUpdate(Generic[ContextType, TokenType]):
-    #: Safe default satisfying ``PolicyProtocol``: joint ``sample``
-    #: draws serve every policy. Subclasses opt into cheaper sampling
-    #: modes by overriding this (see
-    #: :class:`~bayesianbandits.api.PolicyProtocol` for the semantics).
-    marginal_ok: bool = False
+    #: Safe default satisfying ``PolicyProtocol``: fully joint draws
+    #: serve every policy. Subclasses declare a weaker requirement to
+    #: get cheaper draws (see :class:`~bayesianbandits.DrawKind`).
+    consumes: DrawKind = DrawKind.JOINT
 
     def _draw_samples(
         self,
@@ -29,10 +29,12 @@ class PolicyDefaultUpdate(Generic[ContextType, TokenType]):
     ) -> NDArray[np.float64]:
         """Draw ``(n_arms, n_contexts, size)`` samples for ``select``.
 
-        Samples each arm from its own learner, marginally when
-        ``marginal_ok`` (iid per-row draws are exact for policies
-        consuming only per-(arm, context) statistics) and jointly
-        otherwise.
+        Samples each arm from its own learner, marginally when the
+        policy consumes ``MARGINAL_ONLY`` (iid per-row draws are exact
+        for policies reading only per-(arm, context) statistics) and
+        jointly otherwise. ``CONTEXT_JOINT`` and ``JOINT`` coincide
+        here: every arm has its own learner, so there is no cross-arm
+        dependence for a context block to preserve.
 
         Drawing one arm at a time is the correct joint law here because
         agents using this path give every arm an independent learner --
@@ -46,7 +48,11 @@ class PolicyDefaultUpdate(Generic[ContextType, TokenType]):
         """
         samples = np.array(
             [
-                (arm.sample_marginal if self.marginal_ok else arm.sample)(X, size)
+                (
+                    arm.sample_marginal
+                    if self.consumes == DrawKind.MARGINAL_ONLY
+                    else arm.sample
+                )(X, size)
                 for arm in arms
             ]
         )

--- a/src/bayesianbandits/policies/_epsilon_greedy.py
+++ b/src/bayesianbandits/policies/_epsilon_greedy.py
@@ -114,9 +114,6 @@ class EpsilonGreedy(PolicyDefaultUpdate[ContextType, TokenType]):
     #: draws (``sample_marginal``) are exact for this policy.
     consumes = DrawKind.MARGINAL_ONLY
 
-    #: The marginal path already serves this policy's per-(arm, context)
-    #: statistics; per-context joint blocks are unnecessary.
-
     @property
     def samples_needed(self) -> int:
         """Number of samples per arm per context needed for decision making."""

--- a/src/bayesianbandits/policies/_epsilon_greedy.py
+++ b/src/bayesianbandits/policies/_epsilon_greedy.py
@@ -13,6 +13,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from .._arm import Arm, ContextType, TokenType
+from .._draw_kind import DrawKind
 from ._base import PolicyDefaultUpdate
 
 
@@ -111,7 +112,10 @@ class EpsilonGreedy(PolicyDefaultUpdate[ContextType, TokenType]):
 
     #: Consumes only per-(arm, context) statistics, so iid marginal
     #: draws (``sample_marginal``) are exact for this policy.
-    marginal_ok = True
+    consumes = DrawKind.MARGINAL_ONLY
+
+    #: The marginal path already serves this policy's per-(arm, context)
+    #: statistics; per-context joint blocks are unnecessary.
 
     @property
     def samples_needed(self) -> int:

--- a/src/bayesianbandits/policies/_exp3a.py
+++ b/src/bayesianbandits/policies/_exp3a.py
@@ -226,9 +226,6 @@ class EXP3A(PolicyDefaultUpdate[ContextType, TokenType]):
     #: draws (``sample_marginal``) are exact for this policy.
     consumes = DrawKind.MARGINAL_ONLY
 
-    #: The marginal path already serves this policy's per-(arm, context)
-    #: statistics; per-context joint blocks are unnecessary.
-
     @property
     def samples_needed(self) -> int:
         """Number of samples per arm per context needed for decision making."""

--- a/src/bayesianbandits/policies/_exp3a.py
+++ b/src/bayesianbandits/policies/_exp3a.py
@@ -12,6 +12,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from .._arm import Arm, ContextType, TokenType
+from .._draw_kind import DrawKind
 from ._base import PolicyDefaultUpdate
 
 
@@ -223,7 +224,10 @@ class EXP3A(PolicyDefaultUpdate[ContextType, TokenType]):
 
     #: Consumes only per-(arm, context) statistics, so iid marginal
     #: draws (``sample_marginal``) are exact for this policy.
-    marginal_ok = True
+    consumes = DrawKind.MARGINAL_ONLY
+
+    #: The marginal path already serves this policy's per-(arm, context)
+    #: statistics; per-context joint blocks are unnecessary.
 
     @property
     def samples_needed(self) -> int:
@@ -388,7 +392,7 @@ class EXP3A(PolicyDefaultUpdate[ContextType, TokenType]):
             multiplied with the importance weights.
         """
         # Recompute probabilities (stateless design); only per-arm means
-        # are consumed, so marginal draws are exact when marginal_ok
+        # are read, which is why this policy consumes MARGINAL_ONLY
         rewards = self._draw_samples(all_arms, X, self.samples).mean(axis=-1)
         weights = np.exp(self.eta * (rewards - rewards.max(axis=0)))
 

--- a/src/bayesianbandits/policies/_information_directed_sampling.py
+++ b/src/bayesianbandits/policies/_information_directed_sampling.py
@@ -7,6 +7,7 @@ from typing import (
     Optional,
     Tuple,
     Union,
+    cast,
     overload,
 )
 
@@ -19,11 +20,38 @@ from .._draw_kind import DrawKind
 from ._base import PolicyDefaultUpdate
 
 
+def _finite_draws(
+    samples: NDArray[np.float64], rng: np.random.Generator
+) -> NDArray[np.float64]:
+    """Replace non-finite draws so one overflow cannot pin a decision.
+
+    A single ``inf`` or ``nan`` (a log-link GLM overflowing, say) makes
+    that context's regret and gain non-finite for *every* arm, and the
+    resolved-posterior fallback would then deterministically play the
+    overflowed arm on every call. Each offending draw is replaced, for
+    all arms of its context, by a random finite draw of the same
+    context, keeping within-draw coherence; a context with no finite
+    draw is zeroed, leaving its arms tied. Finite inputs pass through.
+    """
+    finite = np.isfinite(samples)
+    if finite.all():
+        return samples
+    samples = samples.copy()
+    good_draw = cast(NDArray[np.bool_], np.all(finite, axis=0))  # (n_contexts, n_draws)
+    for ctx in np.flatnonzero(~np.all(good_draw, axis=1)):
+        good = np.flatnonzero(good_draw[ctx])
+        bad = np.flatnonzero(~good_draw[ctx])
+        if good.size == 0:
+            samples[:, ctx, :] = 0.0
+        else:
+            samples[:, ctx, bad] = samples[:, ctx, rng.choice(good, size=bad.size)]
+    return samples
+
+
 def _vids_statistics(
     samples: NDArray[np.float64],
     alive: NDArray[np.bool_],
     masked: Optional[NDArray[np.float64]] = None,
-    mu: Optional[NDArray[np.float64]] = None,
     indicator: Optional[NDArray[np.bool_]] = None,
 ) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
     """Monte Carlo regret and information-gain estimates, ``(n_arms, n_contexts)``.
@@ -35,9 +63,10 @@ def _vids_statistics(
     learning which alive arm is optimal. ``samples`` is
     ``(n_arms, n_contexts, n_draws)`` and must be jointly coherent across
     arms within a draw; dead arms are excluded from the argmax and their
-    returned statistics are meaningless. ``masked``, ``mu``, and
-    ``indicator`` let the top_k slot loop reuse the alive-masked tensor,
-    the means, and the boolean scratch across slots.
+    returned statistics are meaningless. ``masked`` and ``indicator``
+    let the top_k slot loop reuse the alive-masked tensor and the
+    boolean scratch across slots. Every entry of ``samples`` must be
+    finite: one ``inf`` or ``nan`` draw poisons its context's row sums.
 
     Only arms winning at least one draw enter the conditioning
     (:math:`p(A^* = b) = 0` zeroes every other term exactly), so the
@@ -48,7 +77,6 @@ def _vids_statistics(
     n_arms, n_contexts, n_draws = samples.shape
     if masked is None:
         masked = np.where(alive[:, :, np.newaxis], samples, -np.inf)
-    means = mu  # (n_arms, n_contexts); derived from the GEMM below if None
 
     # max + equality pass: cheaper than argmax over the leading axis,
     # and downstream wants the indicator, not the label
@@ -79,10 +107,9 @@ def _vids_statistics(
     # cond_sums[c, a, b]: arm a's draw total where ever-optimal arm b wins
     cond_sums = np.matmul(samples.transpose(1, 0, 2), weights.transpose(0, 2, 1))
     row_sums = cond_sums.sum(axis=-1)  # (C, K): each arm's full draw sum
-    if means is None:
-        # the weight columns partition the draws, so the row sums are
-        # already each arm's draw total: no extra pass for the means
-        means = row_sums.T / n_draws
+    # the weight columns partition the draws, so the row sums are
+    # already each arm's draw total: no extra pass for the means
+    means = row_sums.T / n_draws  # (n_arms, n_contexts)
 
     # E[max] from the same GEMM: the winning arm's entry sums rho over
     # its winning draws (ties still add rho exactly once). Regret as a
@@ -415,7 +442,7 @@ class InformationDirectedSampling(PolicyDefaultUpdate[ContextType, TokenType]):
         List[Arm[ContextType, TokenType]], List[List[Arm[ContextType, TokenType]]]
     ]:
         """Select arms by minimizing the information ratio over pre-generated samples."""
-        samples = draw_contiguous(samples)
+        samples = _finite_draws(draw_contiguous(samples), rng)
         n_arms, n_contexts, _ = samples.shape
         n_slots = 1 if top_k is None else min(top_k, n_arms)
 

--- a/src/bayesianbandits/policies/_information_directed_sampling.py
+++ b/src/bayesianbandits/policies/_information_directed_sampling.py
@@ -17,12 +17,44 @@ from .._arm import Arm, ContextType, TokenType
 from .._draw_kind import DrawKind
 from ._base import PolicyDefaultUpdate
 
+#: Byte budget for one slab of the draw-major copy below. Sized to keep
+#: the source block of a slab resident in L2 while it is scattered out.
+_COPY_SLAB_BYTES = 1 << 20
+
+
+def _draw_contiguous(samples: NDArray[np.float64]) -> NDArray[np.float64]:
+    """``samples`` as a C-ordered ``(n_arms, n_contexts, n_draws)`` tensor.
+
+    Agents hand this tensor to a policy as a transposed view of the
+    learner's ``(size, n_rows)`` output, which leaves the draw axis with
+    the *largest* stride. Every statistic below reduces or contracts over
+    draws, and the conditional-mean GEMM falls off BLAS entirely in that
+    layout: materializing the natural order first costs one pass and buys
+    back two orders of magnitude.
+
+    numpy's own copy walks the draw axis outermost and so touches a fresh
+    cache line per element. Copying a slab of draws at a time keeps the
+    source block resident while it is scattered out, which runs about
+    three times faster on the large shapes. Already-contiguous input is
+    returned untouched.
+    """
+    if samples.dtype == np.float64 and samples.flags.c_contiguous:
+        return samples
+    n_arms, n_contexts, n_draws = samples.shape
+    out = np.empty(samples.shape, dtype=np.float64)
+    slab = max(1, min(n_draws, _COPY_SLAB_BYTES // max(1, n_arms * n_contexts * 8)))
+    for start in range(0, n_draws, slab):
+        stop = start + slab
+        out[:, :, start:stop] = samples[:, :, start:stop]
+    return out
+
 
 def _vids_statistics(
     samples: NDArray[np.float64],
     alive: NDArray[np.bool_],
     masked: Optional[NDArray[np.float64]] = None,
     mu: Optional[NDArray[np.float64]] = None,
+    indicator: Optional[NDArray[np.bool_]] = None,
 ) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
     """Monte Carlo estimates of expected regret and variance-based information gain.
 
@@ -39,8 +71,16 @@ def _vids_statistics(
         statistics are meaningless.
     masked, mu : NDArray[np.float64], optional
         Precomputed ``np.where(alive[:, :, np.newaxis], samples, -np.inf)``
-        and ``samples.mean(axis=-1)``. The top_k slot loop maintains these
-        across slots rather than re-materializing them here each slot.
+        and ``samples.mean(axis=-1)``. The top_k slot loop maintains
+        ``masked`` in place across slots rather than re-materializing it
+        here each slot. When ``mu`` is omitted, the means are recovered
+        from the conditional-sum GEMM at no cost (its columns partition
+        the draws, so its row sums are the arms' draw totals) rather than
+        by a pass over the tensor.
+    indicator : NDArray[np.bool_], optional
+        Boolean scratch buffer shaped like ``samples``. The top_k slot
+        loop passes one in so the largest allocation here happens once per
+        ``select`` rather than once per slot.
 
     Returns
     -------
@@ -51,30 +91,87 @@ def _vids_statistics(
         :math:`\\sum_{a'} p(a') (\\mathbb{E}[\\theta_a \\mid A^* = a'] -
         \\mathbb{E}[\\theta_a])^2`, the variance of arm ``a``'s posterior
         mean under resolution of which alive arm is optimal.
+
+    Notes
+    -----
+    The conditioning is only over arms that win at least one draw:
+    :math:`p(A^* = b) = 0` for every other arm, so its term in
+    :math:`v` is exactly zero and its conditional means are never read.
+    The conditional-sum GEMM therefore runs over ``M`` columns rather
+    than ``n_arms``, where ``M`` is the number of ever-optimal arms per
+    context -- typically far below ``n_arms`` once the posterior has any
+    shape (often single digits at 96 arms). Cost drops from
+    :math:`O(K^2 S)` to :math:`O(K M S)` per context with the result
+    unchanged, since only zero-weight terms are dropped.
     """
-    n_arms, _, n_draws = samples.shape
+    n_arms, n_contexts, n_draws = samples.shape
     if masked is None:
         masked = np.where(alive[:, :, np.newaxis], samples, -np.inf)
-    means: NDArray[np.float64] = (
-        samples.mean(axis=-1) if mu is None else mu
-    )  # (n_arms, n_contexts)
-    argmax_idx = masked.argmax(axis=0)  # (n_contexts, n_draws)
-    # the values at the argmax are the max: gather them rather than
-    # sweeping the full (n_arms, n_contexts, n_draws) tensor a second time
-    rho_star = np.take_along_axis(masked, argmax_idx[np.newaxis], axis=0)[0].mean(
-        axis=-1
-    )  # (n_contexts,)
-    delta = np.clip(rho_star[np.newaxis, :] - means, 0.0, None)
+    means = mu  # (n_arms, n_contexts); derived from the GEMM below if None
 
-    onehot = (argmax_idx[:, :, np.newaxis] == np.arange(n_arms)).astype(np.float64)
-    counts = onehot.sum(axis=1).T  # (n_arms, n_contexts); zero for dead arms
-    p_opt = counts / n_draws
-    # cond_sums[a, b, c]: sum of arm a's draws over the draws where b is
-    # optimal, as a batched GEMM over contexts (much faster than einsum here)
-    cond_sums = np.matmul(samples.transpose(1, 0, 2), onehot).transpose(1, 2, 0)
-    mu_cond = cond_sums / np.maximum(counts, 1.0)[np.newaxis, :, :]
+    # The max, not the argmax. Everything downstream wants the *indicator*
+    # of the optimal arm rather than its label, and numpy reduces over a
+    # leading axis with a generic loop: argmax over axis 0 of this tensor
+    # costs several times the contiguous max plus the equality pass that
+    # produces the indicator directly.
+    rho = masked.max(axis=0)  # (n_contexts, n_draws)
+    is_opt: NDArray[np.bool_] = (
+        np.empty(samples.shape, dtype=np.bool_) if indicator is None else indicator
+    )
+    np.equal(masked, rho, out=is_opt)
+    # summing bool promotes elementwise to int64 and runs ~4x slower than
+    # a uint16 accumulator, which n_draws < 2**16 makes exact
+    count_dtype = np.uint16 if n_draws < 2**16 else np.int64
+    counts = np.add.reduce(
+        is_opt.view(np.uint8), axis=-1, dtype=count_dtype
+    )  # (n_arms, n_contexts); zero for dead arms
+
+    # Gather the ever-optimal arms per context, padded to the widest
+    # context with never-optimal arms (whose weight is zero, so padding
+    # contributes nothing).
+    ever = counts > 0
+    m_max = int(ever.sum(axis=0).max())
+    opt_idx = np.argsort(~ever, axis=0, kind="stable")[:m_max].T  # (C, M)
+    ctx_col = np.arange(n_contexts)[:, np.newaxis]
+    weights = is_opt[opt_idx, ctx_col, :].astype(np.float64)  # (C, M, n_draws)
+    if int(counts.sum()) != n_contexts * n_draws:
+        # Exact ties are measure-zero for a continuous posterior but not
+        # impossible: duplicate arms under a shared learner draw identical
+        # rewards. Split a tied draw evenly so p_opt stays a probability.
+        # Every marked arm is ever-optimal, so the per-draw total over the
+        # gathered columns is the full total.
+        weights /= weights.sum(axis=1, keepdims=True)
+    counts_sub = weights.sum(axis=-1)  # (C, M)
+    p_opt = counts_sub / n_draws
+    # cond_sums[c, a, b]: sum of arm a's draws over the draws where
+    # ever-optimal arm b is optimal, as a batched GEMM over contexts
+    cond_sums = np.matmul(samples.transpose(1, 0, 2), weights.transpose(0, 2, 1))
+    row_sums = cond_sums.sum(axis=-1)  # (C, K): each arm's full draw sum
+    if means is None:
+        # The gathered columns carry total weight one on every draw, so
+        # cond_sums' rows already hold each arm's full draw sum: the mean
+        # falls out of the GEMM and needs no pass over the tensor.
+        means = row_sums.T / n_draws
+
+    # E[max] from the same GEMM: entry (c, opt_idx[c, m], m) sums the
+    # winning arm's own draws over the draws it wins, i.e. rho over those
+    # draws (on a tied draw every marked arm equals the max, so the split
+    # weights still add rho exactly once). Summing over m totals rho.
+    # Taking regret as a difference of cond_sums entries keeps the
+    # zero-regret case *exactly* zero: an always-optimal arm's rho_sums
+    # and row_sums are the same float, so its ratio classifies as 0, not
+    # as an ulp of regret with no gain (which would read as resolved).
+    rho_sums = cond_sums[ctx_col, opt_idx, np.arange(m_max)[np.newaxis, :]].sum(axis=1)
+    delta = np.clip((rho_sums[:, np.newaxis] - row_sums).T / n_draws, 0.0, None)
+
+    # guard the zero-count columns only: a split tie leaves fractional
+    # counts, which clamping up to one would silently rescale
+    nonzero = np.where(counts_sub > 0.0, counts_sub, 1.0)
+    mu_cond = cond_sums / nonzero[:, np.newaxis, :]
     # counts == 0 leaves mu_cond at 0, but p_opt == 0 zeroes the term anyway
-    v = np.einsum("bc,abc->ac", p_opt, (mu_cond - means[:, np.newaxis, :]) ** 2)
+    dev = mu_cond - means.T[:, :, np.newaxis]
+    dev *= dev
+    v = np.matmul(dev, p_opt[:, :, np.newaxis])[:, :, 0].T
     return delta, v
 
 
@@ -89,13 +186,38 @@ def _optimal_two_point(
 
     The minimizer of :math:`\\Delta(\\pi)^2 / v(\\pi)` over distributions
     :math:`\\pi` is supported on at most two arms (Russo & Van Roy 2018,
-    Prop. 6), so it suffices to scan all ordered pairs ``(a, b)``. For a
-    fixed pair, with mixing weight ``q`` on ``a``, the ratio is
+    Prop. 6), so it suffices to scan pairs ``(a, b)``. For a fixed pair,
+    with mixing weight ``q`` on ``a``, the ratio is
     ``(A q + B)^2 / (C q + D)`` where ``A = delta_a - delta_b``,
     ``B = delta_b``, ``C = v_a - v_b``, ``D = v_b``; its stationary points
     are ``q = -B / A`` (zero regret) and ``q = (C B - 2 A D) / (A C)``, so
     the minimum over ``q`` in ``[0, 1]`` is attained at one of those
     (clipped) or an endpoint.
+
+    Four reductions cut the scan well below its ``K^2 x 4`` face value
+    without excluding any candidate that could be the optimum, so the
+    minimum is the same:
+
+    * The endpoints ``q = 0`` and ``q = 1`` evaluate to the *single-arm*
+      ratios ``delta_b^2 / v_b`` and ``delta_a^2 / v_a``. Their minimum
+      over all pairs is the best single-arm ratio, an ``O(K)`` sweep per
+      context instead of ``O(K^2)``.
+    * ``q = -B / A`` never lands strictly inside ``(0, 1)``. Regret is
+      clipped at zero, so ``B >= 0``, and the root is ``<= 0`` when
+      ``A > 0`` and ``>= 1`` when ``A < 0``: an endpoint either way, and
+      hence already covered by the sweep above.
+    * Only the Pareto frontier of the ``(v_a, delta_a)`` points can
+      support an optimal mixture. If ``a'`` weakly dominates ``a``
+      (``v_a' >= v_a`` and ``delta_a' <= delta_a``), moving ``a``'s
+      weight to ``a'`` cannot increase :math:`\\Delta(\\pi)` and cannot
+      decrease :math:`v(\\pi)`, so it cannot increase the ratio: some
+      optimal pair lies within the non-dominated set. The frontier is
+      found by one sort per context, and the interior-root scan runs
+      over its ``m`` members -- typically single digits -- rather than
+      all ``K`` arms: ``O(K log K + m^2)`` per context.
+    * ``f(q; a, b) == f(1 - q; b, a)``, so scanning ordered pairs does
+      exactly twice the work of scanning unordered ones. Only the
+      interior root survives, over ``m (m - 1) / 2`` frontier pairs.
 
     Ratio conventions: a mixture with exactly zero regret has ratio 0
     (optimal no matter the gain); positive regret with zero gain has ratio
@@ -110,48 +232,100 @@ def _optimal_two_point(
         with nonzero regret everywhere (the posterior has resolved).
     """
     n_arms, n_contexts = delta.shape
-    a_delta = delta[:, np.newaxis, :] - delta[np.newaxis, :, :]  # (K, K, C)
-    b_delta = np.broadcast_to(delta[np.newaxis, :, :], a_delta.shape)
-    c_gain = v[:, np.newaxis, :] - v[np.newaxis, :, :]
-    d_gain = np.broadcast_to(v[np.newaxis, :, :], a_delta.shape)
+    ctx_idx = np.arange(n_contexts)
+
+    # Endpoints: the best degenerate distribution, O(K * C).
+    single = np.full(delta.shape, np.inf)
+    np.divide(delta * delta, v, out=single, where=v > 0.0)
+    single[delta == 0.0] = 0.0
+    single = np.where(alive, single, np.inf)
+    s_idx = single.argmin(axis=0)
+    s_ratio = single[s_idx, ctx_idx]
+
+    if n_arms < 2:
+        return s_idx, s_idx, np.ones(n_contexts), s_ratio
+
+    # Pareto frontier per context: sort by v descending (dead arms are
+    # pushed last and can never dominate) and keep each arm whose regret
+    # strictly undercuts every higher-v arm's. Every excluded arm is
+    # weakly dominated by a kept one, so the kept set suffices.
+    delta_eff = np.where(alive, delta, np.inf)
+    v_key = np.where(alive, v, -1.0)
+    order = np.argsort(-v_key, axis=0, kind="stable")  # (K, C)
+    d_ord = np.take_along_axis(delta_eff, order, axis=0)
+    run_min = np.minimum.accumulate(d_ord, axis=0)
+    prev_min = np.empty_like(run_min)
+    prev_min[0] = np.inf
+    prev_min[1:] = run_min[:-1]
+    keep_ord = d_ord < prev_min  # (K, C); dead arms sort behind alive ones
+    m_counts = keep_ord.sum(axis=0)
+    m_max = int(m_counts.max())
+    if m_max < 2:
+        return s_idx, s_idx, np.ones(n_contexts), s_ratio
+
+    pos = np.argsort(~keep_ord, axis=0, kind="stable")[:m_max]  # (m, C)
+    keep_idx = np.take_along_axis(order, pos, axis=0).T  # (C, m)
+    ctx_col = ctx_idx[:, np.newaxis]
+    d_front = delta[keep_idx, ctx_col]  # (C, m)
+    v_front = v[keep_idx, ctx_col]
+
+    # Interior stationary point, one per unordered frontier pair. The
+    # pair list is ragged: contexts contribute only their own frontier's
+    # pairs, so one context with a large frontier does not inflate the
+    # scan for every other context (frontier sizes are heavy-tailed in
+    # practice: most contexts resolve to one or two arms while a few
+    # keep many).
+    iu_a, iu_b = np.triu_indices(m_max, k=1)
+    in_ctx = iu_b[np.newaxis, :] < m_counts[:, np.newaxis]  # (C, n_pairs)
+    ctx_rep, pair_rep = np.nonzero(in_ctx)  # row-major: sorted by context
+    i_loc = iu_a[pair_rep]
+    j_loc = iu_b[pair_rep]
+    d_a = d_front[ctx_rep, i_loc]
+    d_b = d_front[ctx_rep, j_loc]
+    v_a = v_front[ctx_rep, i_loc]
+    v_b = v_front[ctx_rep, j_loc]
+    a_delta = d_a - d_b
+    c_gain = v_a - v_b
 
     with np.errstate(divide="ignore", invalid="ignore"):
-        root_zero = -b_delta / a_delta
-        root_interior = (c_gain * b_delta - 2.0 * a_delta * d_gain) / (a_delta * c_gain)
+        q = (c_gain * d_b - 2.0 * a_delta * v_b) / (a_delta * c_gain)
+    # NaN (a zero denominator) and roots outside the open interval both
+    # drop out here: a clipped root is an endpoint, already scanned.
+    interior = (q > 0.0) & (q < 1.0)
+    q = np.where(interior, q, 0.0)
 
-    # Running elementwise minimum over the four q candidates, rather than
-    # stacking them into (4, K, K, C) tensors: peak memory stays a few
-    # (K, K, C) arrays instead of several 4x-sized ones
-    best_ratio = np.full(a_delta.shape, np.inf)
-    best_q = np.zeros(a_delta.shape)
-    q_candidates = (
-        0.0,
-        1.0,
-        np.clip(np.nan_to_num(root_zero, nan=0.0, posinf=1.0, neginf=0.0), 0.0, 1.0),
-        np.clip(
-            np.nan_to_num(root_interior, nan=0.0, posinf=1.0, neginf=0.0), 0.0, 1.0
-        ),
-    )
-    for q_cand in q_candidates:
-        num = (a_delta * q_cand + b_delta) ** 2
-        den = c_gain * q_cand + d_gain
-        ratio = np.full_like(num, np.inf)
-        np.divide(num, den, out=ratio, where=den > 0.0)
-        ratio[num == 0.0] = 0.0
-        better = ratio < best_ratio
-        best_q = np.where(better, q_cand, best_q)
-        np.minimum(best_ratio, ratio, out=best_ratio)
+    num = (a_delta * q + d_b) ** 2
+    den = c_gain * q + v_b
+    ratio = np.full_like(num, np.inf)
+    np.divide(num, den, out=ratio, where=interior & (den > 0.0))
 
-    pair_alive = alive[:, np.newaxis, :] & alive[np.newaxis, :, :]
-    best_ratio = np.where(pair_alive, best_ratio, np.inf)
+    # Segment minimum per context: ``ctx_rep`` is sorted, so each
+    # context's pairs form one contiguous run.
+    present = np.flatnonzero(m_counts >= 2)
+    seg_starts = np.searchsorted(ctx_rep, present)
+    seg_min = np.minimum.reduceat(ratio, seg_starts)
+    # first pair achieving its segment's minimum (exact float equality
+    # with the reduction's own output; inf == inf keeps resolved
+    # contexts consistent, and take_pair discards them below)
+    seg_of = np.searchsorted(present, ctx_rep)
+    achievers = np.flatnonzero(ratio == seg_min[seg_of])
+    _, first = np.unique(seg_of[achievers], return_index=True)
+    best = achievers[first]  # one flat pair index per present context
 
-    flat_ratio = best_ratio.reshape(n_arms * n_arms, n_contexts)
-    pair_idx = flat_ratio.argmin(axis=0)  # (C,)
-    ctx_idx = np.arange(n_contexts)
-    a_idx = pair_idx // n_arms
-    b_idx = pair_idx % n_arms
-    q = best_q.reshape(n_arms * n_arms, n_contexts)[pair_idx, ctx_idx]
-    return a_idx, b_idx, q, flat_ratio[pair_idx, ctx_idx]
+    p_ratio = np.full(n_contexts, np.inf)
+    p_ratio[present] = seg_min
+    q_ctx = np.zeros(n_contexts)
+    q_ctx[present] = q[best]
+    a_ctx = np.zeros(n_contexts, dtype=np.intp)
+    b_ctx = np.zeros(n_contexts, dtype=np.intp)
+    a_ctx[present] = keep_idx[present, i_loc[best]]
+    b_ctx[present] = keep_idx[present, j_loc[best]]
+
+    take_pair = p_ratio < s_ratio
+    a_idx = np.where(take_pair, a_ctx, s_idx)
+    b_idx = np.where(take_pair, b_ctx, s_idx)
+    q_best = np.where(take_pair, q_ctx, 1.0)
+    return a_idx, b_idx, q_best, np.where(take_pair, p_ratio, s_ratio)
 
 
 def _sample_information_ratio_minimizer(
@@ -341,18 +515,24 @@ class InformationDirectedSampling(PolicyDefaultUpdate[ContextType, TokenType]):
         List[Arm[ContextType, TokenType]], List[List[Arm[ContextType, TokenType]]]
     ]:
         """Select arms by minimizing the information ratio over pre-generated samples."""
+        samples = _draw_contiguous(samples)
         n_arms, n_contexts, _ = samples.shape
         n_slots = 1 if top_k is None else min(top_k, n_arms)
 
         alive = np.ones((n_arms, n_contexts), dtype=np.bool_)
-        # mu is alive-invariant; masked is maintained in place across
-        # slots (dead arms' draws set to -inf) instead of re-materialized
-        mu = samples.mean(axis=-1)
-        masked = samples if n_slots == 1 else samples.astype(np.float64, copy=True)
+        # masked is maintained in place across slots (dead arms' draws
+        # set to -inf) instead of re-materialized; the means fall out of
+        # each slot's conditional-sum GEMM, so no pass computes them
+        masked = samples if n_slots == 1 else samples.copy()
+        # the argmax indicator is the largest array the statistics touch;
+        # allocate it once and let every slot write into it
+        indicator = np.empty(samples.shape, dtype=np.bool_)
         ctx_idx = np.arange(n_contexts)
         choices = np.empty((n_slots, n_contexts), dtype=np.intp)
         for slot in range(n_slots):
-            delta, v = _vids_statistics(samples, alive, masked=masked, mu=mu)
+            delta, v = _vids_statistics(
+                samples, alive, masked=masked, indicator=indicator
+            )
             picks = _sample_information_ratio_minimizer(delta, v, alive, rng)
             choices[slot] = picks
             alive[picks, ctx_idx] = False

--- a/src/bayesianbandits/policies/_information_directed_sampling.py
+++ b/src/bayesianbandits/policies/_information_directed_sampling.py
@@ -168,7 +168,7 @@ def _optimal_two_point(
         else ``b_idx``, achieving ``ratio``; ``inf`` means the posterior
         has resolved.
     """
-    n_arms, n_contexts = delta.shape
+    n_contexts = delta.shape[1]
     ctx_idx = np.arange(n_contexts)
 
     # Endpoints: the best degenerate distribution, O(K * C).
@@ -178,9 +178,6 @@ def _optimal_two_point(
     single = np.where(alive, single, np.inf)
     s_idx = single.argmin(axis=0)
     s_ratio = single[s_idx, ctx_idx]
-
-    if n_arms < 2:
-        return s_idx, s_idx, np.ones(n_contexts), s_ratio
 
     # Pareto frontier: sort by v descending (dead arms last, never
     # dominating), keep arms whose regret undercuts every higher-v arm's

--- a/src/bayesianbandits/policies/_information_directed_sampling.py
+++ b/src/bayesianbandits/policies/_information_directed_sampling.py
@@ -14,39 +14,9 @@ import numpy as np
 from numpy.typing import NDArray
 
 from .._arm import Arm, ContextType, TokenType
+from .._blas_helpers import draw_contiguous
 from .._draw_kind import DrawKind
 from ._base import PolicyDefaultUpdate
-
-#: Byte budget for one slab of the draw-major copy below. Sized to keep
-#: the source block of a slab resident in L2 while it is scattered out.
-_COPY_SLAB_BYTES = 1 << 20
-
-
-def _draw_contiguous(samples: NDArray[np.float64]) -> NDArray[np.float64]:
-    """``samples`` as a C-ordered ``(n_arms, n_contexts, n_draws)`` tensor.
-
-    Agents hand this tensor to a policy as a transposed view of the
-    learner's ``(size, n_rows)`` output, which leaves the draw axis with
-    the *largest* stride. Every statistic below reduces or contracts over
-    draws, and the conditional-mean GEMM falls off BLAS entirely in that
-    layout: materializing the natural order first costs one pass and buys
-    back two orders of magnitude.
-
-    numpy's own copy walks the draw axis outermost and so touches a fresh
-    cache line per element. Copying a slab of draws at a time keeps the
-    source block resident while it is scattered out, which runs about
-    three times faster on the large shapes. Already-contiguous input is
-    returned untouched.
-    """
-    if samples.dtype == np.float64 and samples.flags.c_contiguous:
-        return samples
-    n_arms, n_contexts, n_draws = samples.shape
-    out = np.empty(samples.shape, dtype=np.float64)
-    slab = max(1, min(n_draws, _COPY_SLAB_BYTES // max(1, n_arms * n_contexts * 8)))
-    for start in range(0, n_draws, slab):
-        stop = start + slab
-        out[:, :, start:stop] = samples[:, :, start:stop]
-    return out
 
 
 def _vids_statistics(
@@ -116,7 +86,7 @@ def _vids_statistics(
     # produces the indicator directly.
     rho = masked.max(axis=0)  # (n_contexts, n_draws)
     is_opt: NDArray[np.bool_] = (
-        np.empty(samples.shape, dtype=np.bool_) if indicator is None else indicator
+        np.empty_like(samples, dtype=np.bool_) if indicator is None else indicator
     )
     np.equal(masked, rho, out=is_opt)
     # summing bool promotes elementwise to int64 and runs ~4x slower than
@@ -515,7 +485,7 @@ class InformationDirectedSampling(PolicyDefaultUpdate[ContextType, TokenType]):
         List[Arm[ContextType, TokenType]], List[List[Arm[ContextType, TokenType]]]
     ]:
         """Select arms by minimizing the information ratio over pre-generated samples."""
-        samples = _draw_contiguous(samples)
+        samples = draw_contiguous(samples)
         n_arms, n_contexts, _ = samples.shape
         n_slots = 1 if top_k is None else min(top_k, n_arms)
 
@@ -526,7 +496,7 @@ class InformationDirectedSampling(PolicyDefaultUpdate[ContextType, TokenType]):
         masked = samples if n_slots == 1 else samples.copy()
         # the argmax indicator is the largest array the statistics touch;
         # allocate it once and let every slot write into it
-        indicator = np.empty(samples.shape, dtype=np.bool_)
+        indicator = np.empty_like(samples, dtype=np.bool_)
         ctx_idx = np.arange(n_contexts)
         choices = np.empty((n_slots, n_contexts), dtype=np.intp)
         for slot in range(n_slots):

--- a/src/bayesianbandits/policies/_information_directed_sampling.py
+++ b/src/bayesianbandits/policies/_information_directed_sampling.py
@@ -1,0 +1,398 @@
+"""
+Information-directed sampling policy for Bayesian bandits.
+"""
+
+from typing import (
+    List,
+    Optional,
+    Tuple,
+    Union,
+    overload,
+)
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .._arm import Arm, ContextType, TokenType
+from .._draw_kind import DrawKind
+from ._base import PolicyDefaultUpdate
+
+
+def _vids_statistics(
+    samples: NDArray[np.float64],
+    alive: NDArray[np.bool_],
+    masked: Optional[NDArray[np.float64]] = None,
+    mu: Optional[NDArray[np.float64]] = None,
+) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Monte Carlo estimates of expected regret and variance-based information gain.
+
+    Parameters
+    ----------
+    samples : NDArray[np.float64]
+        Joint posterior samples, shape ``(n_arms, n_contexts, n_draws)``.
+        Draw ``m`` must be coherent across arms within a context: the
+        conditional means below condition on which arm is optimal *within
+        the same draw*.
+    alive : NDArray[np.bool_]
+        Shape ``(n_arms, n_contexts)``. Dead arms are excluded from the
+        argmax (they cannot be "the optimal arm"), and their returned
+        statistics are meaningless.
+    masked, mu : NDArray[np.float64], optional
+        Precomputed ``np.where(alive[:, :, np.newaxis], samples, -np.inf)``
+        and ``samples.mean(axis=-1)``. The top_k slot loop maintains these
+        across slots rather than re-materializing them here each slot.
+
+    Returns
+    -------
+    delta, v : NDArray[np.float64]
+        Shape ``(n_arms, n_contexts)``. ``delta[a, c]`` estimates
+        :math:`\\mathbb{E}[\\max_{a'} \\theta_{a'}] - \\mathbb{E}[\\theta_a]`
+        over alive arms, clipped at zero. ``v[a, c]`` estimates
+        :math:`\\sum_{a'} p(a') (\\mathbb{E}[\\theta_a \\mid A^* = a'] -
+        \\mathbb{E}[\\theta_a])^2`, the variance of arm ``a``'s posterior
+        mean under resolution of which alive arm is optimal.
+    """
+    n_arms, _, n_draws = samples.shape
+    if masked is None:
+        masked = np.where(alive[:, :, np.newaxis], samples, -np.inf)
+    means: NDArray[np.float64] = (
+        samples.mean(axis=-1) if mu is None else mu
+    )  # (n_arms, n_contexts)
+    argmax_idx = masked.argmax(axis=0)  # (n_contexts, n_draws)
+    # the values at the argmax are the max: gather them rather than
+    # sweeping the full (n_arms, n_contexts, n_draws) tensor a second time
+    rho_star = np.take_along_axis(masked, argmax_idx[np.newaxis], axis=0)[0].mean(
+        axis=-1
+    )  # (n_contexts,)
+    delta = np.clip(rho_star[np.newaxis, :] - means, 0.0, None)
+
+    onehot = (argmax_idx[:, :, np.newaxis] == np.arange(n_arms)).astype(np.float64)
+    counts = onehot.sum(axis=1).T  # (n_arms, n_contexts); zero for dead arms
+    p_opt = counts / n_draws
+    # cond_sums[a, b, c]: sum of arm a's draws over the draws where b is
+    # optimal, as a batched GEMM over contexts (much faster than einsum here)
+    cond_sums = np.matmul(samples.transpose(1, 0, 2), onehot).transpose(1, 2, 0)
+    mu_cond = cond_sums / np.maximum(counts, 1.0)[np.newaxis, :, :]
+    # counts == 0 leaves mu_cond at 0, but p_opt == 0 zeroes the term anyway
+    v = np.einsum("bc,abc->ac", p_opt, (mu_cond - means[:, np.newaxis, :]) ** 2)
+    return delta, v
+
+
+def _optimal_two_point(
+    delta: NDArray[np.float64],
+    v: NDArray[np.float64],
+    alive: NDArray[np.bool_],
+) -> Tuple[
+    NDArray[np.intp], NDArray[np.intp], NDArray[np.float64], NDArray[np.float64]
+]:
+    """Per context, the two-point distribution minimizing the information ratio.
+
+    The minimizer of :math:`\\Delta(\\pi)^2 / v(\\pi)` over distributions
+    :math:`\\pi` is supported on at most two arms (Russo & Van Roy 2018,
+    Prop. 6), so it suffices to scan all ordered pairs ``(a, b)``. For a
+    fixed pair, with mixing weight ``q`` on ``a``, the ratio is
+    ``(A q + B)^2 / (C q + D)`` where ``A = delta_a - delta_b``,
+    ``B = delta_b``, ``C = v_a - v_b``, ``D = v_b``; its stationary points
+    are ``q = -B / A`` (zero regret) and ``q = (C B - 2 A D) / (A C)``, so
+    the minimum over ``q`` in ``[0, 1]`` is attained at one of those
+    (clipped) or an endpoint.
+
+    Ratio conventions: a mixture with exactly zero regret has ratio 0
+    (optimal no matter the gain); positive regret with zero gain has ratio
+    ``inf``. Dead arms are excluded from the scan.
+
+    Returns
+    -------
+    a_idx, b_idx, q, ratio : NDArray
+        Each shape ``(n_contexts,)``: play ``a_idx`` with probability ``q``,
+        else ``b_idx``, achieving information ratio ``ratio``. An
+        infinite ``ratio`` means no alive pair has any information gain
+        with nonzero regret everywhere (the posterior has resolved).
+    """
+    n_arms, n_contexts = delta.shape
+    a_delta = delta[:, np.newaxis, :] - delta[np.newaxis, :, :]  # (K, K, C)
+    b_delta = np.broadcast_to(delta[np.newaxis, :, :], a_delta.shape)
+    c_gain = v[:, np.newaxis, :] - v[np.newaxis, :, :]
+    d_gain = np.broadcast_to(v[np.newaxis, :, :], a_delta.shape)
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        root_zero = -b_delta / a_delta
+        root_interior = (c_gain * b_delta - 2.0 * a_delta * d_gain) / (a_delta * c_gain)
+
+    # Running elementwise minimum over the four q candidates, rather than
+    # stacking them into (4, K, K, C) tensors: peak memory stays a few
+    # (K, K, C) arrays instead of several 4x-sized ones
+    best_ratio = np.full(a_delta.shape, np.inf)
+    best_q = np.zeros(a_delta.shape)
+    q_candidates = (
+        0.0,
+        1.0,
+        np.clip(np.nan_to_num(root_zero, nan=0.0, posinf=1.0, neginf=0.0), 0.0, 1.0),
+        np.clip(
+            np.nan_to_num(root_interior, nan=0.0, posinf=1.0, neginf=0.0), 0.0, 1.0
+        ),
+    )
+    for q_cand in q_candidates:
+        num = (a_delta * q_cand + b_delta) ** 2
+        den = c_gain * q_cand + d_gain
+        ratio = np.full_like(num, np.inf)
+        np.divide(num, den, out=ratio, where=den > 0.0)
+        ratio[num == 0.0] = 0.0
+        better = ratio < best_ratio
+        best_q = np.where(better, q_cand, best_q)
+        np.minimum(best_ratio, ratio, out=best_ratio)
+
+    pair_alive = alive[:, np.newaxis, :] & alive[np.newaxis, :, :]
+    best_ratio = np.where(pair_alive, best_ratio, np.inf)
+
+    flat_ratio = best_ratio.reshape(n_arms * n_arms, n_contexts)
+    pair_idx = flat_ratio.argmin(axis=0)  # (C,)
+    ctx_idx = np.arange(n_contexts)
+    a_idx = pair_idx // n_arms
+    b_idx = pair_idx % n_arms
+    q = best_q.reshape(n_arms * n_arms, n_contexts)[pair_idx, ctx_idx]
+    return a_idx, b_idx, q, flat_ratio[pair_idx, ctx_idx]
+
+
+def _sample_information_ratio_minimizer(
+    delta: NDArray[np.float64],
+    v: NDArray[np.float64],
+    alive: NDArray[np.bool_],
+    rng: np.random.Generator,
+) -> NDArray[np.intp]:
+    """Per context, sample an arm from the information-ratio-minimizing distribution.
+
+    Falls back to the greedy arm (``argmin delta`` among alive arms) in
+    contexts where every pair's ratio is infinite: the posterior has
+    resolved and there is no information left to buy.
+
+    Returns
+    -------
+    NDArray[np.intp]
+        Shape ``(n_contexts,)``, the sampled arm index per context.
+    """
+    a_idx, b_idx, q, ratio = _optimal_two_point(delta, v, alive)
+    picks = np.where(rng.random(delta.shape[1]) < q, a_idx, b_idx)
+
+    resolved = ~np.isfinite(ratio)
+    if np.any(resolved):
+        greedy = np.where(alive, delta, np.inf).argmin(axis=0)
+        picks = np.where(resolved, greedy, picks)
+    return picks
+
+
+class InformationDirectedSampling(PolicyDefaultUpdate[ContextType, TokenType]):
+    """
+    Policy object for variance-based information-directed sampling (IDS).
+
+    At each round, IDS plays the (possibly randomized) action distribution
+    minimizing the information ratio, the squared expected regret per unit
+    of information gained about the identity of the optimal arm:
+
+    .. math::
+
+        \\pi^* = \\arg\\min_{\\pi \\in \\Delta_K} \\;
+        \\frac{\\left(\\sum_a \\pi_a \\Delta_a\\right)^2}
+             {\\sum_a \\pi_a v_a}
+
+    where both terms are estimated from ``samples`` joint Monte Carlo draws
+    :math:`\\theta^{(m)}` of the arms' rewards:
+
+    .. math::
+
+        \\Delta_a = \\mathbb{E}\\left[\\max_{a'} \\theta_{a'}\\right]
+        - \\mathbb{E}[\\theta_a],
+        \\qquad
+        v_a = \\sum_{a'} p(A^* = a')
+        \\left(\\mathbb{E}[\\theta_a \\mid A^* = a'] -
+        \\mathbb{E}[\\theta_a]\\right)^2
+
+    :math:`v_a` is the variance-based information gain of Russo & Van Roy
+    [1]_: how much arm :math:`a`'s posterior mean moves upon learning which
+    arm is optimal. It is a lower bound on the mutual information
+    :math:`I(A^*; Y_a)` (up to a common noise factor) and is what makes IDS
+    exploit cross-arm correlation: with a shared learner, observing one arm
+    can be highly informative about another arm being optimal. The
+    minimizing distribution is supported on at most two arms, found here by
+    a closed-form scan over all pairs.
+
+    Parameters
+    ----------
+    samples : int, default=1000
+        Number of joint posterior samples used to estimate the regret and
+        information-gain terms.
+
+    Examples
+    --------
+    >>> from bayesianbandits import Agent, Arm, NormalInverseGammaRegressor
+    >>> from bayesianbandits import InformationDirectedSampling
+    >>>
+    >>> arms = [
+    ...     Arm(f"arm_{i}", learner=NormalInverseGammaRegressor())
+    ...     for i in range(3)
+    ... ]
+    >>> agent = Agent(arms, InformationDirectedSampling())
+
+    Fewer Monte Carlo draws trade estimation accuracy for speed:
+
+    >>> agent = Agent(arms, InformationDirectedSampling(samples=500))
+
+    See Also
+    --------
+    ThompsonSampling : Randomized exploration via posterior sampling.
+        Cheaper per decision; explores proportionally to uncertainty but
+        does not direct exploration toward informative arms.
+    UpperConfidenceBound : Deterministic optimism via posterior quantiles.
+    EpsilonGreedy : Simple exploration via random arm selection.
+
+    Notes
+    -----
+    **Regret bounds (standard setting).** Russo & Van Roy [1]_ show that
+    variance-based IDS satisfies the same
+    :math:`\\mathbb{E}[\\mathrm{Regret}(T)] \\le \\sqrt{K T \\log K / 2}`
+    Bayesian bound as the information-ratio analysis of Thompson sampling
+    [2]_, while its per-round ratio minimization can be substantially smaller in
+    structured problems (correlated arms, shared parameters), where
+    Thompson sampling may repeatedly re-explore arms whose value is already
+    implied by other observations.
+
+    **Joint draws matter.** The conditional means inside :math:`v_a`
+    condition on which arm is optimal *within the same posterior draw*, so
+    this policy requires coherent joint samples across arms
+    (``consumes = DrawKind.CONTEXT_JOINT``). With a shared learner
+    (:class:`~bayesianbandits.LipschitzContextualAgent` or a shared
+    pipeline), joint weight-space draws provide this. When arms have
+    independent learners, independent per-arm draws *are* the correct joint
+    distribution. If a shared learner cannot be batch-sampled, the per-arm
+    fallback draws are incoherent across arms and :math:`v_a` degrades to
+    its independent-arms form: still a valid algorithm, but blind to
+    cross-arm correlation.
+
+    **top_k semantics.** ``top_k=k`` returns k sequential IDS draws without
+    replacement: slot 1 is exact IDS, and each later slot re-estimates
+    :math:`\\Delta` and :math:`v` restricted to the remaining arms (the
+    subgame with chosen arms removed), then plays exact IDS on it. Slot
+    order is meaningful and ``top_k=1`` matches the base policy in
+    distribution. No formal slate-bandit guarantee is claimed for
+    :math:`k > 1`.
+
+    **Applicability to this library.** The bounds above assume stationary
+    rewards and exact posteriors, and the observation-noise factor relating
+    :math:`v_a` to mutual information is common across arms only when
+    arms share a likelihood (e.g. one shared learner, or homoscedastic
+    Gaussian arms). Contextual features, approximate posteriors, and
+    variance-increasing decay fall outside the formal analysis, though the
+    regret-per-information principle driving exploration is preserved.
+
+    References
+    ----------
+    .. [1] Russo, D. and Van Roy, B. (2018). "Learning to optimize via
+       information-directed sampling." Operations Research 66(1), 230-252.
+
+    .. [2] Russo, D. and Van Roy, B. (2016). "An information-theoretic
+       analysis of Thompson sampling." Journal of Machine Learning Research
+       17(68), 1-30.
+    """
+
+    def __repr__(self) -> str:
+        return f"InformationDirectedSampling(samples={self.samples})"
+
+    def __init__(self, samples: int = 1000):
+        self.samples = samples
+
+    #: Information gain conditions on which arm is the argmax within a
+    #: draw, so arms must be jointly distributed; decisions are solved
+    #: per context, so the dependence across contexts is never read.
+    #: That is exactly ``CONTEXT_JOINT``, which lets an agent serve this
+    #: with per-context reward-space blocks -- far cheaper than fully
+    #: joint draws at this policy's sample counts.
+    consumes = DrawKind.CONTEXT_JOINT
+
+    @property
+    def samples_needed(self) -> int:
+        """Number of samples per arm per context needed for decision making."""
+        return self.samples
+
+    @overload
+    def select(
+        self,
+        samples: NDArray[np.float64],  # Shape: (n_arms, n_contexts, samples_needed)
+        arms: List[Arm[ContextType, TokenType]],
+        rng: np.random.Generator,
+        top_k: None = None,
+    ) -> List[Arm[ContextType, TokenType]]: ...
+
+    @overload
+    def select(
+        self,
+        samples: NDArray[np.float64],  # Shape: (n_arms, n_contexts, samples_needed)
+        arms: List[Arm[ContextType, TokenType]],
+        rng: np.random.Generator,
+        top_k: int,
+    ) -> List[List[Arm[ContextType, TokenType]]]: ...
+
+    def select(
+        self,
+        samples: NDArray[np.float64],  # Shape: (n_arms, n_contexts, samples_needed)
+        arms: List[Arm[ContextType, TokenType]],
+        rng: np.random.Generator,
+        top_k: Optional[int] = None,
+    ) -> Union[
+        List[Arm[ContextType, TokenType]], List[List[Arm[ContextType, TokenType]]]
+    ]:
+        """Select arms by minimizing the information ratio over pre-generated samples."""
+        n_arms, n_contexts, _ = samples.shape
+        n_slots = 1 if top_k is None else min(top_k, n_arms)
+
+        alive = np.ones((n_arms, n_contexts), dtype=np.bool_)
+        # mu is alive-invariant; masked is maintained in place across
+        # slots (dead arms' draws set to -inf) instead of re-materialized
+        mu = samples.mean(axis=-1)
+        masked = samples if n_slots == 1 else samples.astype(np.float64, copy=True)
+        ctx_idx = np.arange(n_contexts)
+        choices = np.empty((n_slots, n_contexts), dtype=np.intp)
+        for slot in range(n_slots):
+            delta, v = _vids_statistics(samples, alive, masked=masked, mu=mu)
+            picks = _sample_information_ratio_minimizer(delta, v, alive, rng)
+            choices[slot] = picks
+            alive[picks, ctx_idx] = False
+            if slot + 1 < n_slots:
+                masked[picks, ctx_idx, :] = -np.inf
+
+        if top_k is None:
+            return [arms[idx] for idx in choices[0]]
+        return [
+            [arms[choices[slot, ctx]] for slot in range(n_slots)]
+            for ctx in range(n_contexts)
+        ]
+
+    @overload
+    def __call__(
+        self,
+        arms: List[Arm[ContextType, TokenType]],
+        X: ContextType,
+        rng: np.random.Generator,
+        top_k: None = None,
+    ) -> List[Arm[ContextType, TokenType]]: ...
+
+    @overload
+    def __call__(
+        self,
+        arms: List[Arm[ContextType, TokenType]],
+        X: ContextType,
+        rng: np.random.Generator,
+        top_k: int,
+    ) -> List[List[Arm[ContextType, TokenType]]]: ...
+
+    def __call__(
+        self,
+        arms: List[Arm[ContextType, TokenType]],
+        X: ContextType,
+        rng: np.random.Generator,
+        top_k: Optional[int] = None,
+    ) -> Union[
+        List[Arm[ContextType, TokenType]], List[List[Arm[ContextType, TokenType]]]
+    ]:
+        """Choose arm(s) using information-directed sampling."""
+        samples = self._draw_samples(arms, X, self.samples_needed)
+        return self.select(samples, arms, rng, top_k)

--- a/src/bayesianbandits/policies/_information_directed_sampling.py
+++ b/src/bayesianbandits/policies/_information_directed_sampling.py
@@ -26,116 +26,74 @@ def _vids_statistics(
     mu: Optional[NDArray[np.float64]] = None,
     indicator: Optional[NDArray[np.bool_]] = None,
 ) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
-    """Monte Carlo estimates of expected regret and variance-based information gain.
+    """Monte Carlo regret and information-gain estimates, ``(n_arms, n_contexts)``.
 
-    Parameters
-    ----------
-    samples : NDArray[np.float64]
-        Joint posterior samples, shape ``(n_arms, n_contexts, n_draws)``.
-        Draw ``m`` must be coherent across arms within a context: the
-        conditional means below condition on which arm is optimal *within
-        the same draw*.
-    alive : NDArray[np.bool_]
-        Shape ``(n_arms, n_contexts)``. Dead arms are excluded from the
-        argmax (they cannot be "the optimal arm"), and their returned
-        statistics are meaningless.
-    masked, mu : NDArray[np.float64], optional
-        Precomputed ``np.where(alive[:, :, np.newaxis], samples, -np.inf)``
-        and ``samples.mean(axis=-1)``. The top_k slot loop maintains
-        ``masked`` in place across slots rather than re-materializing it
-        here each slot. When ``mu`` is omitted, the means are recovered
-        from the conditional-sum GEMM at no cost (its columns partition
-        the draws, so its row sums are the arms' draw totals) rather than
-        by a pass over the tensor.
-    indicator : NDArray[np.bool_], optional
-        Boolean scratch buffer shaped like ``samples``. The top_k slot
-        loop passes one in so the largest allocation here happens once per
-        ``select`` rather than once per slot.
+    ``delta[a, c]`` estimates :math:`\\mathbb{E}[\\max_{a'} \\theta_{a'}] -
+    \\mathbb{E}[\\theta_a]` over alive arms, clipped at zero; ``v[a, c]``
+    estimates :math:`\\sum_{a'} p(a') (\\mathbb{E}[\\theta_a \\mid A^* = a']
+    - \\mathbb{E}[\\theta_a])^2`, how much arm ``a``'s mean moves upon
+    learning which alive arm is optimal. ``samples`` is
+    ``(n_arms, n_contexts, n_draws)`` and must be jointly coherent across
+    arms within a draw; dead arms are excluded from the argmax and their
+    returned statistics are meaningless. ``masked``, ``mu``, and
+    ``indicator`` let the top_k slot loop reuse the alive-masked tensor,
+    the means, and the boolean scratch across slots.
 
-    Returns
-    -------
-    delta, v : NDArray[np.float64]
-        Shape ``(n_arms, n_contexts)``. ``delta[a, c]`` estimates
-        :math:`\\mathbb{E}[\\max_{a'} \\theta_{a'}] - \\mathbb{E}[\\theta_a]`
-        over alive arms, clipped at zero. ``v[a, c]`` estimates
-        :math:`\\sum_{a'} p(a') (\\mathbb{E}[\\theta_a \\mid A^* = a'] -
-        \\mathbb{E}[\\theta_a])^2`, the variance of arm ``a``'s posterior
-        mean under resolution of which alive arm is optimal.
-
-    Notes
-    -----
-    The conditioning is only over arms that win at least one draw:
-    :math:`p(A^* = b) = 0` for every other arm, so its term in
-    :math:`v` is exactly zero and its conditional means are never read.
-    The conditional-sum GEMM therefore runs over ``M`` columns rather
-    than ``n_arms``, where ``M`` is the number of ever-optimal arms per
-    context -- typically far below ``n_arms`` once the posterior has any
-    shape (often single digits at 96 arms). Cost drops from
-    :math:`O(K^2 S)` to :math:`O(K M S)` per context with the result
-    unchanged, since only zero-weight terms are dropped.
+    Only arms winning at least one draw enter the conditioning
+    (:math:`p(A^* = b) = 0` zeroes every other term exactly), so the
+    conditional-sum GEMM runs over the ``M`` ever-optimal arms per
+    context rather than all ``K``: ``O(K M S)`` with ``M`` typically
+    single digits.
     """
     n_arms, n_contexts, n_draws = samples.shape
     if masked is None:
         masked = np.where(alive[:, :, np.newaxis], samples, -np.inf)
     means = mu  # (n_arms, n_contexts); derived from the GEMM below if None
 
-    # The max, not the argmax. Everything downstream wants the *indicator*
-    # of the optimal arm rather than its label, and numpy reduces over a
-    # leading axis with a generic loop: argmax over axis 0 of this tensor
-    # costs several times the contiguous max plus the equality pass that
-    # produces the indicator directly.
+    # max + equality pass: cheaper than argmax over the leading axis,
+    # and downstream wants the indicator, not the label
     rho = masked.max(axis=0)  # (n_contexts, n_draws)
     is_opt: NDArray[np.bool_] = (
         np.empty_like(samples, dtype=np.bool_) if indicator is None else indicator
     )
     np.equal(masked, rho, out=is_opt)
-    # summing bool promotes elementwise to int64 and runs ~4x slower than
-    # a uint16 accumulator, which n_draws < 2**16 makes exact
+    # a uint16 accumulator beats bool->int64 promotion ~4x; exact below 2**16
     count_dtype = np.uint16 if n_draws < 2**16 else np.int64
     counts = np.add.reduce(
         is_opt.view(np.uint8), axis=-1, dtype=count_dtype
     )  # (n_arms, n_contexts); zero for dead arms
 
-    # Gather the ever-optimal arms per context, padded to the widest
-    # context with never-optimal arms (whose weight is zero, so padding
-    # contributes nothing).
+    # gather the ever-optimal arms per context; padding with
+    # never-optimal arms contributes zero weight
     ever = counts > 0
     m_max = int(ever.sum(axis=0).max())
     opt_idx = np.argsort(~ever, axis=0, kind="stable")[:m_max].T  # (C, M)
     ctx_col = np.arange(n_contexts)[:, np.newaxis]
     weights = is_opt[opt_idx, ctx_col, :].astype(np.float64)  # (C, M, n_draws)
     if int(counts.sum()) != n_contexts * n_draws:
-        # Exact ties are measure-zero for a continuous posterior but not
-        # impossible: duplicate arms under a shared learner draw identical
-        # rewards. Split a tied draw evenly so p_opt stays a probability.
-        # Every marked arm is ever-optimal, so the per-draw total over the
-        # gathered columns is the full total.
+        # exact ties (e.g. duplicate arms under a shared learner): split
+        # a tied draw evenly so p_opt stays a probability
         weights /= weights.sum(axis=1, keepdims=True)
     counts_sub = weights.sum(axis=-1)  # (C, M)
     p_opt = counts_sub / n_draws
-    # cond_sums[c, a, b]: sum of arm a's draws over the draws where
-    # ever-optimal arm b is optimal, as a batched GEMM over contexts
+    # cond_sums[c, a, b]: arm a's draw total where ever-optimal arm b wins
     cond_sums = np.matmul(samples.transpose(1, 0, 2), weights.transpose(0, 2, 1))
     row_sums = cond_sums.sum(axis=-1)  # (C, K): each arm's full draw sum
     if means is None:
-        # The gathered columns carry total weight one on every draw, so
-        # cond_sums' rows already hold each arm's full draw sum: the mean
-        # falls out of the GEMM and needs no pass over the tensor.
+        # the weight columns partition the draws, so the row sums are
+        # already each arm's draw total: no extra pass for the means
         means = row_sums.T / n_draws
 
-    # E[max] from the same GEMM: entry (c, opt_idx[c, m], m) sums the
-    # winning arm's own draws over the draws it wins, i.e. rho over those
-    # draws (on a tied draw every marked arm equals the max, so the split
-    # weights still add rho exactly once). Summing over m totals rho.
-    # Taking regret as a difference of cond_sums entries keeps the
-    # zero-regret case *exactly* zero: an always-optimal arm's rho_sums
-    # and row_sums are the same float, so its ratio classifies as 0, not
-    # as an ulp of regret with no gain (which would read as resolved).
+    # E[max] from the same GEMM: the winning arm's entry sums rho over
+    # its winning draws (ties still add rho exactly once). Regret as a
+    # difference of cond_sums entries keeps an always-optimal arm's
+    # regret *exactly* zero, where an ulp of regret with zero gain would
+    # flip its ratio from 0 to inf.
     rho_sums = cond_sums[ctx_col, opt_idx, np.arange(m_max)[np.newaxis, :]].sum(axis=1)
     delta = np.clip((rho_sums[:, np.newaxis] - row_sums).T / n_draws, 0.0, None)
 
-    # guard the zero-count columns only: a split tie leaves fractional
-    # counts, which clamping up to one would silently rescale
+    # guard zero-count columns only: split ties leave fractional counts,
+    # which clamping up to one would rescale
     nonzero = np.where(counts_sub > 0.0, counts_sub, 1.0)
     mu_cond = cond_sums / nonzero[:, np.newaxis, :]
     # counts == 0 leaves mu_cond at 0, but p_opt == 0 zeroes the term anyway
@@ -154,52 +112,34 @@ def _optimal_two_point(
 ]:
     """Per context, the two-point distribution minimizing the information ratio.
 
-    The minimizer of :math:`\\Delta(\\pi)^2 / v(\\pi)` over distributions
-    :math:`\\pi` is supported on at most two arms (Russo & Van Roy 2018,
-    Prop. 6), so it suffices to scan pairs ``(a, b)``. For a fixed pair,
-    with mixing weight ``q`` on ``a``, the ratio is
-    ``(A q + B)^2 / (C q + D)`` where ``A = delta_a - delta_b``,
-    ``B = delta_b``, ``C = v_a - v_b``, ``D = v_b``; its stationary points
-    are ``q = -B / A`` (zero regret) and ``q = (C B - 2 A D) / (A C)``, so
-    the minimum over ``q`` in ``[0, 1]`` is attained at one of those
-    (clipped) or an endpoint.
+    The minimizer of :math:`\\Delta(\\pi)^2 / v(\\pi)` is supported on at
+    most two arms (Russo & Van Roy 2018, Prop. 6), so scanning pairs
+    suffices. For a pair with weight ``q`` on ``a`` the ratio is
+    ``(A q + B)^2 / (C q + D)`` with ``A = delta_a - delta_b``,
+    ``B = delta_b``, ``C = v_a - v_b``, ``D = v_b``; its stationary
+    points are ``q = -B / A`` and ``q = (C B - 2 A D) / (A C)``, so the
+    minimum over ``[0, 1]`` is at one of those or an endpoint.
 
-    Four reductions cut the scan well below its ``K^2 x 4`` face value
-    without excluding any candidate that could be the optimum, so the
-    minimum is the same:
+    The scan is cut far below ``K^2 x 4`` without excluding a possible
+    optimum: the endpoints are the single-arm ratios, whose minimum is
+    one ``O(K)`` sweep; ``q = -B / A`` is never strictly interior once
+    regret is clipped at zero (``B >= 0`` forces it outside ``(0, 1)``);
+    only the Pareto frontier of the ``(v_a, delta_a)`` points can
+    support an optimal mixture, since moving weight from a dominated arm
+    to its dominator never increases the ratio; and
+    ``f(q; a, b) == f(1 - q; b, a)`` halves the pairs. What remains is
+    one interior root per unordered frontier pair,
+    ``O(K log K + m^2)`` per context with ``m`` typically single digits.
 
-    * The endpoints ``q = 0`` and ``q = 1`` evaluate to the *single-arm*
-      ratios ``delta_b^2 / v_b`` and ``delta_a^2 / v_a``. Their minimum
-      over all pairs is the best single-arm ratio, an ``O(K)`` sweep per
-      context instead of ``O(K^2)``.
-    * ``q = -B / A`` never lands strictly inside ``(0, 1)``. Regret is
-      clipped at zero, so ``B >= 0``, and the root is ``<= 0`` when
-      ``A > 0`` and ``>= 1`` when ``A < 0``: an endpoint either way, and
-      hence already covered by the sweep above.
-    * Only the Pareto frontier of the ``(v_a, delta_a)`` points can
-      support an optimal mixture. If ``a'`` weakly dominates ``a``
-      (``v_a' >= v_a`` and ``delta_a' <= delta_a``), moving ``a``'s
-      weight to ``a'`` cannot increase :math:`\\Delta(\\pi)` and cannot
-      decrease :math:`v(\\pi)`, so it cannot increase the ratio: some
-      optimal pair lies within the non-dominated set. The frontier is
-      found by one sort per context, and the interior-root scan runs
-      over its ``m`` members -- typically single digits -- rather than
-      all ``K`` arms: ``O(K log K + m^2)`` per context.
-    * ``f(q; a, b) == f(1 - q; b, a)``, so scanning ordered pairs does
-      exactly twice the work of scanning unordered ones. Only the
-      interior root survives, over ``m (m - 1) / 2`` frontier pairs.
-
-    Ratio conventions: a mixture with exactly zero regret has ratio 0
-    (optimal no matter the gain); positive regret with zero gain has ratio
-    ``inf``. Dead arms are excluded from the scan.
+    A mixture with exactly zero regret has ratio 0; positive regret with
+    zero gain has ratio ``inf``. Dead arms are excluded.
 
     Returns
     -------
     a_idx, b_idx, q, ratio : NDArray
-        Each shape ``(n_contexts,)``: play ``a_idx`` with probability ``q``,
-        else ``b_idx``, achieving information ratio ``ratio``. An
-        infinite ``ratio`` means no alive pair has any information gain
-        with nonzero regret everywhere (the posterior has resolved).
+        Each ``(n_contexts,)``: play ``a_idx`` with probability ``q``,
+        else ``b_idx``, achieving ``ratio``; ``inf`` means the posterior
+        has resolved.
     """
     n_arms, n_contexts = delta.shape
     ctx_idx = np.arange(n_contexts)
@@ -215,10 +155,8 @@ def _optimal_two_point(
     if n_arms < 2:
         return s_idx, s_idx, np.ones(n_contexts), s_ratio
 
-    # Pareto frontier per context: sort by v descending (dead arms are
-    # pushed last and can never dominate) and keep each arm whose regret
-    # strictly undercuts every higher-v arm's. Every excluded arm is
-    # weakly dominated by a kept one, so the kept set suffices.
+    # Pareto frontier: sort by v descending (dead arms last, never
+    # dominating), keep arms whose regret undercuts every higher-v arm's
     delta_eff = np.where(alive, delta, np.inf)
     v_key = np.where(alive, v, -1.0)
     order = np.argsort(-v_key, axis=0, kind="stable")  # (K, C)
@@ -239,12 +177,9 @@ def _optimal_two_point(
     d_front = delta[keep_idx, ctx_col]  # (C, m)
     v_front = v[keep_idx, ctx_col]
 
-    # Interior stationary point, one per unordered frontier pair. The
-    # pair list is ragged: contexts contribute only their own frontier's
-    # pairs, so one context with a large frontier does not inflate the
-    # scan for every other context (frontier sizes are heavy-tailed in
-    # practice: most contexts resolve to one or two arms while a few
-    # keep many).
+    # Ragged pair list: each context contributes only its own frontier's
+    # pairs (frontier sizes are heavy-tailed, so one wide context must
+    # not inflate the scan for the rest)
     iu_a, iu_b = np.triu_indices(m_max, k=1)
     in_ctx = iu_b[np.newaxis, :] < m_counts[:, np.newaxis]  # (C, n_pairs)
     ctx_rep, pair_rep = np.nonzero(in_ctx)  # row-major: sorted by context
@@ -259,8 +194,8 @@ def _optimal_two_point(
 
     with np.errstate(divide="ignore", invalid="ignore"):
         q = (c_gain * d_b - 2.0 * a_delta * v_b) / (a_delta * c_gain)
-    # NaN (a zero denominator) and roots outside the open interval both
-    # drop out here: a clipped root is an endpoint, already scanned.
+    # NaN and out-of-interval roots drop out: a clipped root is an
+    # endpoint, already scanned
     interior = (q > 0.0) & (q < 1.0)
     q = np.where(interior, q, 0.0)
 
@@ -269,14 +204,12 @@ def _optimal_two_point(
     ratio = np.full_like(num, np.inf)
     np.divide(num, den, out=ratio, where=interior & (den > 0.0))
 
-    # Segment minimum per context: ``ctx_rep`` is sorted, so each
-    # context's pairs form one contiguous run.
+    # segment minimum per context: ctx_rep is sorted, runs contiguous
     present = np.flatnonzero(m_counts >= 2)
     seg_starts = np.searchsorted(ctx_rep, present)
     seg_min = np.minimum.reduceat(ratio, seg_starts)
-    # first pair achieving its segment's minimum (exact float equality
-    # with the reduction's own output; inf == inf keeps resolved
-    # contexts consistent, and take_pair discards them below)
+    # first achiever per segment (exact equality with the reduction's
+    # own output; inf == inf is fine, take_pair discards those below)
     seg_of = np.searchsorted(present, ctx_rep)
     achievers = np.flatnonzero(ratio == seg_min[seg_of])
     _, first = np.unique(seg_of[achievers], return_index=True)
@@ -444,12 +377,9 @@ class InformationDirectedSampling(PolicyDefaultUpdate[ContextType, TokenType]):
     def __init__(self, samples: int = 1000):
         self.samples = samples
 
-    #: Information gain conditions on which arm is the argmax within a
-    #: draw, so arms must be jointly distributed; decisions are solved
-    #: per context, so the dependence across contexts is never read.
-    #: That is exactly ``CONTEXT_JOINT``, which lets an agent serve this
-    #: with per-context reward-space blocks -- far cheaper than fully
-    #: joint draws at this policy's sample counts.
+    #: Information gain conditions on the within-draw argmax (arms must
+    #: be jointly distributed) but each context is solved on its own:
+    #: exactly ``CONTEXT_JOINT``.
     consumes = DrawKind.CONTEXT_JOINT
 
     @property
@@ -490,12 +420,9 @@ class InformationDirectedSampling(PolicyDefaultUpdate[ContextType, TokenType]):
         n_slots = 1 if top_k is None else min(top_k, n_arms)
 
         alive = np.ones((n_arms, n_contexts), dtype=np.bool_)
-        # masked is maintained in place across slots (dead arms' draws
-        # set to -inf) instead of re-materialized; the means fall out of
-        # each slot's conditional-sum GEMM, so no pass computes them
+        # masked (dead arms at -inf) and the boolean scratch are
+        # maintained across slots instead of re-materialized per slot
         masked = samples if n_slots == 1 else samples.copy()
-        # the argmax indicator is the largest array the statistics touch;
-        # allocate it once and let every slot write into it
         indicator = np.empty_like(samples, dtype=np.bool_)
         ctx_idx = np.arange(n_contexts)
         choices = np.empty((n_slots, n_contexts), dtype=np.intp)

--- a/src/bayesianbandits/policies/_thompson_sampling.py
+++ b/src/bayesianbandits/policies/_thompson_sampling.py
@@ -95,11 +95,10 @@ class ThompsonSampling(PolicyDefaultUpdate[ContextType, TokenType]):
         return "ThompsonSampling()"
 
     #: Requires joint draws (arms compared within a shared posterior
-    #: draw), so marginal sampling must not be used.
+    #: draw), so marginal sampling must not be used. Draws one sample
+    #: per pull, for which weight-space ``sample`` is always the
+    #: cheaper joint path.
     consumes = DrawKind.JOINT
-
-    #: Draws one sample per pull, for which weight-space ``sample`` is
-    #: always the cheaper joint path.
 
     @property
     def samples_needed(self) -> int:

--- a/src/bayesianbandits/policies/_thompson_sampling.py
+++ b/src/bayesianbandits/policies/_thompson_sampling.py
@@ -13,6 +13,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from .._arm import Arm, ContextType, TokenType
+from .._draw_kind import DrawKind
 from ._base import PolicyDefaultUpdate
 
 
@@ -95,7 +96,10 @@ class ThompsonSampling(PolicyDefaultUpdate[ContextType, TokenType]):
 
     #: Requires joint draws (arms compared within a shared posterior
     #: draw), so marginal sampling must not be used.
-    marginal_ok = False
+    consumes = DrawKind.JOINT
+
+    #: Draws one sample per pull, for which weight-space ``sample`` is
+    #: always the cheaper joint path.
 
     @property
     def samples_needed(self) -> int:

--- a/src/bayesianbandits/policies/_upper_confidence_bound.py
+++ b/src/bayesianbandits/policies/_upper_confidence_bound.py
@@ -13,6 +13,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from .._arm import Arm, ContextType, TokenType
+from .._draw_kind import DrawKind
 from ._base import PolicyDefaultUpdate
 
 
@@ -115,7 +116,10 @@ class UpperConfidenceBound(PolicyDefaultUpdate[ContextType, TokenType]):
 
     #: Consumes only per-(arm, context) statistics, so iid marginal
     #: draws (``sample_marginal``) are exact for this policy.
-    marginal_ok = True
+    consumes = DrawKind.MARGINAL_ONLY
+
+    #: The marginal path already serves this policy's per-(arm, context)
+    #: statistics; per-context joint blocks are unnecessary.
 
     @property
     def samples_needed(self) -> int:

--- a/src/bayesianbandits/policies/_upper_confidence_bound.py
+++ b/src/bayesianbandits/policies/_upper_confidence_bound.py
@@ -118,9 +118,6 @@ class UpperConfidenceBound(PolicyDefaultUpdate[ContextType, TokenType]):
     #: draws (``sample_marginal``) are exact for this policy.
     consumes = DrawKind.MARGINAL_ONLY
 
-    #: The marginal path already serves this policy's per-(arm, context)
-    #: statistics; per-context joint blocks are unnecessary.
-
     @property
     def samples_needed(self) -> int:
         """Number of samples per arm per context needed for decision making."""

--- a/tests/test_context_joint_wiring.py
+++ b/tests/test_context_joint_wiring.py
@@ -1,0 +1,154 @@
+"""Agent wiring for ``CONTEXT_JOINT`` draws.
+
+``LipschitzContextualAgent`` stacks arm features arm-major, but a
+per-context joint block needs each context's arm rows adjacent. These
+check that permutation and its inverse, the block size the agent asks
+for, and the pipeline's forwarding and fallback.
+"""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from bayesianbandits import (
+    Arm,
+    ArmColumnFeaturizer,
+    InformationDirectedSampling,
+    LipschitzContextualAgent,
+    NormalRegressor,
+)
+from bayesianbandits._arm import (
+    _sample_context_major_blocks,
+    _take_rows,
+    resolve_reward_space_sampler,
+)
+from bayesianbandits.pipelines import LearnerPipeline
+
+
+class TestAgentWiring:
+    @pytest.mark.parametrize(
+        ("n_arms", "n_ctx"),
+        [(3, 2), (3, 1), (1, 3)],
+        ids=["general", "one-ctx", "one-arm"],
+    )
+    def test_context_major_axes_are_restored(self, n_arms, n_ctx):
+        """The sampler is handed context-major rows; the result must come
+        back indexed ``(arm, context, draw)``. Exact, by construction.
+        The single-arm and single-context cases skip the gather, so they
+        take a different branch and are the common shapes in production."""
+        size = 4
+        # arm-major row ``a * n_ctx + c`` carries the payload ``a * 10 + c``
+        X = np.array(
+            [[a * 10 + c] for a in range(n_arms) for c in range(n_ctx)], dtype=float
+        )
+
+        def sampler(X_in, size):
+            return np.tile(X_in[:, 0], (size, 1))
+
+        out = _sample_context_major_blocks(sampler, X, n_arms, n_ctx, size)
+        assert out.shape == (n_arms, n_ctx, size)
+        for a in range(n_arms):
+            for c in range(n_ctx):
+                assert_allclose(out[a, c], a * 10 + c)
+
+    def test_take_rows_uses_iloc_for_dataframes(self):
+        """Plain ``X[indices]`` selects columns by label on a DataFrame,
+        so positional row selection must go through ``iloc``."""
+        pd = pytest.importorskip("pandas")
+        df = pd.DataFrame(np.arange(9.0).reshape(3, 3), columns=["a", "b", "c"])
+        assert _take_rows(df, np.array([2, 0, 1])).values.tolist() == [
+            [6, 7, 8],
+            [0, 1, 2],
+            [3, 4, 5],
+        ]
+
+    def _make_lipschitz(self, learner, n_arms=4, seed=0):
+        arms = [Arm(i, reward_function=None, learner=None) for i in range(n_arms)]
+        return LipschitzContextualAgent(
+            arms=arms,
+            policy=InformationDirectedSampling(samples=500),
+            arm_featurizer=ArmColumnFeaturizer(column_name="product_id"),
+            learner=learner,
+            random_seed=seed,
+        )
+
+    def test_lipschitz_agent_blocks_by_arm(self, monkeypatch):
+        """One block per arm is what makes the draws context-joint."""
+        rng = np.random.default_rng(0)
+        d = 100
+        agent = self._make_lipschitz(NormalRegressor(alpha=1.0, beta=1.0))
+        X_train = rng.standard_normal((300, d))
+        agent.pull(X_train[:1])
+        agent.update(X_train, rng.standard_normal(300))
+
+        calls = {"n": 0}
+        original = type(agent.learner).sample_reward_space  # type: ignore[attr-defined]
+
+        def counting(self, X, size=1, *, block_size=None):
+            calls["n"] += 1
+            assert block_size == len(agent.arms)
+            return original(self, X, size, block_size=block_size)
+
+        monkeypatch.setattr(type(agent.learner), "sample_reward_space", counting)
+        assert len(agent.pull(rng.standard_normal((3, d)))) == 3
+        assert calls["n"] == 1
+
+    def test_lipschitz_agent_falls_back_when_the_gate_declines(self):
+        rng = np.random.default_rng(0)
+        agent = self._make_lipschitz(NormalRegressor(alpha=1.0, beta=1.0))
+        X = rng.standard_normal((3, 2))
+        agent.pull(X)
+        agent.update(X, rng.standard_normal(3))
+        assert len(agent.pull(X)) == 3
+
+    def test_pipeline_forwards_reward_space(self):
+        rng = np.random.default_rng(0)
+        model = NormalRegressor(alpha=1.0, beta=1.0, random_state=0)
+        model.fit(rng.standard_normal((300, 101)), rng.standard_normal(300))
+        pipeline = LearnerPipeline(steps=[], learner=model)
+        X = rng.standard_normal((4, 101))
+        model.random_state_ = np.random.default_rng(3)
+        via_pipeline = pipeline.sample_reward_space(X, 1000, block_size=2)
+        model.random_state_ = np.random.default_rng(3)
+        assert_allclose(via_pipeline, model.sample_reward_space(X, 1000, block_size=2))
+
+    def test_pipeline_falls_back_to_joint_sample(self):
+        """A learner without ``sample_reward_space`` still gets draws, and
+        they are fully joint, which is a superset of what was asked."""
+
+        class PlainLearner:
+            def sample(self, X, size=1):
+                return np.zeros((size, X.shape[0]))
+
+            def predict(self, X):
+                return np.full(X.shape[0], 3.0)
+
+            def partial_fit(self, X, y, sample_weight=None):
+                return self
+
+            def decay(self, X, *, decay_rate=None):
+                self.decayed = True
+
+        learner = PlainLearner()
+        pipeline = LearnerPipeline(steps=[], learner=learner)  # type: ignore[arg-type]
+        X = np.zeros((4, 3))
+        assert pipeline.sample_reward_space(X, 7, block_size=2).shape == (7, 4)
+        assert not pipeline._use_reward_space(4, 7, 2)
+
+    def test_resolver_never_bypasses_a_custom_sample(self):
+        """A subclass overriding ``sample`` without ``sample_reward_space``
+        must keep its own sampling behavior."""
+
+        class ClippedRegressor(NormalRegressor):
+            def sample(self, X, size=1):
+                return np.clip(super().sample(X, size), 0.0, None)
+
+        rng = np.random.default_rng(0)
+        est = ClippedRegressor(alpha=1.0, beta=1.0)
+        est.fit(rng.standard_normal((300, 101)), rng.standard_normal(300))
+        assert resolve_reward_space_sampler(est, 10, 1000) is None
+        assert (est.sample(rng.standard_normal((10, 101)), size=50) >= 0.0).all()
+
+    def test_resolver_skips_unfitted_models(self):
+        est = NormalRegressor(alpha=1.0, beta=1.0)
+        assert resolve_reward_space_sampler(est, 10, 1000) is None

--- a/tests/test_context_joint_wiring.py
+++ b/tests/test_context_joint_wiring.py
@@ -141,6 +141,18 @@ class TestAgentWiring:
         assert resolve_reward_space_sampler(est, 10, 1000) is None
         assert (est.sample(rng.standard_normal((10, 101)), size=50) >= 0.0).all()
 
+    def test_resolver_ignores_instance_level_methods(self):
+        """A learner carrying ``sample_reward_space`` as an instance
+        attribute defines nothing on its class, so the MRO walk finds
+        neither method and the resolver declines."""
+
+        class Shell:
+            pass
+
+        learner = Shell()
+        learner.sample_reward_space = lambda X, size=1, block_size=None: None  # type: ignore[attr-defined]
+        assert resolve_reward_space_sampler(learner, 4, 100, 2) is None
+
     def test_resolver_skips_unfitted_models(self):
         est = NormalRegressor(alpha=1.0, beta=1.0)
         assert resolve_reward_space_sampler(est, 10, 1000) is None

--- a/tests/test_context_joint_wiring.py
+++ b/tests/test_context_joint_wiring.py
@@ -93,14 +93,6 @@ class TestAgentWiring:
         assert len(agent.pull(rng.standard_normal((3, d)))) == 3
         assert calls["n"] == 1
 
-    def test_lipschitz_agent_falls_back_when_the_gate_declines(self):
-        rng = np.random.default_rng(0)
-        agent = self._make_lipschitz(NormalRegressor(alpha=1.0, beta=1.0))
-        X = rng.standard_normal((3, 2))
-        agent.pull(X)
-        agent.update(X, rng.standard_normal(3))
-        assert len(agent.pull(X)) == 3
-
     def test_pipeline_forwards_reward_space(self):
         rng = np.random.default_rng(0)
         model = NormalRegressor(alpha=1.0, beta=1.0, random_state=0)

--- a/tests/test_draw_kind.py
+++ b/tests/test_draw_kind.py
@@ -1,0 +1,121 @@
+"""The policy/agent contract: policies state a need, agents pick a method.
+
+What matters is that each policy declares a level it can actually
+consume, and that the agent supplies something at least that strong.
+The lattice itself is an ``IntEnum``, so its ordering needs no test.
+"""
+
+from unittest import mock
+
+import numpy as np
+import pytest
+
+from bayesianbandits import (
+    EXP3A,
+    Arm,
+    ArmColumnFeaturizer,
+    DrawKind,
+    EpsilonGreedy,
+    InformationDirectedSampling,
+    LipschitzContextualAgent,
+    NormalRegressor,
+    ThompsonSampling,
+    UpperConfidenceBound,
+)
+from bayesianbandits._arm import resolve_reward_space_sampler
+
+
+@pytest.mark.parametrize(
+    ("policy", "expected"),
+    [
+        (UpperConfidenceBound(alpha=0.8), DrawKind.MARGINAL_ONLY),
+        (EpsilonGreedy(epsilon=0.1), DrawKind.MARGINAL_ONLY),
+        (EXP3A(eta=1.0), DrawKind.MARGINAL_ONLY),
+        (InformationDirectedSampling(samples=50), DrawKind.CONTEXT_JOINT),
+        (ThompsonSampling(), DrawKind.JOINT),
+    ],
+    ids=lambda p: type(p).__name__ if hasattr(p, "consumes") else str(p),
+)
+def test_each_policy_declares_what_it_consumes(policy, expected):
+    """Understating this is a correctness bug: the agent will supply
+    draws too weak for the statistics the policy reads."""
+    assert policy.consumes is expected
+
+
+def _lipschitz(policy, batch_reward_function=None, n_arms=3, d=40):
+    arms = [Arm(i, reward_function=None, learner=None) for i in range(n_arms)]
+    agent = LipschitzContextualAgent(
+        arms=arms,
+        policy=policy,
+        arm_featurizer=ArmColumnFeaturizer(column_name="arm"),
+        learner=NormalRegressor(alpha=1.0, beta=1.0),
+        batch_reward_function=batch_reward_function,
+        random_seed=0,
+    )
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((20, d))
+    agent.pull(X[:1])
+    agent.update(X, rng.standard_normal(20))
+    return agent, rng
+
+
+class TestAgentSuppliesAtLeastWhatIsAsked:
+    def test_marginal_only_policy_takes_the_marginal_path(self):
+        agent, rng = _lipschitz(UpperConfidenceBound(alpha=0.8, samples=50))
+        with mock.patch(
+            "bayesianbandits.api.resolve_marginal_sampler"
+        ) as resolve_marginal:
+            resolve_marginal.side_effect = (
+                lambda learner: learner.sample_marginal  # noqa: E731
+            )
+            agent.pull(rng.standard_normal((2, 40)))
+        resolve_marginal.assert_called_once()
+
+    def test_context_joint_policy_takes_the_blocked_path(self):
+        agent, rng = _lipschitz(InformationDirectedSampling(samples=200))
+        with mock.patch(
+            "bayesianbandits.api.resolve_reward_space_sampler",
+            wraps=resolve_reward_space_sampler,
+        ) as resolve_blocks:
+            agent.pull(rng.standard_normal((2, 40)))
+        resolve_blocks.assert_called_once()
+        # one block per arm, which is what makes the draws context-joint
+        assert resolve_blocks.call_args.kwargs["block_size"] == len(agent.arms)
+
+    def test_joint_policy_takes_neither_reduction_path(self):
+        agent, rng = _lipschitz(ThompsonSampling())
+        with (
+            mock.patch("bayesianbandits.api.resolve_marginal_sampler") as marg,
+            mock.patch("bayesianbandits.api.resolve_reward_space_sampler") as blocks,
+        ):
+            agent.pull(rng.standard_normal((2, 40)))
+        marg.assert_not_called()
+        blocks.assert_not_called()
+
+
+class TestBatchRewardFunctionWidens:
+    @staticmethod
+    def _share_of_total(samples, action_tokens):
+        return samples / samples.sum(axis=0, keepdims=True)
+
+    def test_a_supplied_batch_reward_widens_past_marginal(self):
+        """It runs before the policy and may combine arms within a draw,
+        so the arms must be jointly distributed whatever the policy reads."""
+        agent, rng = _lipschitz(
+            UpperConfidenceBound(alpha=0.8, samples=50), self._share_of_total
+        )
+        with mock.patch(
+            "bayesianbandits.api.resolve_marginal_sampler"
+        ) as resolve_marginal:
+            agent.pull(rng.standard_normal((2, 40)))
+        resolve_marginal.assert_not_called()
+
+    def test_widening_cannot_lower_a_joint_policy(self):
+        agent, rng = _lipschitz(ThompsonSampling(), self._share_of_total)
+        with (
+            mock.patch("bayesianbandits.api.resolve_marginal_sampler") as marg,
+            mock.patch("bayesianbandits.api.resolve_reward_space_sampler") as blocks,
+        ):
+            agent.pull(rng.standard_normal((2, 40)))
+        marg.assert_not_called()
+        blocks.assert_not_called()

--- a/tests/test_information_directed_sampling.py
+++ b/tests/test_information_directed_sampling.py
@@ -1,0 +1,382 @@
+"""
+Test suite for the variance-based information-directed sampling (IDS) policy.
+"""
+
+from typing import List
+
+import numpy as np
+import pytest
+
+from bayesianbandits import (
+    Agent,
+    Arm,
+    ArmColumnFeaturizer,
+    ContextualAgent,
+    InformationDirectedSampling,
+    LipschitzContextualAgent,
+    NormalInverseGammaRegressor,
+    NormalRegressor,
+)
+from bayesianbandits.policies._information_directed_sampling import (
+    _optimal_two_point,
+    _sample_information_ratio_minimizer,
+    _vids_statistics,
+)
+
+
+def pairwise_grid_min_ratio(
+    delta: np.ndarray, v: np.ndarray, n_grid: int = 2001
+) -> float:
+    """Reference: grid-search the information ratio over all pairs."""
+    q = np.linspace(0.0, 1.0, n_grid)
+    best = np.inf
+    for a in range(len(delta)):
+        for b in range(len(delta)):
+            num = (q * delta[a] + (1 - q) * delta[b]) ** 2
+            den = q * v[a] + (1 - q) * v[b]
+            ratio = np.full_like(num, np.inf)
+            np.divide(num, den, out=ratio, where=den > 0.0)
+            ratio[num == 0.0] = 0.0
+            best = min(best, ratio.min())
+    return best
+
+
+def simplex_min_ratio(delta: np.ndarray, v: np.ndarray, n_draws: int = 20_000) -> float:
+    """Reference over the *whole* simplex, not just its edges.
+
+    Russo & Van Roy's Prop. 6 says the minimizer is supported on at most
+    two arms, which is what licenses the closed-form pair scan. Sampling
+    full-support mixtures is a direct probe of that claim: if any of them
+    beats the pair optimum, the scan is unsound.
+    """
+    rng = np.random.default_rng(0)
+    w = rng.dirichlet(np.ones(len(delta)), size=n_draws)
+    num = (w @ delta) ** 2
+    den = w @ v
+    ratio = np.full(n_draws, np.inf)
+    np.divide(num, den, out=ratio, where=den > 0.0)
+    ratio[num == 0.0] = 0.0
+    return float(ratio.min())
+
+
+class TestPairOptimizer:
+    """Closed-form pair optimization against a brute-force grid."""
+
+    @pytest.mark.parametrize("seed", range(3))
+    @pytest.mark.parametrize("n_arms", [2, 5, 8])
+    def test_matches_brute_force(self, seed: int, n_arms: int):
+        rng = np.random.default_rng(seed)
+        delta = rng.uniform(0.0, 2.0, size=(n_arms, 1))
+        v = rng.uniform(0.0, 1.5, size=(n_arms, 1))
+        alive = np.ones((n_arms, 1), dtype=bool)
+
+        a_idx, b_idx, q, ratio = _optimal_two_point(delta, v, alive)
+        reference = pairwise_grid_min_ratio(delta[:, 0], v[:, 0])
+
+        # The closed form is exact, so it can only be at or below the grid
+        # minimum; the grid can only overshoot by its resolution.
+        assert ratio[0] <= reference + 1e-12
+        assert reference - ratio[0] <= 1e-4 * max(1.0, reference)
+
+    @pytest.mark.parametrize("seed", range(3))
+    @pytest.mark.parametrize("n_arms", [3, 6])
+    def test_no_full_support_mixture_beats_the_pair_optimum(
+        self, seed: int, n_arms: int
+    ):
+        """The closed form scans pairs only. That is sound exactly because
+        the minimizer is supported on at most two arms, so no mixture over
+        the whole simplex may beat it."""
+        rng = np.random.default_rng(1000 + seed)
+        delta = rng.uniform(0.0, 2.0, size=(n_arms, 1))
+        v = rng.uniform(0.0, 1.5, size=(n_arms, 1))
+        alive = np.ones((n_arms, 1), dtype=bool)
+
+        *_, ratio = _optimal_two_point(delta, v, alive)
+        assert ratio[0] <= simplex_min_ratio(delta[:, 0], v[:, 0]) + 1e-12
+
+    @pytest.mark.parametrize("seed", range(3))
+    def test_reported_mixture_achieves_reported_ratio(self, seed: int):
+        rng = np.random.default_rng(seed)
+        delta = rng.uniform(0.0, 2.0, size=(4, 3))
+        v = rng.uniform(0.0, 1.5, size=(4, 3))
+        # context 2 has regret but no information gain anywhere: its
+        # ratio is infinite, which the loop below must skip
+        v[:, 2] = 0.0
+        alive = np.ones((4, 3), dtype=bool)
+
+        a_idx, b_idx, q, ratio = _optimal_two_point(delta, v, alive)
+        assert not np.isfinite(ratio[2])
+        for c in range(3):
+            if not np.isfinite(ratio[c]):
+                continue
+            num = (q[c] * delta[a_idx[c], c] + (1 - q[c]) * delta[b_idx[c], c]) ** 2
+            den = q[c] * v[a_idx[c], c] + (1 - q[c]) * v[b_idx[c], c]
+            achieved = 0.0 if num == 0.0 else num / den
+            assert achieved == pytest.approx(ratio[c], abs=1e-12)
+
+    def test_zero_regret_arm_gives_zero_ratio(self):
+        # An arm with zero expected regret is played outright: ratio 0.
+        delta = np.array([[0.0], [0.7]])
+        v = np.array([[0.0], [0.3]])
+        alive = np.ones((2, 1), dtype=bool)
+        a_idx, b_idx, q, ratio = _optimal_two_point(delta, v, alive)
+        assert ratio[0] == 0.0
+        played = a_idx[0] if q[0] == 1.0 else b_idx[0]
+        assert played == 0 or q[0] not in (0.0, 1.0)
+
+    def test_no_information_anywhere_is_infinite(self):
+        # Positive regret everywhere, zero gain everywhere: nothing to buy.
+        delta = np.array([[0.5], [0.9]])
+        v = np.zeros((2, 1))
+        alive = np.ones((2, 1), dtype=bool)
+        *_, ratio = _optimal_two_point(delta, v, alive)
+        assert np.isinf(ratio[0])
+
+    def test_dead_arms_are_excluded(self):
+        # The globally best pair involves arm 0; killing it must change the answer.
+        delta = np.array([[0.0], [0.5], [0.6]])
+        v = np.array([[1.0], [0.4], [0.5]])
+        alive = np.array([[False], [True], [True]])
+        a_idx, b_idx, q, ratio = _optimal_two_point(delta, v, alive)
+        assert a_idx[0] != 0 and b_idx[0] != 0
+        assert np.isfinite(ratio[0])
+
+    def test_interior_mixture_sampling_frequencies(self):
+        # delta/v chosen so the optimum is a strict interior mixture.
+        delta = np.array([[0.1], [0.9]])
+        v = np.array([[0.01], [1.0]])
+        alive = np.ones((2, 1), dtype=bool)
+        a_idx, b_idx, q, ratio = _optimal_two_point(delta, v, alive)
+        assert 0.0 < q[0] < 1.0
+
+        rng = np.random.default_rng(0)
+        n_trials = 4_000
+        picks = np.concatenate(
+            [
+                _sample_information_ratio_minimizer(delta, v, alive, rng)
+                for _ in range(n_trials)
+            ]
+        )
+        freq_a = np.mean(picks == a_idx[0])
+        sigma = np.sqrt(q[0] * (1 - q[0]) / n_trials)
+        assert abs(freq_a - q[0]) < 5 * sigma
+
+    def test_resolved_posterior_falls_back_to_greedy(self):
+        """With no information left to buy, every pair's ratio is
+        infinite and the minimizer plays the lowest-regret alive arm
+        rather than whatever pair (0, 0) the argmin happens to land on."""
+        # positive regret, zero gain everywhere -> ratio inf
+        delta = np.array([[0.5, 2.0], [0.2, 1.0], [0.9, 0.4]])
+        v = np.zeros((3, 2))
+        alive = np.ones((3, 2), dtype=bool)
+        _, _, _, ratio = _optimal_two_point(delta, v, alive)
+        assert not np.isfinite(ratio).any()
+
+        rng = np.random.default_rng(0)
+        picks = _sample_information_ratio_minimizer(delta, v, alive, rng)
+        assert picks.tolist() == [1, 2]  # argmin delta per context
+
+    def test_resolved_greedy_respects_dead_arms(self):
+        """The greedy fallback must not resurrect an arm already taken
+        by an earlier top_k slot, even when it has the lowest regret."""
+        delta = np.array([[0.5], [0.2], [0.9]])
+        v = np.zeros((3, 1))
+        alive = np.array([[True], [False], [True]])  # best arm is dead
+        picks = _sample_information_ratio_minimizer(
+            delta, v, alive, np.random.default_rng(0)
+        )
+        assert picks.tolist() == [0]
+
+
+class TestVidsStatistics:
+    """Monte Carlo regret and information-gain estimates."""
+
+    def test_hand_computed_two_arm_case(self):
+        # arm 0 draws [2, 0], arm 1 draws [1, 1]: each optimal in one draw.
+        samples = np.array([[[2.0, 0.0]], [[1.0, 1.0]]])
+        alive = np.ones((2, 1), dtype=bool)
+        delta, v = _vids_statistics(samples, alive)
+        # rho* = mean(max) = 1.5, mu = [1, 1]
+        np.testing.assert_allclose(delta, [[0.5], [0.5]])
+        # E[theta_0 | A*] in {2, 0} with p = 1/2 each -> v_0 = 1
+        # E[theta_1 | A*] = 1 always -> v_1 = 0
+        np.testing.assert_allclose(v, [[1.0], [0.0]])
+
+    def test_dominant_arm_has_zero_regret_and_no_information(self):
+        # arm 0 wins every draw: posterior resolved, all gains vanish.
+        samples = np.stack(
+            [np.full((1, 50), 3.0), np.random.default_rng(0).normal(0.0, 0.5, (1, 50))]
+        )
+        alive = np.ones((2, 1), dtype=bool)
+        delta, v = _vids_statistics(samples, alive)
+        assert delta[0, 0] == 0.0
+        np.testing.assert_allclose(v, 0.0, atol=1e-12)
+
+    def test_masked_arm_is_excluded_from_argmax(self):
+        # With arm 0 dead, the subgame is arms 1 vs 2.
+        samples = np.array(
+            [[[9.0, 9.0]], [[2.0, 0.0]], [[1.0, 1.0]]]
+        )  # arm 0 dominates when alive
+        alive = np.array([[False], [True], [True]])
+        delta, v = _vids_statistics(samples, alive)
+        np.testing.assert_allclose(delta[1:], [[0.5], [0.5]])
+        np.testing.assert_allclose(v[1:], [[1.0], [0.0]])
+
+    def test_correlated_draws_transfer_information(self):
+        # Perfectly anti-correlated arms: learning who is optimal moves
+        # both conditional means, so *both* arms carry information -- the
+        # signature shared-learner effect. With theta ~ N(0, 1) the gains
+        # have closed forms: E[theta | theta > 0] = sqrt(2/pi) gives
+        # v = 2/pi jointly, while independent draws of the same marginals
+        # give E[Y | Y < X] = -1/sqrt(pi) and v = 1/pi -- exactly half.
+        rng = np.random.default_rng(3)
+        theta = rng.normal(0.0, 1.0, size=100_000)
+        joint = np.stack([theta[None, :], -theta[None, :]])
+        alive = np.ones((2, 1), dtype=bool)
+        _, v_joint = _vids_statistics(joint, alive)
+
+        shuffled = joint.copy()
+        rng.shuffle(shuffled[1, 0])
+        _, v_indep = _vids_statistics(shuffled, alive)
+
+        np.testing.assert_allclose(v_joint, 2 / np.pi, rtol=0.05)
+        np.testing.assert_allclose(v_indep[1, 0], 1 / np.pi, rtol=0.05)
+
+
+class TestSelect:
+    """Policy-level selection semantics."""
+
+    def make_arms(self, n: int) -> List[Arm]:
+        return [Arm(i, learner=NormalInverseGammaRegressor()) for i in range(n)]
+
+    def test_resolved_posterior_plays_greedy(self):
+        # Constant samples with distinct means: no information anywhere,
+        # fallback plays the best arm deterministically.
+        samples = np.stack([np.full((1, 100), m) for m in [1.0, 3.0, 2.0]])
+        arms = self.make_arms(3)
+        policy = InformationDirectedSampling()
+        rng = np.random.default_rng(0)
+        for _ in range(10):
+            assert policy.select(samples, arms, rng)[0] is arms[1]
+
+    def test_pure_informative_arm_is_played(self):
+        # arm 0 known to give 1.0; arm 1 is a coin flip between 2 and 0.
+        # Regret is equal (0.5 each), all information sits on arm 1, so
+        # IDS plays arm 1 with probability one.
+        draws = np.tile([2.0, 0.0], 50)
+        samples = np.stack([np.full((1, 100), 1.0), draws[None, :]])
+        arms = self.make_arms(2)
+        policy = InformationDirectedSampling()
+        rng = np.random.default_rng(0)
+        for _ in range(10):
+            assert policy.select(samples, arms, rng)[0] is arms[1]
+
+    def test_top_k_one_matches_base_policy(self):
+        rng_state = np.random.default_rng(7)
+        samples = rng_state.normal(size=(4, 3, 200))
+        arms = self.make_arms(4)
+        policy = InformationDirectedSampling()
+
+        base = policy.select(samples, arms, np.random.default_rng(11))
+        slates = policy.select(samples, arms, np.random.default_rng(11), top_k=1)
+        assert [s[0] for s in slates] == base
+
+    def test_top_k_prefix_consistency_and_uniqueness(self):
+        samples = np.random.default_rng(5).normal(size=(5, 4, 300))
+        arms = self.make_arms(5)
+        policy = InformationDirectedSampling()
+
+        two = policy.select(samples, arms, np.random.default_rng(3), top_k=2)
+        three = policy.select(samples, arms, np.random.default_rng(3), top_k=3)
+        for slate2, slate3 in zip(two, three):
+            assert slate3[:2] == slate2
+            assert len(set(id(a) for a in slate3)) == 3  # without replacement
+
+    def test_top_k_at_least_n_arms_returns_all(self):
+        samples = np.random.default_rng(2).normal(size=(3, 2, 100))
+        arms = self.make_arms(3)
+        policy = InformationDirectedSampling()
+        slates = policy.select(samples, arms, np.random.default_rng(0), top_k=10)
+        for slate in slates:
+            assert sorted(a.action_token for a in slate) == [0, 1, 2]
+
+    def test_top_k_resolved_posterior_sorts_by_mean(self):
+        samples = np.stack([np.full((1, 50), m) for m in [1.0, 4.0, 2.0, 3.0]])
+        arms = self.make_arms(4)
+        policy = InformationDirectedSampling()
+        (slate,) = policy.select(samples, arms, np.random.default_rng(0), top_k=4)
+        assert [a.action_token for a in slate] == [1, 3, 2, 0]
+
+
+class TestPolicyBasics:
+    def test_initialization_and_repr(self):
+        policy = InformationDirectedSampling()
+        assert policy.samples == 1000
+        assert policy.samples_needed == 1000
+        assert repr(policy) == "InformationDirectedSampling(samples=1000)"
+
+        policy = InformationDirectedSampling(samples=250)
+        assert policy.samples_needed == 250
+
+
+class TestAgentIntegration:
+    """End-to-end pulls and updates through each agent type."""
+
+    def test_agent_pull_update_cycle(self):
+        arms = [Arm(i, learner=NormalInverseGammaRegressor()) for i in range(3)]
+        agent = Agent(arms, InformationDirectedSampling(samples=200), random_seed=0)
+        for reward in [1.0, 0.5, 2.0, 1.5]:
+            (token,) = agent.pull()
+            assert token in {0, 1, 2}
+            agent.update(np.array([reward]))
+
+        slates = agent.pull(top_k=2)
+        assert len(slates[0]) == 2
+
+    @pytest.mark.parametrize("sparse", [False, True])
+    def test_contextual_agent_pull_update_cycle(self, sparse: bool):
+        arms = [
+            Arm(i, learner=NormalRegressor(alpha=1.0, beta=1.0, sparse=sparse))
+            for i in range(3)
+        ]
+        agent = ContextualAgent(
+            arms, InformationDirectedSampling(samples=200), random_seed=0
+        )
+        X = np.array([[1.0, 0.5], [0.2, 1.0]])
+        tokens = agent.pull(X[:1])
+        assert len(tokens) == 1
+        agent.update(X[:1], np.array([1.0]))
+
+        slates = agent.pull(X, top_k=2)
+        assert len(slates) == 2 and all(len(s) == 2 for s in slates)
+
+    def test_lipschitz_agent_shared_learner(self):
+        # Shared learner: joint sampling path (consumes is not MARGINAL_ONLY).
+        arms = [Arm(i, reward_function=None, learner=None) for i in range(4)]
+        agent = LipschitzContextualAgent(
+            arms=arms,
+            policy=InformationDirectedSampling(samples=200),
+            arm_featurizer=ArmColumnFeaturizer(column_name="product_id"),
+            learner=NormalInverseGammaRegressor(),
+            random_seed=0,
+        )
+        X = np.array([[1.0], [2.0], [0.5]])
+        tokens = agent.pull(X)
+        assert len(tokens) == 3
+        agent.update(X, np.array([1.0, 0.0, 2.0]))
+
+        slates = agent.pull(X, top_k=2)
+        assert len(slates) == 3 and all(len(s) == 2 for s in slates)
+
+    def test_concentrates_on_best_arm(self):
+        # After clearly separated observations, IDS should exploit.
+        arms = [Arm(i, learner=NormalInverseGammaRegressor()) for i in range(2)]
+        agent = Agent(arms, InformationDirectedSampling(samples=500), random_seed=42)
+        rng = np.random.default_rng(0)
+        for _ in range(60):
+            (token,) = agent.pull()
+            reward = rng.normal(loc=2.0 if token == 1 else 0.0, scale=0.1)
+            agent.update(np.array([reward]))
+
+        pulls = [agent.pull()[0] for _ in range(20)]
+        assert np.mean([t == 1 for t in pulls]) > 0.9

--- a/tests/test_information_directed_sampling.py
+++ b/tests/test_information_directed_sampling.py
@@ -17,8 +17,8 @@ from bayesianbandits import (
     NormalInverseGammaRegressor,
     NormalRegressor,
 )
+from bayesianbandits._blas_helpers import draw_contiguous
 from bayesianbandits.policies._information_directed_sampling import (
-    _draw_contiguous,
     _optimal_two_point,
     _sample_information_ratio_minimizer,
     _vids_statistics,
@@ -357,34 +357,43 @@ class TestVidsStatistics:
 
 
 class TestDrawContiguous:
-    """The draw-major copy that fronts ``select``."""
+    """The layout normalization that fronts ``select``."""
 
     @pytest.mark.parametrize("shape", [(7, 5, 61), (1, 1, 3), (4, 1, 130), (3, 9, 1)])
-    def test_matches_ascontiguousarray(self, shape):
+    def test_normalizes_a_draw_major_view(self, shape):
         n_arms, n_contexts, n_draws = shape
         drawn = np.random.default_rng(0).normal(size=(n_draws, n_arms, n_contexts))
         view = drawn.transpose(1, 2, 0)
-        out = _draw_contiguous(view)
-        assert out.flags.c_contiguous
+        out = draw_contiguous(view)
+        assert out.strides[-1] == out.itemsize
         np.testing.assert_array_equal(out, view)
 
     def test_contiguous_input_is_not_copied(self):
         samples = np.zeros((3, 2, 5))
-        assert _draw_contiguous(samples) is samples
+        assert draw_contiguous(samples) is samples
+
+    def test_draw_contiguous_view_is_not_copied(self):
+        # The blocked reward-space route yields an (arm, context, draw)
+        # view whose draw axis is contiguous but whose leading axes are
+        # swapped in memory. That satisfies the layout contract as-is.
+        drawn = np.zeros((4, 3, 11))  # (C, K, S) in memory
+        view = drawn.transpose(1, 0, 2)
+        assert not view.flags.c_contiguous
+        assert draw_contiguous(view) is view
 
     def test_slabbing_covers_every_draw(self):
         # A shape whose slab size does not divide the draw count: the
         # final short slab must still be copied.
-        from bayesianbandits.policies import _information_directed_sampling as ids
+        from bayesianbandits import _blas_helpers
 
         drawn = np.random.default_rng(1).normal(size=(37, 4, 3))
         view = drawn.transpose(1, 2, 0)
-        original = ids._COPY_SLAB_BYTES
+        original = _blas_helpers._COPY_SLAB_BYTES
         try:
-            ids._COPY_SLAB_BYTES = 4 * 3 * 8 * 5  # five draws per slab
-            out = ids._draw_contiguous(view)
+            _blas_helpers._COPY_SLAB_BYTES = 4 * 3 * 8 * 5  # five draws per slab
+            out = _blas_helpers.draw_contiguous(view)
         finally:
-            ids._COPY_SLAB_BYTES = original
+            _blas_helpers._COPY_SLAB_BYTES = original
         np.testing.assert_array_equal(out, view)
 
 

--- a/tests/test_information_directed_sampling.py
+++ b/tests/test_information_directed_sampling.py
@@ -115,24 +115,6 @@ class TestPairOptimizer:
             achieved = 0.0 if num == 0.0 else num / den
             assert achieved == pytest.approx(ratio[c], abs=1e-12)
 
-    def test_zero_regret_arm_gives_zero_ratio(self):
-        # An arm with zero expected regret is played outright: ratio 0.
-        delta = np.array([[0.0], [0.7]])
-        v = np.array([[0.0], [0.3]])
-        alive = np.ones((2, 1), dtype=bool)
-        a_idx, b_idx, q, ratio = _optimal_two_point(delta, v, alive)
-        assert ratio[0] == 0.0
-        played = a_idx[0] if q[0] == 1.0 else b_idx[0]
-        assert played == 0 or q[0] not in (0.0, 1.0)
-
-    def test_no_information_anywhere_is_infinite(self):
-        # Positive regret everywhere, zero gain everywhere: nothing to buy.
-        delta = np.array([[0.5], [0.9]])
-        v = np.zeros((2, 1))
-        alive = np.ones((2, 1), dtype=bool)
-        *_, ratio = _optimal_two_point(delta, v, alive)
-        assert np.isinf(ratio[0])
-
     def test_dead_arms_are_excluded(self):
         # The globally best pair involves arm 0; killing it must change the answer.
         delta = np.array([[0.0], [0.5], [0.6]])
@@ -188,25 +170,6 @@ class TestPairOptimizer:
         )
         assert picks.tolist() == [0]
 
-    def test_dominated_arms_cannot_change_the_optimum(self):
-        """The scan runs over the (v, delta) Pareto frontier only. Moving a
-        dominated arm's weight to its dominator never increases the ratio,
-        so adding dominated arms must leave the minimum unchanged."""
-        rng = np.random.default_rng(11)
-        for _ in range(5):
-            delta = rng.uniform(0.1, 1.0, size=(3, 2))
-            v = rng.uniform(0.1, 1.0, size=(3, 2))
-            *_, ratio_small = _optimal_two_point(delta, v, np.ones((3, 2), dtype=bool))
-            # dominated: higher regret, lower gain than arm 0
-            extra_d = delta[0] + rng.uniform(0.1, 0.5, size=(4, 2))
-            extra_v = np.maximum(v[0] - rng.uniform(0.1, 0.5, size=(4, 2)), 0.0)
-            delta_big = np.vstack([delta, extra_d])
-            v_big = np.vstack([v, extra_v])
-            *_, ratio_big = _optimal_two_point(
-                delta_big, v_big, np.ones((7, 2), dtype=bool)
-            )
-            np.testing.assert_allclose(ratio_big, ratio_small, rtol=1e-12)
-
     def test_ragged_frontiers_are_solved_per_context(self):
         """One context with a large frontier next to one already resolved:
         each must get its own optimum (the ragged pair list must not mix
@@ -241,16 +204,6 @@ class TestVidsStatistics:
         # E[theta_0 | A*] in {2, 0} with p = 1/2 each -> v_0 = 1
         # E[theta_1 | A*] = 1 always -> v_1 = 0
         np.testing.assert_allclose(v, [[1.0], [0.0]])
-
-    def test_dominant_arm_has_zero_regret_and_no_information(self):
-        # arm 0 wins every draw: posterior resolved, all gains vanish.
-        samples = np.stack(
-            [np.full((1, 50), 3.0), np.random.default_rng(0).normal(0.0, 0.5, (1, 50))]
-        )
-        alive = np.ones((2, 1), dtype=bool)
-        delta, v = _vids_statistics(samples, alive)
-        assert delta[0, 0] == 0.0
-        np.testing.assert_allclose(v, 0.0, atol=1e-12)
 
     def test_masked_arm_is_excluded_from_argmax(self):
         # With arm 0 dead, the subgame is arms 1 vs 2.
@@ -342,19 +295,6 @@ class TestVidsStatistics:
         # arm 2 is, a unit move either way; arm 2's is 1 throughout.
         np.testing.assert_allclose(v, [[1.0], [1.0], [0.0]])
 
-    def test_layout_does_not_change_the_statistics(self):
-        # Agents hand ``select`` a transposed view whose draw axis has the
-        # largest stride; the fast path materializes C order first.
-        drawn = np.random.default_rng(4).normal(size=(200, 6, 3))  # (draws, arms, ctx)
-        view = drawn.transpose(1, 2, 0)
-        assert not view.flags.c_contiguous
-        alive = np.ones((6, 3), dtype=bool)
-
-        from_view = _vids_statistics(view, alive)
-        from_copy = _vids_statistics(np.ascontiguousarray(view), alive)
-        for got, want in zip(from_view, from_copy):
-            np.testing.assert_allclose(got, want)
-
 
 class TestDrawContiguous:
     """The layout normalization that fronts ``select``."""
@@ -388,12 +328,13 @@ class TestDrawContiguous:
 
         drawn = np.random.default_rng(1).normal(size=(37, 4, 3))
         view = drawn.transpose(1, 2, 0)
-        original = _blas_helpers._COPY_SLAB_BYTES
+        original = (_blas_helpers._COPY_SLAB_BYTES, _blas_helpers._MIN_SLAB_DRAWS)
         try:
             _blas_helpers._COPY_SLAB_BYTES = 4 * 3 * 8 * 5  # five draws per slab
+            _blas_helpers._MIN_SLAB_DRAWS = 1
             out = _blas_helpers.draw_contiguous(view)
         finally:
-            _blas_helpers._COPY_SLAB_BYTES = original
+            _blas_helpers._COPY_SLAB_BYTES, _blas_helpers._MIN_SLAB_DRAWS = original
         np.testing.assert_array_equal(out, view)
 
 
@@ -453,13 +394,6 @@ class TestSelect:
         slates = policy.select(samples, arms, np.random.default_rng(0), top_k=10)
         for slate in slates:
             assert sorted(a.action_token for a in slate) == [0, 1, 2]
-
-    def test_top_k_resolved_posterior_sorts_by_mean(self):
-        samples = np.stack([np.full((1, 50), m) for m in [1.0, 4.0, 2.0, 3.0]])
-        arms = self.make_arms(4)
-        policy = InformationDirectedSampling()
-        (slate,) = policy.select(samples, arms, np.random.default_rng(0), top_k=4)
-        assert [a.action_token for a in slate] == [1, 3, 2, 0]
 
     def test_select_accepts_a_transposed_view(self):
         # The agent's draw tensor is a view, not a C-ordered array.

--- a/tests/test_information_directed_sampling.py
+++ b/tests/test_information_directed_sampling.py
@@ -18,6 +18,7 @@ from bayesianbandits import (
     NormalRegressor,
 )
 from bayesianbandits.policies._information_directed_sampling import (
+    _draw_contiguous,
     _optimal_two_point,
     _sample_information_ratio_minimizer,
     _vids_statistics,
@@ -187,6 +188,45 @@ class TestPairOptimizer:
         )
         assert picks.tolist() == [0]
 
+    def test_dominated_arms_cannot_change_the_optimum(self):
+        """The scan runs over the (v, delta) Pareto frontier only. Moving a
+        dominated arm's weight to its dominator never increases the ratio,
+        so adding dominated arms must leave the minimum unchanged."""
+        rng = np.random.default_rng(11)
+        for _ in range(5):
+            delta = rng.uniform(0.1, 1.0, size=(3, 2))
+            v = rng.uniform(0.1, 1.0, size=(3, 2))
+            *_, ratio_small = _optimal_two_point(delta, v, np.ones((3, 2), dtype=bool))
+            # dominated: higher regret, lower gain than arm 0
+            extra_d = delta[0] + rng.uniform(0.1, 0.5, size=(4, 2))
+            extra_v = np.maximum(v[0] - rng.uniform(0.1, 0.5, size=(4, 2)), 0.0)
+            delta_big = np.vstack([delta, extra_d])
+            v_big = np.vstack([v, extra_v])
+            *_, ratio_big = _optimal_two_point(
+                delta_big, v_big, np.ones((7, 2), dtype=bool)
+            )
+            np.testing.assert_allclose(ratio_big, ratio_small, rtol=1e-12)
+
+    def test_ragged_frontiers_are_solved_per_context(self):
+        """One context with a large frontier next to one already resolved:
+        each must get its own optimum (the ragged pair list must not mix
+        pairs across contexts)."""
+        n_arms = 8
+        # context 0: everything on the frontier (delta falls as v rises);
+        # context 1: arm 0 dominates outright
+        delta = np.empty((n_arms, 2))
+        v = np.empty((n_arms, 2))
+        delta[:, 0] = np.linspace(1.0, 0.1, n_arms)
+        v[:, 0] = np.linspace(0.1, 1.0, n_arms)
+        delta[:, 1] = np.linspace(0.5, 1.2, n_arms)
+        v[:, 1] = np.linspace(1.0, 0.2, n_arms)
+        alive = np.ones((n_arms, 2), dtype=bool)
+        a_idx, b_idx, q, ratio = _optimal_two_point(delta, v, alive)
+        for c in range(2):
+            reference = pairwise_grid_min_ratio(delta[:, c], v[:, c])
+            assert ratio[c] <= reference + 1e-12
+            assert reference - ratio[c] <= 1e-4 * max(1.0, reference)
+
 
 class TestVidsStatistics:
     """Monte Carlo regret and information-gain estimates."""
@@ -241,6 +281,111 @@ class TestVidsStatistics:
 
         np.testing.assert_allclose(v_joint, 2 / np.pi, rtol=0.05)
         np.testing.assert_allclose(v_indep[1, 0], 1 / np.pi, rtol=0.05)
+
+    def test_never_optimal_arms_carry_no_conditioning_weight(self):
+        """v sums over p(A* = b), which is zero for arms that never win a
+        draw; the implementation drops those columns from the conditioning
+        entirely. Statistics must match the unrestricted formula."""
+        rng = np.random.default_rng(8)
+        n_arms, n_draws = 40, 500
+        # two contenders and 38 arms that never win
+        samples = rng.normal(0.0, 0.1, size=(n_arms, 2, n_draws))
+        samples[0] += 5.0
+        samples[1] += 5.0
+        alive = np.ones((n_arms, 2), dtype=bool)
+        delta, v = _vids_statistics(samples, alive)
+
+        # unrestricted reference: full one-hot conditioning
+        masked = samples
+        argmax_idx = masked.argmax(axis=0)
+        onehot = (argmax_idx[:, :, None] == np.arange(n_arms)).astype(np.float64)
+        counts = onehot.sum(axis=1).T
+        p_opt = counts / n_draws
+        cond = np.matmul(samples.transpose(1, 0, 2), onehot).transpose(1, 2, 0)
+        mu_cond = cond / np.maximum(counts, 1.0)[None, :, :]
+        means = samples.mean(axis=-1)
+        v_ref = np.einsum("bc,abc->ac", p_opt, (mu_cond - means[:, None, :]) ** 2)
+        np.testing.assert_allclose(v, v_ref, atol=1e-12)
+        assert (counts > 0).sum(axis=0).max() <= 2  # the premise held
+
+    def test_derived_means_keep_zero_regret_exact(self):
+        """The means and E[max] are both recovered from the conditional-sum
+        GEMM rather than by passes over the tensor. For an always-optimal
+        arm the two recoveries read the same float, so its regret is
+        *exactly* zero -- an ulp of regret with zero gain would flip its
+        ratio from 0 (play it outright) to inf (posterior looks resolved).
+        Sums whose draws don't reduce exactly under reordering probe this."""
+        rng = np.random.default_rng(21)
+        n_arms, n_draws = 7, 337
+        samples = rng.normal(0.0, 1.0, size=(n_arms, 3, n_draws)) / 3.0
+        samples[4] += 100.0  # arm 4 wins every draw in every context
+        alive = np.ones((n_arms, 3), dtype=bool)
+        delta, v = _vids_statistics(samples, alive)
+        assert (delta[4] == 0.0).all()
+        a_idx, b_idx, q, ratio = _optimal_two_point(delta, v, alive)
+        assert (ratio == 0.0).all()
+
+    def test_tied_optima_split_evenly(self):
+        # Duplicate arms under a shared learner draw identical rewards, so
+        # the argmax is a genuine tie. The optimal-arm indicator is built
+        # by comparing against the max rather than by argmax, which marks
+        # every tied arm: splitting the draw evenly across them keeps
+        # p(A* = a) a probability and treats the twins symmetrically.
+        twin = np.array([[[2.0, 0.0]], [[2.0, 0.0]], [[1.0, 1.0]]])
+        alive = np.ones((3, 1), dtype=bool)
+        delta, v = _vids_statistics(twin, alive)
+
+        # rho* = mean(max) = 1.5 and mu = [1, 1, 1], so regret is uniform
+        np.testing.assert_allclose(delta, [[0.5], [0.5], [0.5]])
+        # each twin takes half of draw 0, so p = [1/4, 1/4, 1/2]. A twin's
+        # conditional mean is 2 when either twin is optimal and 0 when
+        # arm 2 is, a unit move either way; arm 2's is 1 throughout.
+        np.testing.assert_allclose(v, [[1.0], [1.0], [0.0]])
+
+    def test_layout_does_not_change_the_statistics(self):
+        # Agents hand ``select`` a transposed view whose draw axis has the
+        # largest stride; the fast path materializes C order first.
+        drawn = np.random.default_rng(4).normal(size=(200, 6, 3))  # (draws, arms, ctx)
+        view = drawn.transpose(1, 2, 0)
+        assert not view.flags.c_contiguous
+        alive = np.ones((6, 3), dtype=bool)
+
+        from_view = _vids_statistics(view, alive)
+        from_copy = _vids_statistics(np.ascontiguousarray(view), alive)
+        for got, want in zip(from_view, from_copy):
+            np.testing.assert_allclose(got, want)
+
+
+class TestDrawContiguous:
+    """The draw-major copy that fronts ``select``."""
+
+    @pytest.mark.parametrize("shape", [(7, 5, 61), (1, 1, 3), (4, 1, 130), (3, 9, 1)])
+    def test_matches_ascontiguousarray(self, shape):
+        n_arms, n_contexts, n_draws = shape
+        drawn = np.random.default_rng(0).normal(size=(n_draws, n_arms, n_contexts))
+        view = drawn.transpose(1, 2, 0)
+        out = _draw_contiguous(view)
+        assert out.flags.c_contiguous
+        np.testing.assert_array_equal(out, view)
+
+    def test_contiguous_input_is_not_copied(self):
+        samples = np.zeros((3, 2, 5))
+        assert _draw_contiguous(samples) is samples
+
+    def test_slabbing_covers_every_draw(self):
+        # A shape whose slab size does not divide the draw count: the
+        # final short slab must still be copied.
+        from bayesianbandits.policies import _information_directed_sampling as ids
+
+        drawn = np.random.default_rng(1).normal(size=(37, 4, 3))
+        view = drawn.transpose(1, 2, 0)
+        original = ids._COPY_SLAB_BYTES
+        try:
+            ids._COPY_SLAB_BYTES = 4 * 3 * 8 * 5  # five draws per slab
+            out = ids._draw_contiguous(view)
+        finally:
+            ids._COPY_SLAB_BYTES = original
+        np.testing.assert_array_equal(out, view)
 
 
 class TestSelect:
@@ -306,6 +451,26 @@ class TestSelect:
         policy = InformationDirectedSampling()
         (slate,) = policy.select(samples, arms, np.random.default_rng(0), top_k=4)
         assert [a.action_token for a in slate] == [1, 3, 2, 0]
+
+    def test_select_accepts_a_transposed_view(self):
+        # The agent's draw tensor is a view, not a C-ordered array.
+        drawn = np.random.default_rng(9).normal(size=(400, 4, 3))
+        view = drawn.transpose(1, 2, 0)
+        arms = self.make_arms(4)
+        policy = InformationDirectedSampling()
+
+        from_view = policy.select(view, arms, np.random.default_rng(2))
+        from_copy = policy.select(
+            np.ascontiguousarray(view), arms, np.random.default_rng(2)
+        )
+        assert from_view == from_copy
+
+    def test_select_does_not_mutate_its_input(self):
+        samples = np.random.default_rng(6).normal(size=(4, 2, 150))
+        before = samples.copy()
+        policy = InformationDirectedSampling()
+        policy.select(samples, self.make_arms(4), np.random.default_rng(0), top_k=3)
+        np.testing.assert_array_equal(samples, before)
 
 
 class TestPolicyBasics:

--- a/tests/test_information_directed_sampling.py
+++ b/tests/test_information_directed_sampling.py
@@ -337,6 +337,23 @@ class TestDrawContiguous:
             _blas_helpers._COPY_SLAB_BYTES, _blas_helpers._MIN_SLAB_DRAWS = original
         np.testing.assert_array_equal(out, view)
 
+    def test_wide_leading_axes_fall_back_to_numpy_copy(self):
+        # A slab below _MIN_SLAB_DRAWS re-touches every output row per
+        # draw, so numpy's copy takes over; the result must still be
+        # unit-stride and equal.
+        from bayesianbandits import _blas_helpers
+
+        drawn = np.random.default_rng(2).normal(size=(100, 6, 9))
+        view = drawn.transpose(1, 2, 0)
+        original = _blas_helpers._COPY_SLAB_BYTES
+        try:
+            _blas_helpers._COPY_SLAB_BYTES = 6 * 9 * 8 * 2  # two draws per slab
+            out = _blas_helpers.draw_contiguous(view)
+        finally:
+            _blas_helpers._COPY_SLAB_BYTES = original
+        assert out.strides[-1] == out.itemsize
+        np.testing.assert_array_equal(out, view)
+
 
 class TestSelect:
     """Policy-level selection semantics."""
@@ -407,6 +424,23 @@ class TestSelect:
             np.ascontiguousarray(view), arms, np.random.default_rng(2)
         )
         assert from_view == from_copy
+
+    def test_non_finite_draws_cannot_pin_a_context(self):
+        # One overflowed draw (a log-link GLM under a wide prior) must
+        # not make the resolved-posterior fallback play the overflowed
+        # arm deterministically; a context with no finite draw at all is
+        # zeroed rather than raising.
+        rng = np.random.default_rng(0)
+        samples = rng.normal(size=(3, 2, 100))
+        samples[1] += 5.0  # arm 1 is clearly best
+        samples[2, 0, 3] = np.inf  # poisons context 0 unguarded
+        samples[:, 1, :] = np.nan  # context 1 has no finite draw
+        arms = self.make_arms(3)
+        policy = InformationDirectedSampling()
+        for _ in range(10):
+            chosen = policy.select(samples, arms, rng)
+            assert chosen[0] is arms[1]
+            assert chosen[1] in arms  # tied context still selects
 
     def test_select_does_not_mutate_its_input(self):
         samples = np.random.default_rng(6).normal(size=(4, 2, 150))

--- a/tests/test_marginal_sampling.py
+++ b/tests/test_marginal_sampling.py
@@ -40,7 +40,6 @@ from bayesianbandits import (
     LipschitzContextualAgent,
     NormalInverseGammaRegressor,
     NormalRegressor,
-    ThompsonSampling,
     UpperConfidenceBound,
 )
 from bayesianbandits._arm import (
@@ -356,12 +355,6 @@ class TestPlumbing:
             draws = pipeline.sample_marginal(X, size=5)
         spy.assert_called_once()
         assert draws.shape == (5, 3)
-
-    def test_policies_declare_what_they_consume(self):
-        assert UpperConfidenceBound().consumes is DrawKind.MARGINAL_ONLY
-        assert EXP3A().consumes is DrawKind.MARGINAL_ONLY
-        assert EpsilonGreedy().consumes is DrawKind.MARGINAL_ONLY
-        assert ThompsonSampling().consumes is DrawKind.JOINT
 
     @pytest.mark.parametrize(
         "policy",

--- a/tests/test_marginal_sampling.py
+++ b/tests/test_marginal_sampling.py
@@ -14,11 +14,12 @@ Covers four fronts:
 3. The independence contract: marginal draws are iid across rows, while
    ``sample`` rows within a draw are correlated.
 4. Plumbing: ``Arm``/``LearnerPipeline`` forwarding, the policies'
-   ``marginal_ok`` opt-in (and subclass
+   ``consumes = DrawKind.MARGINAL_ONLY`` opt-in (and subclass
    opt-out), and the fallback to joint ``sample`` for learners without
    ``sample_marginal`` or whose class overrides ``sample`` without it.
 """
 
+from functools import partial
 from unittest import mock
 
 import numpy as np
@@ -34,6 +35,7 @@ from bayesianbandits import (
     ArmColumnFeaturizer,
     BayesianGLM,
     ContextualAgent,
+    DrawKind,
     EpsilonGreedy,
     LipschitzContextualAgent,
     NormalInverseGammaRegressor,
@@ -43,33 +45,13 @@ from bayesianbandits import (
 )
 from bayesianbandits._arm import (
     batch_identity,
-    is_elementwise_batch_reward,
     resolve_marginal_sampler,
 )
 from bayesianbandits.pipelines import LearnerPipeline
-from tests._helpers import cov_inv_dense
+from tests._helpers import cov_inv_dense, fit_dense, fit_sparse
 
-
-def _fit_dense(cls=NormalRegressor, d=40, rows=200, seed=0, **kwargs) -> tuple:
-    rng = np.random.default_rng(seed)
-    if cls is NormalRegressor:
-        kwargs.setdefault("alpha", 1.0)
-        kwargs.setdefault("beta", 1.0)
-    est = cls(random_state=0, **kwargs)
-    X_train = rng.standard_normal((rows, d))
-    y = X_train @ rng.standard_normal(d) + rng.standard_normal(rows)
-    est.fit(X_train, y)
-    return est, rng
-
-
-def _fit_sparse(d=400, rows=300, seed=0, **kwargs):
-    rng = np.random.default_rng(seed)
-    est = NormalRegressor(alpha=1.0, beta=1.0, sparse=True, random_state=0, **kwargs)
-    X_train = sp.csc_array(
-        sp.random(rows, d, density=10 / d, random_state=1)  # type: ignore[call-arg]
-    )
-    est.fit(X_train, rng.standard_normal(rows))
-    return est, rng
+_fit_dense = partial(fit_dense, random_state=0)
+_fit_sparse = partial(fit_sparse, random_state=0)
 
 
 def _reference_sd(est, X_dense: np.ndarray) -> np.ndarray:
@@ -330,12 +312,12 @@ class TestPlumbing:
         assert (pipeline.sample_marginal(X, size=500) >= 0.0).all()
 
     def test_policy_marginal_opt_out_uses_joint_sampling(self):
-        """A policy subclass setting ``marginal_ok = False`` must get
+        """A policy subclass setting ``consumes = DrawKind.JOINT`` must get
         joint draws (regression: ``__call__`` once hardcoded
         ``marginal=True`` regardless of the flag)."""
 
         class JointUCB(UpperConfidenceBound):
-            marginal_ok = False
+            consumes = DrawKind.JOINT
 
         est, rng = _fit_dense()
         arms = [Arm(i, learner=est) for i in range(2)]
@@ -375,11 +357,11 @@ class TestPlumbing:
         spy.assert_called_once()
         assert draws.shape == (5, 3)
 
-    def test_policy_marginal_flags(self):
-        assert UpperConfidenceBound().marginal_ok
-        assert EXP3A().marginal_ok
-        assert EpsilonGreedy().marginal_ok
-        assert not ThompsonSampling().marginal_ok
+    def test_policies_declare_what_they_consume(self):
+        assert UpperConfidenceBound().consumes is DrawKind.MARGINAL_ONLY
+        assert EXP3A().consumes is DrawKind.MARGINAL_ONLY
+        assert EpsilonGreedy().consumes is DrawKind.MARGINAL_ONLY
+        assert ThompsonSampling().consumes is DrawKind.JOINT
 
     @pytest.mark.parametrize(
         "policy",
@@ -409,7 +391,7 @@ def _share_of_total(samples, action_tokens):
 
 class TestBatchRewardCoupling:
     """A batch reward function may combine arms within a draw, so it
-    must not be handed iid marginal draws even under a ``marginal_ok``
+    must not be handed iid marginal draws even under a ``MARGINAL_ONLY``
     policy."""
 
     @staticmethod
@@ -430,21 +412,32 @@ class TestBatchRewardCoupling:
             random_seed=0,
         )
 
-    def test_elementwise_predicate(self):
-        assert is_elementwise_batch_reward(None)
-        assert is_elementwise_batch_reward(batch_identity)
-        assert not is_elementwise_batch_reward(_share_of_total)
+    def test_batch_reward_function_widens_the_requirement(self):
+        """A batch reward function runs before the policy and may
+        combine arms within a draw, so it widens the agent's
+        requirement past ``MARGINAL_ONLY`` no matter what the policy
+        declares. There is no opt-out: a function that does map cells
+        independently is indistinguishable from one that does not."""
+        policy = UpperConfidenceBound(alpha=0.9, samples=100)
+        assert policy.consumes == DrawKind.MARGINAL_ONLY
 
-        def opted_in(samples, action_tokens):
-            return samples * 2.0
+        agent = self._agent(policy, _share_of_total)
+        with mock.patch(
+            "bayesianbandits.api.resolve_marginal_sampler",
+            wraps=resolve_marginal_sampler,
+        ) as resolve_marginal:
+            agent.pull(np.random.default_rng(1).standard_normal((2, 2)))
+        resolve_marginal.assert_not_called()
 
-        assert not is_elementwise_batch_reward(opted_in)
-        opted_in.elementwise = True
-        assert is_elementwise_batch_reward(opted_in)
-        # the attribute is a promise about the function, not a wrapper:
-        # it must not change what the function computes
-        samples = np.ones((2, 3, 4))
-        assert_allclose(opted_in(samples, [0, 1]), 2.0 * samples)
+    def test_widening_never_narrows(self):
+        """Widening takes the stronger of the two requirements, so a
+        policy already asking for JOINT is unaffected by the reward
+        function, and one asking for less is raised, never lowered."""
+        assert max(DrawKind.MARGINAL_ONLY, DrawKind.CONTEXT_JOINT) is (
+            DrawKind.CONTEXT_JOINT
+        )
+        assert max(DrawKind.JOINT, DrawKind.CONTEXT_JOINT) is DrawKind.JOINT
+        assert DrawKind.MARGINAL_ONLY < DrawKind.CONTEXT_JOINT < DrawKind.JOINT
 
     @staticmethod
     def _min_cross_arm_corr(samples):
@@ -493,18 +486,21 @@ class TestBatchRewardCoupling:
         )
         assert self._min_cross_arm_corr(marginal) < 0.05
 
-    def test_elementwise_batch_reward_still_uses_marginal(self):
+    def test_any_batch_reward_function_leaves_the_marginal_path(self):
+        """Even a genuinely elementwise function loses the marginal
+        path: the agent cannot verify the promise, and joint draws are
+        no longer expensive enough to justify trusting it."""
+
         def revenue(samples, action_tokens):
             return samples * np.asarray(action_tokens)[:, None, None]
 
-        revenue.elementwise = True
         agent = self._agent(UpperConfidenceBound(alpha=0.9, samples=100), revenue)
         with mock.patch(
             "bayesianbandits.api.resolve_marginal_sampler",
             wraps=resolve_marginal_sampler,
         ) as resolve_marginal:
             agent.pull(np.random.default_rng(1).standard_normal((2, 2)))
-        resolve_marginal.assert_called_once()
+        resolve_marginal.assert_not_called()
 
     def test_identity_batch_reward_still_uses_marginal(self):
         agent = self._agent(UpperConfidenceBound(alpha=0.9, samples=100), None)

--- a/tests/test_sample_layout.py
+++ b/tests/test_sample_layout.py
@@ -1,0 +1,179 @@
+"""The sampling layout contract.
+
+Learner boundary: ``sample``, ``sample_marginal``, and
+``sample_reward_space`` return ``(size, n)`` draws with ``samples.T``
+C-contiguous (each row's draws adjacent), at no cost -- the projection
+is computed transposed. Policy boundary: agents hand ``select`` a
+tensor with a unit-stride draw axis, normalizing only for learners that
+break the contract. ``size == 1`` is contiguous either way, which is
+what keeps Thompson sampling's draw stream bit-for-bit stable.
+"""
+
+from typing import Any, List
+
+import numpy as np
+import pytest
+from scipy.sparse import csc_array
+from scipy.sparse import random as sparse_random
+
+from bayesianbandits import (
+    Arm,
+    ArmColumnFeaturizer,
+    BayesianGLM,
+    ContextualAgent,
+    LipschitzContextualAgent,
+    NormalInverseGammaRegressor,
+    NormalRegressor,
+    ThompsonSampling,
+)
+
+
+def make_learner(kind: str, sparse: bool):
+    if kind == "normal":
+        return NormalRegressor(alpha=1.0, beta=1.0, sparse=sparse, random_state=7)
+    if kind == "nig":
+        return NormalInverseGammaRegressor(sparse=sparse, random_state=7)
+    if kind == "glm_logit":
+        return BayesianGLM(alpha=1.0, link="logit", sparse=sparse, random_state=7)
+    if kind == "glm_log":
+        return BayesianGLM(alpha=1.0, link="log", sparse=sparse, random_state=7)
+    raise ValueError(kind)
+
+
+def make_X(n_rows: int, n_feats: int, sparse: bool):
+    if sparse:
+        return csc_array(
+            sparse_random(n_rows, n_feats, density=0.5, random_state=3, format="csc")
+        )
+    return np.random.default_rng(3).normal(size=(n_rows, n_feats))
+
+
+def fit(learner, n_feats: int, sparse: bool):
+    X = make_X(6, n_feats, sparse)
+    y = np.arange(6, dtype=np.float64)
+    learner.partial_fit(X, y)
+    return learner
+
+
+def assert_draw_contiguous(samples: np.ndarray, size: int, n_rows: int):
+    assert samples.shape == (size, n_rows)
+    assert samples.T.flags.c_contiguous
+
+
+LEARNERS = ["normal", "nig", "glm_logit", "glm_log"]
+
+
+class TestLearnerContract:
+    """(size, n) entry points return draw-contiguous arrays."""
+
+    @pytest.mark.parametrize("kind", LEARNERS)
+    @pytest.mark.parametrize("sparse", [False, True])
+    @pytest.mark.parametrize("size", [1, 7])
+    @pytest.mark.parametrize("fitted", [True, False])
+    def test_sample(self, kind: str, sparse: bool, size: int, fitted: bool):
+        learner = make_learner(kind, sparse)
+        if fitted:
+            fit(learner, 5, sparse)
+        X = make_X(4, 5, sparse)
+        assert_draw_contiguous(learner.sample(X, size=size), size, 4)
+
+    @pytest.mark.parametrize("kind", LEARNERS)
+    @pytest.mark.parametrize("sparse", [False, True])
+    @pytest.mark.parametrize("size", [1, 7])
+    def test_sample_marginal(self, kind: str, sparse: bool, size: int):
+        learner = fit(make_learner(kind, sparse), 5, sparse)
+        X = make_X(4, 5, sparse)
+        assert_draw_contiguous(learner.sample_marginal(X, size=size), size, 4)
+
+    @pytest.mark.parametrize("kind", LEARNERS)
+    @pytest.mark.parametrize("sparse", [False, True])
+    @pytest.mark.parametrize("size", [1, 7])
+    @pytest.mark.parametrize("block_size", [None, 2])
+    def test_sample_reward_space(
+        self, kind: str, sparse: bool, size: int, block_size: Any
+    ):
+        learner = fit(make_learner(kind, sparse), 5, sparse)
+        X = make_X(4, 5, sparse)
+        assert_draw_contiguous(
+            learner.sample_reward_space(X, size, block_size=block_size), size, 4
+        )
+
+    @pytest.mark.parametrize("kind", ["normal", "nig", "glm_logit"])
+    def test_sample_through_the_row_reduction(self, kind: str):
+        # Two rows and many draws routes sample() through the row-side
+        # support reduction; the contract must hold through that path too.
+        learner = fit(make_learner(kind, True), 40, True)
+        X = make_X(2, 40, True)
+        samples = learner.sample(X, size=50)
+        assert_draw_contiguous(samples, 50, 2)
+
+
+class RecordingPolicy(ThompsonSampling):
+    """Thompson sampling that records the stride of what select receives."""
+
+    def __init__(self, samples_needed_override: int):
+        super().__init__()
+        self._samples_needed = samples_needed_override
+        self.seen: List[Any] = []
+
+    @property
+    def samples_needed(self) -> int:
+        return self._samples_needed
+
+    def select(self, samples, arms, rng, top_k=None):  # type: ignore[override]
+        self.seen.append((samples.shape, samples.strides[-1] == samples.itemsize))
+        return [arms[0] for _ in range(samples.shape[1])]
+
+
+class TestPolicyBoundary:
+    """Agents hand select a tensor whose draw axis is unit-stride."""
+
+    def test_shared_learner_agent(self):
+        policy = RecordingPolicy(samples_needed_override=9)
+        agent = LipschitzContextualAgent(
+            arms=[Arm(i, reward_function=None, learner=None) for i in range(5)],
+            policy=policy,
+            arm_featurizer=ArmColumnFeaturizer(column_name="pid"),
+            learner=NormalRegressor(alpha=1.0, beta=1.0),
+            random_seed=0,
+        )
+        X = np.random.default_rng(0).normal(size=(3, 2))
+        agent.pull(X)
+        agent.update(X, np.zeros(3))
+        agent.pull(X)
+        assert policy.seen and all(ok for _, ok in policy.seen)
+        assert all(shape == (5, 3, 9) for shape, _ in policy.seen)
+
+    def test_per_arm_agent(self):
+        policy = RecordingPolicy(samples_needed_override=9)
+        agent = ContextualAgent(
+            arms=[
+                Arm(i, learner=NormalInverseGammaRegressor(random_state=i))
+                for i in range(4)
+            ],
+            policy=policy,
+            random_seed=0,
+        )
+        X = np.random.default_rng(0).normal(size=(3, 2))
+        agent.pull(X)
+        assert policy.seen and all(ok for _, ok in policy.seen)
+        assert all(shape == (4, 3, 9) for shape, _ in policy.seen)
+
+    def test_nonconforming_learner_is_normalized(self):
+        class COrderNormal(NormalRegressor):
+            """Violates the learner contract: C-ordered (size, n)."""
+
+            def sample(self, X, size=1):
+                return np.ascontiguousarray(super().sample(X, size))
+
+        policy = RecordingPolicy(samples_needed_override=9)
+        agent = LipschitzContextualAgent(
+            arms=[Arm(i, reward_function=None, learner=None) for i in range(5)],
+            policy=policy,
+            arm_featurizer=ArmColumnFeaturizer(column_name="pid"),
+            learner=COrderNormal(alpha=1.0, beta=1.0),
+            random_seed=0,
+        )
+        X = np.random.default_rng(0).normal(size=(3, 2))
+        agent.pull(X)
+        assert policy.seen and all(ok for _, ok in policy.seen)


### PR DESCRIPTION
Rebased onto master now that #269 is merged; the diff is against master. Also carries the IDS `select` optimization and the draw-contiguous layout contract (#272, merged here).

Splits the policy-facing half out of #263. It is separated because it still has open questions (below) and there is no reason for those to gate the sampling speedups in #269.

## The contract

Policies declare what they *consume* rather than which sampling methods they tolerate. `marginal_ok` becomes `consumes: DrawKind` over a totally ordered lattice:

```
MARGINAL_ONLY  <  CONTEXT_JOINT  <  JOINT
```

A policy states a requirement and the agent picks the cheapest exact way to meet it. Supplying more structure than asked is always sound, so an agent may widen silently and can never narrow: `max` is the only combinator and `JOINT` is the default, which means a policy that does not consider this gets correctness rather than speed.

The middle level is the reason for the change. Per-context reward-space blocks are joint across the arms of one context and independent across contexts, which is strictly between marginal and fully joint draws. A boolean could not express it.

## The policy

`InformationDirectedSampling` follows Russo & Van Roy (2018): estimate each arm’s expected regret and variance-based information gain from joint draws, then sample from the two-arm distribution minimizing the information ratio. The minimizer is supported on at most two arms, found by a closed-form scan over pairs. `top_k` returns sequential draws without replacement, each slot re-solving the subgame of the arms that remain.

IDS needs `CONTEXT_JOINT` exactly: its information gain conditions on which arm is the argmax *within* a draw, so arms must be jointly distributed, while each context’s decision is solved on its own.

The `elementwise` opt-out on batch reward functions goes with it. A supplied `batch_reward_function` now always widens to at least `CONTEXT_JOINT`, since it runs before the policy and may combine arms within a draw. The attribute was an unverifiable promise, and joint draws are no longer expensive enough to be worth taking it on trust.

## Three things reviewers should weigh

**1. Should a batch reward function widen to `JOINT` rather than `CONTEXT_JOINT`?** The function receives the whole `(n_arms, n_contexts, size)` tensor, and blocked draws are independent across contexts (measured cross-context correlation 0.003 under blocking against −0.062 unblocked). A reward that couples contexts, such as a shared budget or a softmax over every cell, would silently read manufactured independence. The docstring scopes the function to combining arms, so this is under-specified rather than plainly wrong.

**2. `CONTEXT_JOINT` is unreachable for wide sparse models with many arms.** The blocked route needs `n_arms * p` to fit the half-solve scratch budget, so at `p = 100,000` it fires for roughly twenty arms or fewer. A 96-arm agent always falls back to `sample`, which supplies fully joint draws through its own reduction: stronger than requested, and correct, but the new level earns its keep only on dense and narrow-sparse models.

**3. `select` is the end-to-end bottleneck, not sampling.** Instrumented inside real `LipschitzContextualAgent.pull` calls at 1000 samples: for a dense learner `select` is 98% of a decision at 96 arms and 8 contexts, and 99% at 96 arms and 64 contexts, where a single pull takes 4.5 s. The cost is structural, an `O(K²·C)` pair scan over several `(K, K, C)` tensors plus a `(C, S, K)` one-hot per slot. Sparse learners are the opposite, draw-dominated, and there the reductions in #269 give 4x to 124x.

On whether the policy earns its place: over 200 paired seeds on correlated-arm linear bandits it beats Thompson sampling reliably (t = 4.3 and t = 5.8 in two of three scenarios) but loses slightly to UCB in all three, and UCB runs on `MARGINAL_ONLY` draws at a fraction of the cost. The honest positioning is that IDS is the better choice where Thompson sampling is the incumbent and cross-arm correlation is strong, not a general upgrade.

Supersedes #262.
