### PR TITLE
Add memory_usage accounting across agents, learners, and factors

### DIFF
--- a/src/bayesianbandits/__init__.py
+++ b/src/bayesianbandits/__init__.py
@@ -107,6 +107,20 @@ posterior. Pass to the ``approximator`` argument.
     LaplaceApproximator
     RVGAApproximator
 
+Memory Accounting
+=================
+Agents, arms, learners, and precision factors each carry a
+``memory_usage`` property reporting the bytes they retain, broken down
+by part. The same walk is available as a function for anything else.
+Buffers reachable more than once -- a precision matrix shared with its
+factorization, a learner shared across arms -- are charged once, so a
+total is what dropping the object would free.
+
+.. autosummary::
+
+    memory_usage
+    MemoryUsage
+
 """
 
 from ._arm import Arm
@@ -124,6 +138,7 @@ from ._estimators import (
     NormalRegressor,
 )
 from ._gaussian import LaplaceApproximator, RVGAApproximator
+from ._memory import MemoryUsage, memory_usage
 from .api import (
     Agent,
     ContextualAgent,
@@ -151,6 +166,8 @@ __all__ = [
     "NormalRegressor",
     "LaplaceApproximator",
     "RVGAApproximator",
+    "MemoryUsage",
+    "memory_usage",
     "Agent",
     "ContextualAgent",
     "LipschitzContextualAgent",

--- a/src/bayesianbandits/_arm.py
+++ b/src/bayesianbandits/_arm.py
@@ -20,6 +20,8 @@ import numpy as np
 from numpy.typing import NDArray
 from typing_extensions import Concatenate, ParamSpec, Self, TypeGuard
 
+from ._memory import MemoryUsageMixin
+
 HAS_PANDAS = importlib.util.find_spec("pandas") is not None
 
 P = ParamSpec("P")
@@ -243,7 +245,7 @@ def apply_reward_function(
         return traditional_func(samples)
 
 
-class Arm(Generic[ContextType, TokenType]):
+class Arm(MemoryUsageMixin, Generic[ContextType, TokenType]):
     """Single arm of a multi-armed bandit.
 
     An arm pairs a Bayesian learner with an action token and an

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -42,6 +42,7 @@ from ._gaussian import (
     PosteriorApproximator,
     compute_effective_weights,
 )
+from ._memory import MemoryUsageMixin
 from ._np_utils import groupby_array
 from ._sparse_bayesian_linear_regression import (
     DenseFactor,
@@ -57,7 +58,7 @@ ReturnType = TypeVar("ReturnType")
 SelfType = TypeVar("SelfType", bound="NormalRegressor | BayesianGLM")
 
 
-class DirichletClassifier(BaseEstimator, ClassifierMixin):
+class DirichletClassifier(MemoryUsageMixin, BaseEstimator, ClassifierMixin):
     """
     Intercept-only Dirichlet-Multinomial classifier.
 
@@ -436,7 +437,7 @@ class DirichletClassifier(BaseEstimator, ClassifierMixin):
             self.known_alphas_[x.item()] *= decay_rate
 
 
-class GammaRegressor(BaseEstimator, RegressorMixin):
+class GammaRegressor(MemoryUsageMixin, BaseEstimator, RegressorMixin):
     """
     Intercept-only Gamma-Poisson conjugate regression model.
 
@@ -1275,7 +1276,9 @@ class _RewardSpacePredictiveMixin:
         return X_pred
 
 
-class NormalRegressor(_RewardSpacePredictiveMixin, BaseEstimator, RegressorMixin):
+class NormalRegressor(
+    _RewardSpacePredictiveMixin, MemoryUsageMixin, BaseEstimator, RegressorMixin
+):
     """
     Bayesian linear regression with known noise variance.
 
@@ -2423,7 +2426,9 @@ def multivariate_t_sample_from_covariance(
     return _squeeze_output(samples)
 
 
-class BayesianGLM(_RewardSpacePredictiveMixin, BaseEstimator, RegressorMixin):
+class BayesianGLM(
+    _RewardSpacePredictiveMixin, MemoryUsageMixin, BaseEstimator, RegressorMixin
+):
     """
     Bayesian Generalized Linear Model with Laplace approximation.
 

--- a/src/bayesianbandits/_gaussian.py
+++ b/src/bayesianbandits/_gaussian.py
@@ -11,6 +11,8 @@ from scipy.sparse import csc_array
 from scipy.sparse import issparse as sp_issparse
 from scipy.special import expit
 
+from ._memory import MemoryUsageMixin
+
 # Type aliases
 ArrayType = Union[NDArray[np.float64], csc_array]
 LinkFunction = Literal["logit", "log"]
@@ -406,7 +408,7 @@ class PosteriorApproximator(Protocol):
 
 
 @dataclass
-class LaplaceApproximator(PosteriorApproximator):
+class LaplaceApproximator(MemoryUsageMixin, PosteriorApproximator):
     """Laplace approximation via iteratively reweighted least squares (IRLS).
 
     Approximates the posterior of a Bayesian GLM by finding the MAP
@@ -917,7 +919,7 @@ def update_gaussian_posterior_rvga(
 
 
 @dataclass
-class RVGAApproximator(PosteriorApproximator):
+class RVGAApproximator(MemoryUsageMixin, PosteriorApproximator):
     """R-VGA posterior approximation via expected curvature.
 
     Replaces Laplace's point-estimate curvature with expected curvature

--- a/src/bayesianbandits/_memory.py
+++ b/src/bayesianbandits/_memory.py
@@ -1,0 +1,554 @@
+"""Byte-level accounting for the state a bandit keeps between rounds.
+
+A fitted agent's memory is spread across Python attributes, NumPy
+buffers, SciPy sparse triples, and -- when a model is sparse -- a
+factorization that lives entirely inside a C library. ``sys.getsizeof``
+sees only the first of those: it reports the header of a ``csc_array``
+and nothing about its data, and 144 bytes for a SuperLU object holding
+tens of megabytes. This module walks the object graph instead, charging
+each buffer once to whichever holder reaches it first.
+
+The public surface is :func:`memory_usage`, which any object can be
+passed to, and :class:`MemoryUsageMixin`, which gives a class a
+``memory_usage`` property over its own state.
+
+Notes
+-----
+**What is counted.** Instance state only: ``__dict__`` (which is where
+``functools.cached_property`` puts its results, so a factorization that
+has been built is reported and one that has not costs nothing), slots,
+container elements, and closure cells. Classes and modules are not
+counted -- they are shared by the whole process, not owned by the
+object.
+
+**Shared buffers are charged once.** A precision matrix is referenced
+both by the estimator and by the factor built from it; a
+:class:`~bayesianbandits.LipschitzContextualAgent` gives every arm the
+same learner; :func:`~bayesianbandits._sparse_bayesian_linear_regression.scale_factor`
+makes shallow copies that share one numeric factorization. Every one of
+those is reported at its first sighting and as ``0`` afterwards, so a
+total is the memory that would be freed by dropping the object, not the
+sum over its references.
+
+**Views are charged for their buffer.** A slice keeps its base array
+alive, so ``arr[:10]`` from a 100 MB buffer is charged 100 MB -- the
+memory that is actually held, not the part being looked at.
+
+**C factorizations are computed from their own array lengths.** Neither
+CHOLMOD nor SuperLU reports its allocation to Python -- both track it
+internally, and neither wrapper surfaces the counter -- so each is
+priced from the structure counts it does expose.
+
+For CHOLMOD that is exact: scikit-sparse finalizes every factor to
+packed simplicial form, which fixes each array's length in terms of
+``nnz`` and ``N``. For SuperLU it is a lower bound, because SciPy
+exposes only the logical nonzero count and SuperLU stores ``L`` as
+dense supernode blocks that cover more than that -- 10-20% more on the
+factorizations this library builds. Those reports carry ``exact=False``
+and say so in :attr:`MemoryUsage.note`.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Mapping as AbcMapping
+from dataclasses import dataclass, field
+from types import BuiltinFunctionType, FunctionType, MethodType, ModuleType
+from typing import Any, Dict, Iterable, Iterator, Mapping, Tuple
+
+import numpy as np
+from scipy.sparse import issparse
+
+__all__ = ["MemoryUsage", "MemoryUsageMixin", "memory_usage"]
+
+
+_UNITS = ("B", "KiB", "MiB", "GiB", "TiB", "PiB")
+
+
+def _human(n_bytes: int) -> str:
+    """Format a byte count the way a memory tool should read: exact
+    below a kibibyte, one decimal above it."""
+    size = float(n_bytes)
+    for unit in _UNITS:
+        if abs(size) < 1024.0 or unit == _UNITS[-1]:
+            return f"{int(size)} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024.0
+    raise AssertionError("unreachable")  # pragma: no cover
+
+
+@dataclass(frozen=True)
+class MemoryUsage:
+    """Bytes held by an object, and by each of its parts.
+
+    Attributes
+    ----------
+    total : int
+        Bytes retained, including everything in :attr:`parts`.
+    exact : bool
+        False if any component was estimated rather than measured --
+        see the module notes on CHOLMOD and SuperLU. An estimate
+        anywhere makes every total containing it inexact.
+    parts : Mapping[str, MemoryUsage]
+        Breakdown by attribute name, container index, or dictionary key.
+        Empty for a leaf.
+    note : str
+        Why a number is what it is, when that is not obvious: the buffer
+        a view holds alive, the second sighting of a shared array, the
+        storage format behind an estimate.
+
+    Examples
+    --------
+    >>> usage = MemoryUsage(
+    ...     1536,
+    ...     parts={"coef_": MemoryUsage(512), "cov_inv_": MemoryUsage(1024)},
+    ... )
+    >>> usage.total
+    1536
+    >>> print(usage)
+    1.5 KiB
+    ├── cov_inv_: 1.0 KiB
+    └── coef_: 512 B
+
+    Sizes are plain integers, so they compose with ordinary arithmetic:
+
+    >>> int(usage) // 1024
+    1
+    """
+
+    total: int
+    exact: bool = True
+    parts: Mapping[str, "MemoryUsage"] = field(default_factory=dict)
+    note: str = ""
+
+    def __int__(self) -> int:
+        return self.total
+
+    def __repr__(self) -> str:
+        estimate = "" if self.exact else ", estimated"
+        return f"MemoryUsage({_human(self.total)}{estimate})"
+
+    def __str__(self) -> str:
+        return self.report()
+
+    def report(self, max_depth: int = 3, min_bytes: int = 0) -> str:
+        """Render the breakdown as an indented tree, largest part first.
+
+        Parameters
+        ----------
+        max_depth : int, default=3
+            Levels of nesting to show. Deeper parts are summed into
+            their ancestor's total, which is always the full figure --
+            trimming the tree never changes a number.
+        min_bytes : int, default=0
+            Hide parts smaller than this. Useful on an agent, where the
+            interesting rows are the posteriors and the noise is a few
+            dozen bytes of hyperparameters per arm.
+
+        Examples
+        --------
+        >>> usage = MemoryUsage(
+        ...     2048,
+        ...     parts={
+        ...         "big": MemoryUsage(2000, parts={"inner": MemoryUsage(2000)}),
+        ...         "small": MemoryUsage(48),
+        ...     },
+        ... )
+        >>> print(usage.report(max_depth=1))
+        2.0 KiB
+        ├── big: 2.0 KiB
+        └── small: 48 B
+        >>> print(usage.report(min_bytes=100))
+        2.0 KiB
+        └── big: 2.0 KiB
+            └── inner: 2.0 KiB
+        """
+        header = _human(self.total)
+        if not self.exact:
+            header += " (estimated)"
+        if self.note:
+            header += f"  [{self.note}]"
+        lines = [header]
+        lines.extend(self._rows(max_depth, min_bytes, prefix=""))
+        return "\n".join(lines)
+
+    def _rows(self, depth: int, min_bytes: int, prefix: str) -> Iterator[str]:
+        if depth <= 0:
+            return
+        shown = [
+            (name, part)
+            for name, part in sorted(self.parts.items(), key=lambda kv: -kv[1].total)
+            if part.total >= min_bytes
+        ]
+        for i, (name, part) in enumerate(shown):
+            last = i == len(shown) - 1
+            label = f"{name}: {_human(part.total)}"
+            if part.note:
+                label += f"  [{part.note}]"
+            yield f"{prefix}{'└── ' if last else '├── '}{label}"
+            yield from part._rows(
+                depth - 1, min_bytes, prefix + ("    " if last else "│   ")
+            )
+
+
+class MemoryUsageMixin:
+    """Gives a class a ``memory_usage`` property over its own state.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from bayesianbandits import NormalInverseGammaRegressor
+    >>> est = NormalInverseGammaRegressor()
+    >>> _ = est.fit(np.array([[1.0, 0.0], [0.0, 1.0]]), np.array([1.0, 2.0]))
+    >>> est.memory_usage.parts["coef_"].total
+    16
+
+    The property is recomputed on access and never touches the data it
+    measures, so it is safe to call in a hot loop or a metrics scrape.
+    """
+
+    __slots__ = ()
+
+    @property
+    def memory_usage(self) -> MemoryUsage:
+        """Bytes retained by this object; see :class:`MemoryUsage`."""
+        return memory_usage(self)
+
+
+def memory_usage(obj: Any) -> MemoryUsage:
+    """Bytes retained by ``obj`` and everything it holds alive.
+
+    Parameters
+    ----------
+    obj : Any
+        Any object. Estimators, agents, factors, arrays, sparse
+        matrices, and plain containers are all understood; anything
+        else falls back to its header size and is reported inexact.
+
+    Returns
+    -------
+    MemoryUsage
+        Total and per-part breakdown.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from bayesianbandits import memory_usage
+    >>> memory_usage(np.zeros((100, 100))).total
+    80000
+
+    A buffer reachable twice is charged once, so a total is what
+    dropping the object would free:
+
+    >>> arr = np.zeros(1000)
+    >>> memory_usage([arr, arr]).parts["[1]"].note
+    'shared; counted at first sighting'
+    """
+    return _Accountant().measure(obj)
+
+
+# Objects whose ``sys.getsizeof`` is the whole truth: no referents worth
+# following, no hidden allocation behind a C pointer.
+_LEAF_TYPES: Tuple[type, ...] = (
+    bool,
+    bytearray,
+    bytes,
+    complex,
+    float,
+    int,
+    str,
+    type(None),
+    np.dtype,
+    np.generic,
+)
+
+_SEQUENCE_TYPES: Tuple[type, ...] = (list, tuple, set, frozenset)
+
+_UNCOUNTED_TYPES: Tuple[type, ...] = (ModuleType, type, BuiltinFunctionType)
+
+# Immutables Python may hand out as one shared object; see ``_claim``.
+_INTERNED_TYPES: Tuple[type, ...] = (bool, complex, float, int, type(None))
+
+
+class _Accountant:
+    """One walk of an object graph.
+
+    Keeps a reference to everything it has seen, both to charge shared
+    buffers once and to keep ``id`` from being recycled underneath the
+    ledger by an intermediate that the walk itself dropped.
+    """
+
+    def __init__(self) -> None:
+        self._seen: Dict[int, Any] = {}
+
+    def measure(self, obj: Any) -> MemoryUsage:
+        if self._claim(obj) is False:
+            return MemoryUsage(0, note="shared; counted at first sighting")
+        if isinstance(obj, np.ndarray):
+            return self._ndarray(obj)
+        if issparse(obj):
+            return self._composite(
+                obj,
+                _vars_items(obj),
+                overhead=_instance_overhead(obj),
+                note="sparse array",
+            )
+        if _is_cholmod_factor(obj):
+            return _cholmod_usage(obj)
+        if _is_superlu(obj):
+            return _superlu_usage(obj)
+        if isinstance(obj, _LEAF_TYPES):
+            return MemoryUsage(sys.getsizeof(obj))
+        if isinstance(obj, _UNCOUNTED_TYPES):
+            return MemoryUsage(0, note="shared by the process; not counted")
+        if isinstance(obj, np.random.Generator):
+            return self._composite(obj, [("bit_generator", obj.bit_generator)])
+        if isinstance(obj, np.random.BitGenerator):
+            return self._composite(obj, [("state", obj.state)])
+        if isinstance(obj, AbcMapping):
+            return self._composite(obj, _mapping_items(obj))
+        if isinstance(obj, _SEQUENCE_TYPES):
+            return self._composite(obj, _sequence_items(obj))
+        if isinstance(obj, (FunctionType, MethodType)):
+            return self._composite(obj, _callable_items(obj))
+        state = list(_state_items(obj))
+        if state or hasattr(obj, "__dict__"):
+            return self._composite(obj, state, overhead=_instance_overhead(obj))
+        return MemoryUsage(
+            sys.getsizeof(obj), exact=False, note="opaque object; header only"
+        )
+
+    def _claim(self, obj: Any) -> bool:
+        """Record ``obj`` as counted, returning False if it already was.
+
+        Small immutables are exempt: Python interns them, so the same
+        ``0`` or ``1.0`` really is one object across a dozen unrelated
+        hyperparameters, and deduplicating those would fill a report
+        with 0-byte rows that say "shared" about nothing.
+        """
+        if isinstance(obj, _INTERNED_TYPES):
+            return True
+        if id(obj) in self._seen:
+            return False
+        self._seen[id(obj)] = obj
+        return True
+
+    def _composite(
+        self,
+        obj: Any,
+        items: Iterable[Tuple[str, Any]],
+        overhead: int = 0,
+        note: str = "",
+    ) -> MemoryUsage:
+        """Sum an object's own footprint and its named parts."""
+        total = sys.getsizeof(obj) if overhead == 0 else overhead
+        exact = True
+        parts: Dict[str, MemoryUsage] = {}
+        for name, value in items:
+            part = self.measure(value)
+            parts[name] = part
+            total += part.total
+            exact &= part.exact
+        return MemoryUsage(total, exact, parts, note)
+
+    def _ndarray(self, arr: np.ndarray) -> MemoryUsage:
+        """An array is charged for the buffer it keeps alive.
+
+        A view's ``nbytes`` is the window, not the allocation: the base
+        stays alive as long as the view does, so the base is what a
+        memory report has to name. When the base is not an array at all
+        -- CHOLMOD and SuperLU both hand out read-only views onto their
+        own storage -- the bytes belong to that C object and are counted
+        there instead.
+        """
+        base = arr.base
+        if base is None:
+            return MemoryUsage(arr.nbytes)
+        if isinstance(base, np.ndarray):
+            owner = self.measure(base)
+            if owner.total <= arr.nbytes:
+                # Nothing surprising: a reshape, a transpose, or a base
+                # already charged elsewhere. Report it without comment.
+                return owner
+            return MemoryUsage(
+                owner.total,
+                owner.exact,
+                note=f"view holding a {_human(owner.total)} buffer alive",
+            )
+        held = self.measure(base)
+        return MemoryUsage(
+            held.total,
+            held.exact,
+            note="view of memory owned by " + type(base).__name__,
+        )
+
+
+def _instance_overhead(obj: Any) -> int:
+    """Header plus attribute dictionary, without its contents."""
+    overhead = sys.getsizeof(obj)
+    instance_dict = getattr(obj, "__dict__", None)
+    if instance_dict is not None:
+        overhead += sys.getsizeof(instance_dict)
+    return overhead
+
+
+def _vars_items(obj: Any) -> Iterator[Tuple[str, Any]]:
+    yield from vars(obj).items()
+
+
+def _mapping_items(obj: Mapping[Any, Any]) -> Iterator[Tuple[str, Any]]:
+    for key, value in obj.items():
+        yield f"[{key!r}]", value
+
+
+def _sequence_items(obj: Iterable[Any]) -> Iterator[Tuple[str, Any]]:
+    for i, value in enumerate(obj):
+        yield f"[{i}]", value
+
+
+def _callable_items(obj: Any) -> Iterator[Tuple[str, Any]]:
+    """A reward function's closure can hold a lookup table; follow it."""
+    func = obj.__func__ if isinstance(obj, MethodType) else obj
+    if isinstance(obj, MethodType):
+        yield "__self__", obj.__self__
+    for i, cell in enumerate(func.__closure__ or ()):
+        try:
+            yield f"closure[{i}]", cell.cell_contents
+        except ValueError:  # pragma: no cover - empty cell in a recursive def
+            continue
+    for i, default in enumerate(func.__defaults__ or ()):
+        yield f"default[{i}]", default
+
+
+def _state_items(obj: Any) -> Iterator[Tuple[str, Any]]:
+    """Instance attributes, from ``__dict__`` and from slots.
+
+    Read out of ``__dict__`` rather than through ``getattr``, so that a
+    ``cached_property`` that has never been evaluated is not evaluated
+    here: measuring a model must not build the factorization it is
+    measuring.
+    """
+    yield from getattr(obj, "__dict__", {}).items()
+    seen: set[str] = set()
+    for klass in type(obj).__mro__:
+        for name in getattr(klass, "__slots__", ()) or ():
+            if name in ("__dict__", "__weakref__") or name in seen:
+                continue
+            seen.add(name)
+            try:
+                yield name, getattr(obj, name)
+            except AttributeError:
+                continue
+
+
+def _is_cholmod_factor(obj: Any) -> bool:
+    """A ``sksparse.cholmod.CholeskyFactor``, duck-typed.
+
+    Imported nowhere in this module: scikit-sparse is optional, and the
+    check has to work whether or not it is installed.
+    """
+    return type(obj).__module__.startswith("sksparse") and all(
+        hasattr(obj, attr) for attr in ("N", "nnz", "itype", "is_super")
+    )
+
+
+def _is_superlu(obj: Any) -> bool:
+    """A ``scipy.sparse.linalg.SuperLU``, duck-typed. The class is not
+    importable from SciPy's public API, so match on the object."""
+    return type(obj).__name__ == "SuperLU" and all(
+        hasattr(obj, attr) for attr in ("nnz", "shape", "perm_r")
+    )
+
+
+def _cholmod_usage(factor: Any) -> MemoryUsage:
+    """Bytes CHOLMOD holds for a factor, computed from its own array
+    lengths.
+
+    Every array in a ``cholmod_factor`` has a length scikit-sparse
+    exposes: ``x`` and ``i`` hold ``nzmax`` entries, ``p`` holds
+    ``n + 1``, and ``Perm`` and ``ColCount`` hold ``n`` each. The one
+    length not exposed directly is ``nzmax``, and for a *packed* factor
+    it equals the nonzero count -- which ``nnz`` reports, summing
+    ``ColCount``.
+
+    That covers every factor scikit-sparse returns.
+    :meth:`CholeskyFactor.factorize` sets ``final_super = False``,
+    ``final_pack = True`` and ``final_monotonic = True`` before handing
+    the factor back, so the result is packed and simplicial whatever
+    ordering or supernodal mode produced it -- ``nzmax == nnz``, and
+    this figure is exact rather than modelled. A factor from somewhere
+    else that is still supernodal stores dense blocks covering more
+    than ``nnz`` entries; that case is detected and reported as a lower
+    bound.
+
+    Excluded: the scratch workspace on the ``cholmod_common`` that
+    scikit-sparse gives each factor. It is scratch rather than factor
+    state, and runs to tens of bytes per feature against this figure's
+    twelve per nonzero.
+    """
+    n = int(factor.N)
+    nnz = int(factor.nnz)
+    value_size = np.dtype(factor.dtype).itemsize
+    index_size = np.dtype(factor.itype).itemsize
+    # x[nzmax], i[nzmax], p[n + 1], Perm[n], ColCount[n]
+    values = nnz * value_size
+    indices = nnz * index_size
+    structure = (3 * n + 1) * index_size
+    supernodal = bool(factor.is_super)
+    exact = not supernodal
+    note = f"CHOLMOD factor, {nnz} nonzeros; excludes CHOLMOD scratch workspace"
+    if supernodal:
+        note = (
+            f"CHOLMOD factor, {nnz} nonzeros, supernodal; "
+            "lower bound, dense blocks store more than nnz"
+        )
+    return MemoryUsage(
+        values + indices + structure,
+        exact=exact,
+        parts={
+            "values": MemoryUsage(values, exact=exact),
+            "indices": MemoryUsage(indices, exact=exact),
+            "structure": MemoryUsage(structure, exact=exact),
+        },
+        note=note,
+    )
+
+
+def _superlu_usage(lu: Any) -> MemoryUsage:
+    """Lower bound on the memory behind a SuperLU decomposition.
+
+    This one really is a bound, not a measurement, and SciPy is the
+    reason. ``nnz`` -- the nonzeros of ``L`` and ``U`` together -- is
+    the only size the ``SuperLU`` object exposes; ``sys.getsizeof``
+    returns its 144-byte header however large the factorization is, and
+    ``lu.L`` builds a fresh copy rather than describing the one already
+    there. SuperLU itself knows the answer exactly, in the
+    ``mem_usage.for_lu`` that ``dQuerySpace`` fills in, but SciPy wraps
+    neither that call nor the ``SCformat`` array lengths behind it.
+
+    So the arrays are priced at what the logical nonzeros need: float64
+    values, int32 row indices, and the six length-``n`` vectors that the
+    supernodal ``L``, the compressed-column ``U``, and the two
+    permutations keep between them. SuperLU stores ``L`` as dense
+    supernode blocks, which cover more than the logical nonzeros, so the
+    true figure runs above this one -- 10-20% above on the sparse
+    symmetric factorizations this library builds, and further above as
+    supernodes grow denser.
+    """
+    n = int(lu.shape[0])
+    nnz = int(lu.nnz)
+    values = nnz * 8
+    indices = nnz * 4
+    structure = 6 * (n + 1) * 4
+    return MemoryUsage(
+        values + indices + structure,
+        exact=False,
+        parts={
+            "values": MemoryUsage(values, exact=False),
+            "indices": MemoryUsage(indices, exact=False),
+            "structure": MemoryUsage(structure, exact=False),
+        },
+        note=(
+            f"SuperLU factorization, {nnz} nonzeros in L and U; "
+            "lower bound, supernode padding not exposed by SciPy"
+        ),
+    )

--- a/src/bayesianbandits/_sparse_bayesian_linear_regression.py
+++ b/src/bayesianbandits/_sparse_bayesian_linear_regression.py
@@ -34,6 +34,8 @@ from scipy.sparse.linalg import (  # type: ignore
     use_solver,
 )
 
+from ._memory import MemoryUsageMixin
+
 use_solver(useUmfpack=False)
 
 try:
@@ -386,7 +388,7 @@ def _stacked_L(L_block: csc_array, trivial_diag: NDArray[np.float64]) -> csc_arr
 
 
 @dataclass
-class CholmodSparseFactor:
+class CholmodSparseFactor(MemoryUsageMixin):
     """A CHOLMOD factor over the observed block of a precision matrix, and
     the trivial diagonal beside it.
 
@@ -589,7 +591,7 @@ class CholmodSparseFactor:
 
 
 @dataclass
-class SuperLUSparseFactor:
+class SuperLUSparseFactor(MemoryUsageMixin):
     """A SuperLU decomposition over the observed block of a precision
     matrix, and the trivial diagonal beside it; see
     :class:`CholmodSparseFactor` for the layout."""
@@ -791,7 +793,7 @@ SparseFactor = CholmodSparseFactor | SuperLUSparseFactor
 
 
 @dataclass
-class DenseFactor:
+class DenseFactor(MemoryUsageMixin):
     """Wraps a LAPACK Cholesky factorization for solving and sampling.
 
     Stores the upper-triangular factor U where Λ = U^T U.  Every

--- a/src/bayesianbandits/api.py
+++ b/src/bayesianbandits/api.py
@@ -86,6 +86,7 @@ from ._arm import (
     resolve_marginal_sampler,
 )
 from ._arm_featurizer import ArmFeaturizer
+from ._memory import MemoryUsageMixin
 from .policies import (  # noqa: F401
     EpsilonGreedy,
     ThompsonSampling,
@@ -206,7 +207,7 @@ def _reject_shared_learner(
         )
 
 
-class ContextualAgent(Generic[ContextType, TokenType]):
+class ContextualAgent(MemoryUsageMixin, Generic[ContextType, TokenType]):
     """
     Agent for a contextual multi-armed bandit problem.
 
@@ -539,7 +540,7 @@ class ContextualAgent(Generic[ContextType, TokenType]):
             arm.decay(X, decay_rate=decay_rate)
 
 
-class Agent(Generic[TokenType]):
+class Agent(MemoryUsageMixin, Generic[TokenType]):
     """
     Agent for a non-contextual (classic) multi-armed bandit problem.
 
@@ -806,7 +807,7 @@ class Agent(Generic[TokenType]):
         self._inner.decay(np.array([[1]], dtype=np.float64), decay_rate=decay_rate)
 
 
-class LipschitzContextualAgent(Generic[TokenType]):
+class LipschitzContextualAgent(MemoryUsageMixin, Generic[TokenType]):
     """
     Contextual agent with a shared learner and a configurable design matrix.
 

--- a/src/bayesianbandits/pipelines/_agent.py
+++ b/src/bayesianbandits/pipelines/_agent.py
@@ -12,6 +12,7 @@ from numpy.typing import NDArray
 from typing_extensions import Self
 
 from .._arm import Arm, ContextType, TokenType
+from .._memory import MemoryUsageMixin
 from ..api import Agent, ContextualAgent, PolicyProtocol
 
 
@@ -54,7 +55,7 @@ def _transform_data(X: Any, steps: List[Tuple[str, Any]]) -> Any:
     return result
 
 
-class ContextualAgentPipeline(Generic[ContextType, TokenType]):
+class ContextualAgentPipeline(MemoryUsageMixin, Generic[ContextType, TokenType]):
     """Pipeline that wraps a ContextualAgent.
 
     Transforms input data through preprocessing steps before delegating
@@ -250,7 +251,7 @@ class ContextualAgentPipeline(Generic[ContextType, TokenType]):
         return self.steps[ind]
 
 
-class NonContextualAgentPipeline(Generic[TokenType]):
+class NonContextualAgentPipeline(MemoryUsageMixin, Generic[TokenType]):
     """Pipeline that wraps an Agent.
 
     For non-contextual agents, preprocessing steps are not applied since

--- a/src/bayesianbandits/pipelines/_learner.py
+++ b/src/bayesianbandits/pipelines/_learner.py
@@ -13,11 +13,12 @@ from numpy.typing import NDArray
 from typing_extensions import Self
 
 from .._arm import Learner, resolve_marginal_sampler
+from .._memory import MemoryUsageMixin
 
 X_contra = TypeVar("X_contra", contravariant=True)
 
 
-class LearnerPipeline(Generic[X_contra]):
+class LearnerPipeline(MemoryUsageMixin, Generic[X_contra]):
     """Pipeline that implements the Learner protocol with generic input type.
 
     Enables sklearn transformers to work with Bayesian learners by implementing

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,5 +1,3 @@
-import sys
-
 import numpy as np
 import pytest
 import scipy.sparse as sp
@@ -7,13 +5,11 @@ import scipy.sparse as sp
 from bayesianbandits import (
     Arm,
     ContextualAgent,
-    MemoryUsage,
     NormalInverseGammaRegressor,
     NormalRegressor,
     ThompsonSampling,
     memory_usage,
 )
-from bayesianbandits._memory import _cholmod_usage, _human, _is_cholmod_factor
 from bayesianbandits._sparse_bayesian_linear_regression import (
     CholmodSparseFactor,
     SparseSolver,
@@ -22,219 +18,120 @@ from bayesianbandits._sparse_bayesian_linear_regression import (
 )
 
 
-class TestMemoryUsage:
-    def test_total_and_int(self):
-        usage = MemoryUsage(1024, parts={"a": MemoryUsage(1024)})
-        assert usage.total == 1024
-        assert int(usage) == 1024
+def test_measuring_does_not_build_lazy_caches():
+    """The walk reads ``__dict__`` rather than calling ``getattr``. Reach
+    for an attribute instead and asking a model its size silently builds
+    the factorization being measured."""
+    est = NormalRegressor(alpha=1.0, beta=1.0)
+    est.fit(np.eye(3), np.array([1.0, 2.0, 3.0]))
+    est.__dict__.pop("_precision_factor", None)
 
-    def test_repr_flags_estimates(self):
-        assert repr(MemoryUsage(2048)) == "MemoryUsage(2.0 KiB)"
-        assert repr(MemoryUsage(2048, exact=False)) == "MemoryUsage(2.0 KiB, estimated)"
+    est.memory_usage  # noqa: B018 - the point is that this is inert
 
-    def test_report_orders_by_size_and_respects_depth(self):
-        usage = MemoryUsage(
-            3000,
-            parts={
-                "small": MemoryUsage(1000, parts={"deep": MemoryUsage(1000)}),
-                "big": MemoryUsage(2000),
-            },
-        )
-        assert usage.report(max_depth=1).splitlines() == [
-            "2.9 KiB",
-            "├── big: 2.0 KiB",
-            "└── small: 1000 B",
+    assert "_precision_factor" not in est.__dict__
+
+
+class TestSharedBuffersAreChargedOnce:
+    """A total has to be what dropping the object would free, not a sum
+    over references -- otherwise every shared learner and every cached
+    factor double-counts its precision matrix."""
+
+    def test_the_same_array_twice(self):
+        arr = np.zeros(1000)
+        usage = memory_usage([arr, arr])
+        assert usage.parts["[0]"].total == arr.nbytes
+        assert usage.parts["[1]"].total == 0
+
+    def test_precision_shared_between_estimator_and_its_factor(self):
+        est = NormalRegressor(alpha=1.0, beta=1.0, sparse=True)
+        est.fit(sp.csc_array(sp.eye_array(50, format="csc")), np.ones(50))
+        est._precision_factor  # noqa: B018 - materialize the factor
+
+        factor_parts = est.memory_usage.parts["_precision_factor"].parts
+
+        assert factor_parts["_precision"].total == 0
+        assert "shared" in factor_parts["_precision"].note
+
+    def test_rng_shared_by_every_arm_learner(self):
+        arms = [Arm(i, learner=NormalInverseGammaRegressor()) for i in range(5)]
+        agent = ContextualAgent(arms, ThompsonSampling(), random_seed=0)
+
+        per_arm = [
+            part.total for part in agent.memory_usage.parts["_arms"].parts.values()
         ]
-        assert "deep" in usage.report(max_depth=2)
 
-    def test_report_min_bytes_hides_without_changing_totals(self):
-        usage = MemoryUsage(
-            1048, parts={"big": MemoryUsage(1000), "tiny": MemoryUsage(48)}
-        )
-        report = usage.report(min_bytes=100)
-        assert "tiny" not in report
-        assert report.startswith("1.0 KiB")
+        # One Generator across all five learners; only one arm pays for it.
+        assert max(per_arm) - min(per_arm) < 2000
 
-    @pytest.mark.parametrize(
-        "n_bytes, expected",
-        [(0, "0 B"), (512, "512 B"), (1024, "1.0 KiB"), (1024**2, "1.0 MiB")],
-    )
-    def test_human_units(self, n_bytes: int, expected: str):
-        assert _human(n_bytes) == expected
+    def test_interned_scalars_are_exempt(self):
+        """Python hands out one object for the same small float, so
+        deduplicating those would fill a report with 0-byte rows."""
+        usage = memory_usage({"a": 1.0, "b": 1.0})
+        assert usage.parts["['a']"].total == usage.parts["['b']"].total > 0
 
 
-class TestArrays:
-    def test_owned_array_is_its_nbytes(self):
-        assert memory_usage(np.zeros(1000)).total == 8000
-
-    def test_view_is_charged_for_the_buffer_it_holds_alive(self):
+class TestWalk:
+    def test_a_view_is_charged_for_the_buffer_it_holds_alive(self):
+        """SciPy's sparse addition leaves its result on an oversized
+        allocation, which the logical ``nbytes`` would hide."""
         buffer = np.zeros(10_000)
         usage = memory_usage(buffer[:10])
         assert usage.total == buffer.nbytes
         assert "holding" in usage.note
 
-    def test_shared_array_is_counted_once(self):
-        arr = np.zeros(1000)
-        usage = memory_usage([arr, arr])
-        assert usage.parts["[0]"].total == 8000
-        assert usage.parts["[1]"].total == 0
-        assert usage.total < 2 * 8000
-
-    def test_sparse_array_counts_its_three_buffers(self):
-        A = sp.random_array((100, 100), density=0.1, format="csc", rng=0)
-        A = sp.csc_array(A)
+    def test_sparse_arrays_reach_their_three_buffers(self):
+        A = sp.csc_array(sp.random_array((100, 100), density=0.1, format="csc", rng=0))
         usage = memory_usage(A)
         assert usage.parts["data"].total == A.data.nbytes
         assert usage.parts["indices"].total == A.indices.nbytes
         assert usage.parts["indptr"].total == A.indptr.nbytes
-        assert usage.exact
 
-    def test_interned_scalars_are_not_reported_as_shared(self):
-        # Two attributes holding the same interned float must both be
-        # charged, not silently zeroed as "shared".
-        usage = memory_usage({"a": 1.0, "b": 1.0})
-        assert usage.parts["['a']"].total == usage.parts["['b']"].total > 0
-
-
-class TestObjects:
     def test_closure_contents_are_followed(self):
+        """A reward function can close over a lookup table."""
         table = np.zeros(1000)
 
         def reward(x):
             return x * table.sum()
 
-        assert memory_usage(reward).total > 8000
+        assert memory_usage(reward).total > table.nbytes
 
-    def test_modules_and_classes_are_not_counted(self):
-        assert memory_usage(np).total == 0
-        assert memory_usage(NormalRegressor).total == 0
-
-    def test_opaque_object_falls_back_to_its_header(self):
-        opaque = iter([])  # a list_iterator: no __dict__, no slots
-        usage = memory_usage(opaque)
-        assert usage.total == sys.getsizeof(opaque)
-        assert not usage.exact
-        assert "header only" in usage.note
-
-    def test_cycles_terminate(self):
+    def test_a_reference_cycle_terminates(self):
         a: dict = {}
         a["self"] = a
         assert memory_usage(a).total > 0
 
 
-class TestEstimators:
-    def test_dense_estimator_reports_its_posterior(self):
-        est = NormalInverseGammaRegressor()
-        est.fit(np.eye(2), np.array([1.0, 2.0]))
-        usage = est.memory_usage
-        assert usage.parts["coef_"].total == 16
-        assert usage.parts["cov_inv_"].total == 32
-        assert usage.exact
-
-    def test_measuring_does_not_build_lazy_caches(self):
-        est = NormalRegressor(alpha=1.0, beta=1.0)
-        est.fit(np.eye(3), np.array([1.0, 2.0, 3.0]))
-        est.__dict__.pop("_precision_factor", None)
-        est.memory_usage  # noqa: B018 - the point is that this is inert
-        assert "_precision_factor" not in est.__dict__
-
-    def test_precision_is_charged_once_across_estimator_and_factor(self):
-        est = NormalRegressor(alpha=1.0, beta=1.0, sparse=True)
-        X = sp.csc_array(sp.eye_array(50, format="csc"))
-        est.fit(X, np.ones(50))
-        est._precision_factor  # noqa: B018 - materialize the factor
-        usage = est.memory_usage
-        factor_parts = usage.parts["_precision_factor"].parts
-        assert factor_parts["_precision"].total == 0
-        assert "shared" in factor_parts["_precision"].note
-
-    def test_sparse_estimator_totals_exceed_the_dense_attributes(self):
-        est = NormalRegressor(alpha=1.0, beta=1.0, sparse=True)
-        X = sp.csc_array(sp.random_array((20, 500), density=0.05, format="csc", rng=0))
-        est.fit(X, np.ones(20))
-        est._precision_factor  # noqa: B018 - materialize the factor
-        usage = est.memory_usage
-        assert usage.total > usage.parts["cov_inv_"].total
-        assert usage.total >= sum(part.total for part in usage.parts.values())
-
-
-class TestAgents:
-    def test_agent_totals_cover_every_arm(self):
-        arms = [Arm(i, learner=NormalInverseGammaRegressor()) for i in range(3)]
-        agent = ContextualAgent(arms, ThompsonSampling(), random_seed=0)
-        X = np.array([[1.0, 2.0]])
-        agent.pull(X)
-        agent.update(X, np.array([1.0]))
-        usage = agent.memory_usage
-        assert set(usage.parts["_arms"].parts) == {"[0]", "[1]", "[2]"}
-        assert usage.total > sum(
-            arm.parts["learner"].total for arm in usage.parts["_arms"].parts.values()
-        )
-
-    def test_shared_rng_is_not_multiplied_across_arms(self):
-        arms = [Arm(i, learner=NormalInverseGammaRegressor()) for i in range(5)]
-        agent = ContextualAgent(arms, ThompsonSampling(), random_seed=0)
-        per_arm = [
-            part.total for part in agent.memory_usage.parts["_arms"].parts.values()
-        ]
-        # Every learner holds the same Generator; only one of them pays.
-        assert max(per_arm) - min(per_arm) < 2000
-
-
-class TestSparseFactors:
+class TestCFactorizations:
     @pytest.fixture
     def precision(self) -> sp.csc_array:
         rng = np.random.default_rng(0)
         A = sp.random_array((300, 300), density=0.01, format="csc", rng=rng)
         return sp.csc_array(A + A.T + sp.eye_array(300) * 20)
 
-    def test_superlu_is_reported_as_a_lower_bound(self, precision: sp.csc_array):
-        factor = create_sparse_factor(precision, solver=SparseSolver.SUPERLU)
-        assert isinstance(factor, SuperLUSparseFactor)
-        usage = memory_usage(factor._lu)
-        assert usage.total == factor._lu.nnz * 12 + 6 * 301 * 4
-        assert not usage.exact
-        assert "lower bound" in usage.note
-
-    def test_cholmod_is_exact_and_matches_its_array_lengths(
+    def test_cholmod_is_exact_because_its_factor_is_packed_simplicial(
         self, precision: sp.csc_array
     ):
+        """The exactness claim rests on scikit-sparse finalizing every
+        factor to packed simplicial form, where ``nzmax == nnz``. If a
+        release stops doing that, ``is_super`` flips here and the report
+        degrades to a labelled lower bound rather than a silent lie."""
         factor = create_sparse_factor(precision, solver=SparseSolver.CHOLMOD)
         assert isinstance(factor, CholmodSparseFactor)
-        cholmod_factor = factor._factor
-        usage = memory_usage(cholmod_factor)
+
+        usage = memory_usage(factor._factor)
+
+        assert not factor._factor.is_super
         assert usage.exact
-        # scikit-sparse finalizes to packed simplicial, so nzmax == nnz
-        # and the reported arrays are the ones CHOLMOD actually holds.
-        n, nnz = int(cholmod_factor.N), int(cholmod_factor.nnz)
-        index_size = cholmod_factor.itype.itemsize
-        assert usage.total == nnz * (8 + index_size) + (3 * n + 1) * index_size
-        assert not cholmod_factor.is_super
+        assert usage.total > int(factor._factor.nnz) * 8
 
-    def test_dense_factor_is_charged_for_its_triangle(self):
-        est = NormalRegressor(alpha=1.0, beta=1.0)
-        est.fit(np.eye(20), np.ones(20))
-        usage = est._precision_factor.memory_usage
-        assert usage.parts["_U"].total == 20 * 20 * 8
-        assert usage.exact
+    def test_superlu_is_labelled_a_lower_bound(self, precision: sp.csc_array):
+        """SciPy exposes only the logical nonzero count, and SuperLU's
+        supernodal ``L`` stores more than that."""
+        factor = create_sparse_factor(precision, solver=SparseSolver.SUPERLU)
+        assert isinstance(factor, SuperLUSparseFactor)
 
+        usage = memory_usage(factor._lu)
 
-class TestCholmodFallback:
-    """A supernodal factor cannot come out of scikit-sparse, but the
-    branch that would report one as a lower bound still has to work."""
-
-    def test_supernodal_factor_is_reported_as_a_lower_bound(self):
-        class FakeSupernodalFactor:
-            N = 100
-            nnz = 5000
-            dtype = np.dtype(np.float64)
-            itype = np.dtype(np.int32)
-            is_super = True
-
-        FakeSupernodalFactor.__module__ = "sksparse.cholmod"
-        factor = FakeSupernodalFactor()
-        assert _is_cholmod_factor(factor)
-        usage = _cholmod_usage(factor)
         assert not usage.exact
         assert "lower bound" in usage.note
-        assert usage.total == 5000 * 12 + 301 * 4
+        assert usage.total > factor._lu.nnz * 8

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,240 @@
+import sys
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+from bayesianbandits import (
+    Arm,
+    ContextualAgent,
+    MemoryUsage,
+    NormalInverseGammaRegressor,
+    NormalRegressor,
+    ThompsonSampling,
+    memory_usage,
+)
+from bayesianbandits._memory import _cholmod_usage, _human, _is_cholmod_factor
+from bayesianbandits._sparse_bayesian_linear_regression import (
+    CholmodSparseFactor,
+    SparseSolver,
+    SuperLUSparseFactor,
+    create_sparse_factor,
+)
+
+
+class TestMemoryUsage:
+    def test_total_and_int(self):
+        usage = MemoryUsage(1024, parts={"a": MemoryUsage(1024)})
+        assert usage.total == 1024
+        assert int(usage) == 1024
+
+    def test_repr_flags_estimates(self):
+        assert repr(MemoryUsage(2048)) == "MemoryUsage(2.0 KiB)"
+        assert repr(MemoryUsage(2048, exact=False)) == "MemoryUsage(2.0 KiB, estimated)"
+
+    def test_report_orders_by_size_and_respects_depth(self):
+        usage = MemoryUsage(
+            3000,
+            parts={
+                "small": MemoryUsage(1000, parts={"deep": MemoryUsage(1000)}),
+                "big": MemoryUsage(2000),
+            },
+        )
+        assert usage.report(max_depth=1).splitlines() == [
+            "2.9 KiB",
+            "├── big: 2.0 KiB",
+            "└── small: 1000 B",
+        ]
+        assert "deep" in usage.report(max_depth=2)
+
+    def test_report_min_bytes_hides_without_changing_totals(self):
+        usage = MemoryUsage(
+            1048, parts={"big": MemoryUsage(1000), "tiny": MemoryUsage(48)}
+        )
+        report = usage.report(min_bytes=100)
+        assert "tiny" not in report
+        assert report.startswith("1.0 KiB")
+
+    @pytest.mark.parametrize(
+        "n_bytes, expected",
+        [(0, "0 B"), (512, "512 B"), (1024, "1.0 KiB"), (1024**2, "1.0 MiB")],
+    )
+    def test_human_units(self, n_bytes: int, expected: str):
+        assert _human(n_bytes) == expected
+
+
+class TestArrays:
+    def test_owned_array_is_its_nbytes(self):
+        assert memory_usage(np.zeros(1000)).total == 8000
+
+    def test_view_is_charged_for_the_buffer_it_holds_alive(self):
+        buffer = np.zeros(10_000)
+        usage = memory_usage(buffer[:10])
+        assert usage.total == buffer.nbytes
+        assert "holding" in usage.note
+
+    def test_shared_array_is_counted_once(self):
+        arr = np.zeros(1000)
+        usage = memory_usage([arr, arr])
+        assert usage.parts["[0]"].total == 8000
+        assert usage.parts["[1]"].total == 0
+        assert usage.total < 2 * 8000
+
+    def test_sparse_array_counts_its_three_buffers(self):
+        A = sp.random_array((100, 100), density=0.1, format="csc", rng=0)
+        A = sp.csc_array(A)
+        usage = memory_usage(A)
+        assert usage.parts["data"].total == A.data.nbytes
+        assert usage.parts["indices"].total == A.indices.nbytes
+        assert usage.parts["indptr"].total == A.indptr.nbytes
+        assert usage.exact
+
+    def test_interned_scalars_are_not_reported_as_shared(self):
+        # Two attributes holding the same interned float must both be
+        # charged, not silently zeroed as "shared".
+        usage = memory_usage({"a": 1.0, "b": 1.0})
+        assert usage.parts["['a']"].total == usage.parts["['b']"].total > 0
+
+
+class TestObjects:
+    def test_closure_contents_are_followed(self):
+        table = np.zeros(1000)
+
+        def reward(x):
+            return x * table.sum()
+
+        assert memory_usage(reward).total > 8000
+
+    def test_modules_and_classes_are_not_counted(self):
+        assert memory_usage(np).total == 0
+        assert memory_usage(NormalRegressor).total == 0
+
+    def test_opaque_object_falls_back_to_its_header(self):
+        opaque = iter([])  # a list_iterator: no __dict__, no slots
+        usage = memory_usage(opaque)
+        assert usage.total == sys.getsizeof(opaque)
+        assert not usage.exact
+        assert "header only" in usage.note
+
+    def test_cycles_terminate(self):
+        a: dict = {}
+        a["self"] = a
+        assert memory_usage(a).total > 0
+
+
+class TestEstimators:
+    def test_dense_estimator_reports_its_posterior(self):
+        est = NormalInverseGammaRegressor()
+        est.fit(np.eye(2), np.array([1.0, 2.0]))
+        usage = est.memory_usage
+        assert usage.parts["coef_"].total == 16
+        assert usage.parts["cov_inv_"].total == 32
+        assert usage.exact
+
+    def test_measuring_does_not_build_lazy_caches(self):
+        est = NormalRegressor(alpha=1.0, beta=1.0)
+        est.fit(np.eye(3), np.array([1.0, 2.0, 3.0]))
+        est.__dict__.pop("_precision_factor", None)
+        est.memory_usage  # noqa: B018 - the point is that this is inert
+        assert "_precision_factor" not in est.__dict__
+
+    def test_precision_is_charged_once_across_estimator_and_factor(self):
+        est = NormalRegressor(alpha=1.0, beta=1.0, sparse=True)
+        X = sp.csc_array(sp.eye_array(50, format="csc"))
+        est.fit(X, np.ones(50))
+        est._precision_factor  # noqa: B018 - materialize the factor
+        usage = est.memory_usage
+        factor_parts = usage.parts["_precision_factor"].parts
+        assert factor_parts["_precision"].total == 0
+        assert "shared" in factor_parts["_precision"].note
+
+    def test_sparse_estimator_totals_exceed_the_dense_attributes(self):
+        est = NormalRegressor(alpha=1.0, beta=1.0, sparse=True)
+        X = sp.csc_array(sp.random_array((20, 500), density=0.05, format="csc", rng=0))
+        est.fit(X, np.ones(20))
+        est._precision_factor  # noqa: B018 - materialize the factor
+        usage = est.memory_usage
+        assert usage.total > usage.parts["cov_inv_"].total
+        assert usage.total >= sum(part.total for part in usage.parts.values())
+
+
+class TestAgents:
+    def test_agent_totals_cover_every_arm(self):
+        arms = [Arm(i, learner=NormalInverseGammaRegressor()) for i in range(3)]
+        agent = ContextualAgent(arms, ThompsonSampling(), random_seed=0)
+        X = np.array([[1.0, 2.0]])
+        agent.pull(X)
+        agent.update(X, np.array([1.0]))
+        usage = agent.memory_usage
+        assert set(usage.parts["_arms"].parts) == {"[0]", "[1]", "[2]"}
+        assert usage.total > sum(
+            arm.parts["learner"].total for arm in usage.parts["_arms"].parts.values()
+        )
+
+    def test_shared_rng_is_not_multiplied_across_arms(self):
+        arms = [Arm(i, learner=NormalInverseGammaRegressor()) for i in range(5)]
+        agent = ContextualAgent(arms, ThompsonSampling(), random_seed=0)
+        per_arm = [
+            part.total for part in agent.memory_usage.parts["_arms"].parts.values()
+        ]
+        # Every learner holds the same Generator; only one of them pays.
+        assert max(per_arm) - min(per_arm) < 2000
+
+
+class TestSparseFactors:
+    @pytest.fixture
+    def precision(self) -> sp.csc_array:
+        rng = np.random.default_rng(0)
+        A = sp.random_array((300, 300), density=0.01, format="csc", rng=rng)
+        return sp.csc_array(A + A.T + sp.eye_array(300) * 20)
+
+    def test_superlu_is_reported_as_a_lower_bound(self, precision: sp.csc_array):
+        factor = create_sparse_factor(precision, solver=SparseSolver.SUPERLU)
+        assert isinstance(factor, SuperLUSparseFactor)
+        usage = memory_usage(factor._lu)
+        assert usage.total == factor._lu.nnz * 12 + 6 * 301 * 4
+        assert not usage.exact
+        assert "lower bound" in usage.note
+
+    def test_cholmod_is_exact_and_matches_its_array_lengths(
+        self, precision: sp.csc_array
+    ):
+        factor = create_sparse_factor(precision, solver=SparseSolver.CHOLMOD)
+        assert isinstance(factor, CholmodSparseFactor)
+        cholmod_factor = factor._factor
+        usage = memory_usage(cholmod_factor)
+        assert usage.exact
+        # scikit-sparse finalizes to packed simplicial, so nzmax == nnz
+        # and the reported arrays are the ones CHOLMOD actually holds.
+        n, nnz = int(cholmod_factor.N), int(cholmod_factor.nnz)
+        index_size = cholmod_factor.itype.itemsize
+        assert usage.total == nnz * (8 + index_size) + (3 * n + 1) * index_size
+        assert not cholmod_factor.is_super
+
+    def test_dense_factor_is_charged_for_its_triangle(self):
+        est = NormalRegressor(alpha=1.0, beta=1.0)
+        est.fit(np.eye(20), np.ones(20))
+        usage = est._precision_factor.memory_usage
+        assert usage.parts["_U"].total == 20 * 20 * 8
+        assert usage.exact
+
+
+class TestCholmodFallback:
+    """A supernodal factor cannot come out of scikit-sparse, but the
+    branch that would report one as a lower bound still has to work."""
+
+    def test_supernodal_factor_is_reported_as_a_lower_bound(self):
+        class FakeSupernodalFactor:
+            N = 100
+            nnz = 5000
+            dtype = np.dtype(np.float64)
+            itype = np.dtype(np.int32)
+            is_super = True
+
+        FakeSupernodalFactor.__module__ = "sksparse.cholmod"
+        factor = FakeSupernodalFactor()
+        assert _is_cholmod_factor(factor)
+        usage = _cholmod_usage(factor)
+        assert not usage.exact
+        assert "lower bound" in usage.note
+        assert usage.total == 5000 * 12 + 301 * 4


### PR DESCRIPTION
Adds a memory_usage property to agents, arms, learners, pipelines, and
precision factors, plus a memory_usage() function for anything else.
sys.getsizeof cannot answer this question here: it reports the header of
a csc_array and nothing about its buffers, and 144 bytes for a SuperLU
object holding tens of megabytes.

The walk reads __dict__ rather than calling getattr, so measuring a model
never builds the cached factorization it is measuring. Buffers reachable
more than once -- a precision matrix shared with its factor, a learner
shared across arms, the RNG shared by every learner -- are charged at
first sighting and zero after, so a total is what dropping the object
would free rather than a sum over references. Array views are charged
for the buffer they hold alive, which surfaces cases like scipy's sparse
addition leaving its result on an oversized allocation.

The two C factorizations are priced from the structure counts they
expose, since neither wrapper surfaces its library's own allocation
counter:

- CHOLMOD is exact. scikit-sparse finalizes every factor to packed
  simplicial form (final_super=False, final_pack=True), which fixes
  nzmax == nnz and each array's length in terms of nnz and N. Validated
  against the allocator: within 2% of measured, the remainder being
  CHOLMOD's scratch workspace, which is excluded and noted.
- SuperLU is a lower bound and says so. SciPy exposes only the logical
  nonzero count, and SuperLU stores L as dense supernode blocks covering
  more than that -- measured 10-20% above the reported figure.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MDqYkznpoHum1TrTAWiJJH