### PR TITLE
Keep a draw-contiguous layout contract on the sampling entry points

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -109,29 +109,18 @@ Unreleased
 
 **Performance**
 
-- The sampling entry points now keep a layout contract: ``sample``,
-  ``sample_marginal``, and ``sample_reward_space`` return their
-  ``(size, n)`` draws *draw-contiguous* (``samples.T`` is C-contiguous,
-  each row's draws adjacent in memory). This costs nothing -- the final
-  projection is computed transposed, the same inner products written the
-  other way round -- and it makes the ``(n_arms, n_contexts, size)``
-  views the agents build for policies draw-contiguous with **zero
-  copies**. The agents in turn guarantee that layout at the policy
-  boundary, normalizing with one slabbed copy only for a third-party
-  learner that returns C-ordered draws; policies may rely on a
-  unit-stride draw axis and never need defensive copies. Previously the
-  draw axis carried the *largest* stride in the tensor, degrading
-  draw-axis BLAS contractions by orders of magnitude (the IDS entry
-  below) and quantile scans by half.
-
-  ``size=1`` output is contiguous in either orientation, so its exact
-  BLAS call is kept and Thompson sampling's draw stream stays
-  bit-for-bit identical. On a dense 96-arm, 64-context agent at
-  ``samples=1000``, an IDS pull drops from 75 ms to 44 ms (the layout
-  copy disappears) and an ``UpperConfidenceBound`` pull from 238 ms to
-  206 ms (the quantile runs contiguous). Seeded draws on the (also
-  unreleased) marginal and blocked reward-space paths shift, since
-  their normals now fill transposed; distributions are unchanged (#272)
+- The sampling entry points keep a layout contract: ``sample``,
+  ``sample_marginal``, and ``sample_reward_space`` return ``(size, n)``
+  draws with ``samples.T`` C-contiguous, at no cost (the projection is
+  computed transposed -- the same inner products). The
+  ``(n_arms, n_contexts, size)`` tensors agents build for policies are
+  then draw-contiguous with zero copies, where previously the draw axis
+  carried the largest stride in the tensor; agents normalize with one
+  copy for learners that break the contract. ``size=1`` keeps its exact
+  BLAS call, so Thompson sampling stays bit-for-bit identical. A dense
+  96-arm, 64-context IDS pull drops from 75 ms to 44 ms and UCB from
+  238 ms to 206 ms. Seeded draws on the (also unreleased) marginal and
+  blocked reward-space paths shift; distributions are unchanged (#272)
 
 - ``InformationDirectedSampling.select`` no longer reads its draws
   through the agent's transposed view. Agents hand a policy the learner's

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -109,19 +109,6 @@ Unreleased
 
 **Performance**
 
-- The sampling entry points keep a layout contract: ``sample``,
-  ``sample_marginal``, and ``sample_reward_space`` return ``(size, n)``
-  draws with ``samples.T`` C-contiguous, at no cost (the projection is
-  computed transposed -- the same inner products). The
-  ``(n_arms, n_contexts, size)`` tensors agents build for policies are
-  then draw-contiguous with zero copies, where previously the draw axis
-  carried the largest stride in the tensor; agents normalize with one
-  copy for learners that break the contract. ``size=1`` keeps its exact
-  BLAS call, so Thompson sampling stays bit-for-bit identical. A dense
-  96-arm, 64-context IDS pull drops from 75 ms to 44 ms and UCB from
-  238 ms to 206 ms. Seeded draws on the (also unreleased) marginal and
-  blocked reward-space paths shift; distributions are unchanged (#272)
-
 - ``InformationDirectedSampling.select`` no longer reads its draws
   through the agent's transposed view. Agents hand a policy the learner's
   ``(size, n_rows)`` output reshaped and transposed, which leaves the draw

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -109,6 +109,30 @@ Unreleased
 
 **Performance**
 
+- The sampling entry points now keep a layout contract: ``sample``,
+  ``sample_marginal``, and ``sample_reward_space`` return their
+  ``(size, n)`` draws *draw-contiguous* (``samples.T`` is C-contiguous,
+  each row's draws adjacent in memory). This costs nothing -- the final
+  projection is computed transposed, the same inner products written the
+  other way round -- and it makes the ``(n_arms, n_contexts, size)``
+  views the agents build for policies draw-contiguous with **zero
+  copies**. The agents in turn guarantee that layout at the policy
+  boundary, normalizing with one slabbed copy only for a third-party
+  learner that returns C-ordered draws; policies may rely on a
+  unit-stride draw axis and never need defensive copies. Previously the
+  draw axis carried the *largest* stride in the tensor, degrading
+  draw-axis BLAS contractions by orders of magnitude (the IDS entry
+  below) and quantile scans by half.
+
+  ``size=1`` output is contiguous in either orientation, so its exact
+  BLAS call is kept and Thompson sampling's draw stream stays
+  bit-for-bit identical. On a dense 96-arm, 64-context agent at
+  ``samples=1000``, an IDS pull drops from 75 ms to 44 ms (the layout
+  copy disappears) and an ``UpperConfidenceBound`` pull from 238 ms to
+  206 ms (the quantile runs contiguous). Seeded draws on the (also
+  unreleased) marginal and blocked reward-space paths shift, since
+  their normals now fill transposed; distributions are unchanged (#272)
+
 - ``InformationDirectedSampling.select`` no longer reads its draws
   through the agent's transposed view. Agents hand a policy the learner's
   ``(size, n_rows)`` output reshaped and transposed, which leaves the draw

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,10 @@ where = ["src"]
 bayesianbandits = ["*.pyx"]
 
 [tool.pytest.ini_options]
+# Bare `pytest` must never collect benchmarks/: pytest-benchmark runs them
+# as tests without any flag, and the slow 1M-feature cases allocate enough
+# to OOM a development VM. Run them explicitly per the README/CLAUDE.md.
+testpaths = ["tests", "src"]
 addopts = "--doctest-modules -v"
 filterwarnings = "ignore::DeprecationWarning"
 markers = [

--- a/src/bayesianbandits/_arm.py
+++ b/src/bayesianbandits/_arm.py
@@ -658,8 +658,10 @@ def _sample_context_major_blocks(
     Permutes the arm-major stack (row ``a * n_contexts + c``)
     context-major so each context's arm rows form one consecutive
     jointly-drawn block, samples, and restores the (arm, context) axes.
-    Returns shape ``(n_arms, n_contexts, size)``, a zero-copy view of
-    the drawn array.
+    Returns shape ``(n_arms, n_contexts, size)``. For a sampler honoring
+    the layout contract (draw-contiguous ``(size, n)`` output) this is a
+    zero-copy draw-contiguous view; reshaping through the transpose lets
+    numpy fall back to one copy for a sampler that does not.
     """
     if n_arms == 1 or n_contexts == 1:
         # the permutation is the identity; skip the gather-copy
@@ -668,7 +670,7 @@ def _sample_context_major_blocks(
         perm = _context_major_permutation(n_arms, n_contexts)
         X_ctx_major = _take_rows(X_stacked, perm)
     drawn = joint_sampler(X_ctx_major, size=size)
-    return drawn.reshape(size, n_contexts, n_arms).transpose(2, 1, 0)
+    return drawn.T.reshape(n_contexts, n_arms, size).transpose(1, 0, 2)
 
 
 def posterior_identity(learner: Any) -> Any:

--- a/src/bayesianbandits/_arm.py
+++ b/src/bayesianbandits/_arm.py
@@ -658,10 +658,9 @@ def _sample_context_major_blocks(
     Permutes the arm-major stack (row ``a * n_contexts + c``)
     context-major so each context's arm rows form one consecutive
     jointly-drawn block, samples, and restores the (arm, context) axes.
-    Returns shape ``(n_arms, n_contexts, size)``. For a sampler honoring
-    the layout contract (draw-contiguous ``(size, n)`` output) this is a
-    zero-copy draw-contiguous view; reshaping through the transpose lets
-    numpy fall back to one copy for a sampler that does not.
+    Returns shape ``(n_arms, n_contexts, size)``: a zero-copy
+    draw-contiguous view for a contract-conforming sampler, one reshape
+    copy otherwise.
     """
     if n_arms == 1 or n_contexts == 1:
         # the permutation is the identity; skip the gather-copy

--- a/src/bayesianbandits/_blas_helpers.py
+++ b/src/bayesianbandits/_blas_helpers.py
@@ -135,3 +135,62 @@ def affine_lower_factor(
         NDArray[np.float64],
         dgemm(1.0, z, L, trans_b=1, beta=1.0, c=out, overwrite_c=True),
     )
+
+
+def project_draws(
+    weights: NDArray[np.float64], X: Union[NDArray[np.float64], csc_array]
+) -> NDArray[np.float64]:
+    """``weights @ X.T`` -- shape ``(size, n_rows)`` -- draw-contiguous.
+
+    Computed as ``(X @ weights.T).T``: the transpose of the same product,
+    so every element is the same inner product, but the result is written
+    with each *row's draws* contiguous in memory (``samples.T`` is
+    C-contiguous). That is the layout contract of the sampling entry
+    points: agents transpose ``(size, n_rows)`` output into
+    ``(n_arms, n_contexts, size)`` views for the policies, and this
+    orientation makes those views draw-contiguous without a copy.
+
+    ``size == 1`` keeps the original orientation and BLAS call: a
+    single-row result is contiguous either way, and Thompson sampling's
+    bit-for-bit stability across versions pins that exact call.
+    """
+    if weights.shape[0] == 1:
+        return cast(NDArray[np.float64], weights @ X.T)
+    return cast(NDArray[np.float64], (X @ weights.T).T)
+
+
+#: Byte budget for one slab of :func:`draw_contiguous`'s copy. Sized to
+#: keep the source block of a slab resident in L2 while it is scattered
+#: out to its transposed destination.
+_COPY_SLAB_BYTES = 1 << 20
+
+
+def draw_contiguous(samples: NDArray[np.float64]) -> NDArray[np.float64]:
+    """``samples`` with its trailing (draw) axis contiguous, copying if needed.
+
+    The policy boundary's layout contract: a ``(n_arms, n_contexts,
+    n_draws)`` tensor whose draw axis is unit-stride, so reductions and
+    contractions over draws run at full speed. Conforming learners make
+    the agents' transposed reshapes satisfy this for free; this helper
+    is the normalization for tensors that do not (e.g. a third-party
+    learner returning C-ordered ``(size, n_rows)``), whose transposed
+    view leaves the draw axis with the *largest* stride -- a layout
+    under which draw-axis BLAS contractions degrade by orders of
+    magnitude.
+
+    numpy's own copy of such a view walks the draw axis outermost and
+    touches a fresh cache line per element. Copying a slab of draws at
+    a time keeps the source block resident while it is scattered out,
+    about three times faster on large tensors. Conforming input is
+    returned untouched.
+    """
+    if samples.dtype == np.float64 and samples.strides[-1] == samples.itemsize:
+        return samples
+    n_leading = int(np.prod(samples.shape[:-1]))
+    n_draws = samples.shape[-1]
+    out = np.empty(samples.shape, dtype=np.float64)
+    slab = max(1, min(n_draws, _COPY_SLAB_BYTES // max(1, n_leading * 8)))
+    for start in range(0, n_draws, slab):
+        stop = start + slab
+        out[..., start:stop] = samples[..., start:stop]
+    return out

--- a/src/bayesianbandits/_blas_helpers.py
+++ b/src/bayesianbandits/_blas_helpers.py
@@ -140,49 +140,32 @@ def affine_lower_factor(
 def project_draws(
     weights: NDArray[np.float64], X: Union[NDArray[np.float64], csc_array]
 ) -> NDArray[np.float64]:
-    """``weights @ X.T`` -- shape ``(size, n_rows)`` -- draw-contiguous.
+    """``weights @ X.T``, draw-contiguous: ``result.T`` is C-contiguous.
 
-    Computed as ``(X @ weights.T).T``: the transpose of the same product,
-    so every element is the same inner product, but the result is written
-    with each *row's draws* contiguous in memory (``samples.T`` is
-    C-contiguous). That is the layout contract of the sampling entry
-    points: agents transpose ``(size, n_rows)`` output into
-    ``(n_arms, n_contexts, size)`` views for the policies, and this
-    orientation makes those views draw-contiguous without a copy.
-
-    ``size == 1`` keeps the original orientation and BLAS call: a
-    single-row result is contiguous either way, and Thompson sampling's
-    bit-for-bit stability across versions pins that exact call.
+    The layout contract of the sampling entry points (see
+    ``tests/test_sample_layout.py``): computing the transposed product
+    gives the same inner products but lands each row's draws adjacent,
+    so the agents' transposed reshapes for policies need no copy. Do not
+    "simplify" back to ``weights @ X.T``. ``size == 1`` keeps the
+    original BLAS call, pinning Thompson sampling's draw stream.
     """
     if weights.shape[0] == 1:
         return cast(NDArray[np.float64], weights @ X.T)
     return cast(NDArray[np.float64], (X @ weights.T).T)
 
 
-#: Byte budget for one slab of :func:`draw_contiguous`'s copy. Sized to
-#: keep the source block of a slab resident in L2 while it is scattered
-#: out to its transposed destination.
+#: Slab byte budget for :func:`draw_contiguous`: keeps a slab's source
+#: block L2-resident while it is scattered out.
 _COPY_SLAB_BYTES = 1 << 20
 
 
 def draw_contiguous(samples: NDArray[np.float64]) -> NDArray[np.float64]:
-    """``samples`` with its trailing (draw) axis contiguous, copying if needed.
+    """``samples`` with a unit-stride draw (last) axis, copying if needed.
 
-    The policy boundary's layout contract: a ``(n_arms, n_contexts,
-    n_draws)`` tensor whose draw axis is unit-stride, so reductions and
-    contractions over draws run at full speed. Conforming learners make
-    the agents' transposed reshapes satisfy this for free; this helper
-    is the normalization for tensors that do not (e.g. a third-party
-    learner returning C-ordered ``(size, n_rows)``), whose transposed
-    view leaves the draw axis with the *largest* stride -- a layout
-    under which draw-axis BLAS contractions degrade by orders of
-    magnitude.
-
-    numpy's own copy of such a view walks the draw axis outermost and
-    touches a fresh cache line per element. Copying a slab of draws at
-    a time keeps the source block resident while it is scattered out,
-    about three times faster on large tensors. Conforming input is
-    returned untouched.
+    Normalization at the policy boundary for learners that ignore the
+    layout contract; conforming input passes through untouched. Copies
+    slab-wise: numpy's own strided copy walks the draw axis outermost
+    and runs ~3x slower on large tensors.
     """
     if samples.dtype == np.float64 and samples.strides[-1] == samples.itemsize:
         return samples

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -1096,10 +1096,8 @@ def _blocked_colorize(
 
     ``L`` has shape ``(n_blocks, k, k)``, ``z`` has shape
     ``(n_blocks, size, k)``; returns shape ``(size, n_blocks * k)``,
-    draw-contiguous (``result.T`` is C-contiguous) per the sampling
-    layout contract: the batched GEMM writes each block's rows with
-    their draws adjacent, so neither the draw tensor nor the result is
-    copied through a transposed intermediate.
+    draw-contiguous per the sampling layout contract (see
+    :func:`~bayesianbandits._blas_helpers.project_draws`).
     """
     n_blocks, size, k = z.shape
     out = np.empty((n_blocks, k, size))
@@ -1600,9 +1598,8 @@ scipy.sparse.csc_array
         Returns
         -------
         samples : ndarray of shape (size, n_samples)
-            Predicted values for each posterior draw. Draw-contiguous:
-            ``samples.T`` is C-contiguous, so transposed views of the
-            draws are cheap.
+            Predicted values for each posterior draw. Draw-contiguous
+            (``samples.T`` is C-contiguous).
 
         See Also
         --------
@@ -1681,9 +1678,8 @@ scipy.sparse.csc_array
         Returns
         -------
         samples : ndarray of shape (size, n_samples)
-            Independent marginal draws for each row. Draw-contiguous:
-            ``samples.T`` is C-contiguous, so transposed views of the
-            draws are cheap.
+            Independent marginal draws for each row. Draw-contiguous
+            (``samples.T`` is C-contiguous).
 
         See Also
         --------
@@ -1753,9 +1749,8 @@ scipy.sparse.csc_array
         Returns
         -------
         samples : ndarray of shape (size, n_samples)
-            Predicted values for each posterior draw. Draw-contiguous:
-            ``samples.T`` is C-contiguous, so transposed views of the
-            draws are cheap.
+            Predicted values for each posterior draw. Draw-contiguous
+            (``samples.T`` is C-contiguous).
 
         See Also
         --------
@@ -2173,9 +2168,8 @@ scipy.sparse.csc_array
         Returns
         -------
         samples : ndarray of shape (size, n_samples)
-            Predicted values for each posterior draw. Draw-contiguous:
-            ``samples.T`` is C-contiguous, so transposed views of the
-            draws are cheap.
+            Predicted values for each posterior draw. Draw-contiguous
+            (``samples.T`` is C-contiguous).
 
         See Also
         --------
@@ -2256,9 +2250,8 @@ scipy.sparse.csc_array
         Returns
         -------
         samples : ndarray of shape (size, n_samples)
-            Independent marginal draws for each row. Draw-contiguous:
-            ``samples.T`` is C-contiguous, so transposed views of the
-            draws are cheap.
+            Independent marginal draws for each row. Draw-contiguous
+            (``samples.T`` is C-contiguous).
 
         See Also
         --------
@@ -2269,8 +2262,8 @@ scipy.sparse.csc_array
         df = 2.0 * self.a_
         z = standard_normal_f(self.random_state_, size, mean.shape[0])
         # one chi-square per (draw, row) cell: rows must be fully
-        # independent, not merely marginally exact; drawn transposed so
-        # the result inherits the draw-contiguous layout contract
+        # independent, not merely marginally exact; transposed fill for
+        # the draw-contiguous layout
         g = self.random_state_.chisquare(df, size=(mean.shape[0], size)).T
         # the (b/a) scale factor and the df/g mixing fold into one
         # per-cell scale
@@ -2317,9 +2310,8 @@ scipy.sparse.csc_array
         Returns
         -------
         samples : ndarray of shape (size, n_samples)
-            Predicted values for each posterior draw. Draw-contiguous:
-            ``samples.T`` is C-contiguous, so transposed views of the
-            draws are cheap.
+            Predicted values for each posterior draw. Draw-contiguous
+            (``samples.T`` is C-contiguous).
 
         See Also
         --------
@@ -2930,9 +2922,8 @@ scipy.sparse.csc_array
         samples : ndarray of shape (size, n_samples)
             Predicted values for each posterior sample. For
             ``link='logit'``, probabilities in [0, 1]. For
-            ``link='log'``, expected counts (positive reals). Draw-contiguous:
-            ``samples.T`` is C-contiguous, so transposed views of the
-            draws are cheap.
+            ``link='log'``, expected counts (positive reals). Draw-contiguous
+            (``samples.T`` is C-contiguous).
 
         See Also
         --------
@@ -3005,9 +2996,8 @@ scipy.sparse.csc_array
         -------
         samples : ndarray of shape (size, n_samples)
             Independent marginal draws for each row, on the response
-            scale of the link. Draw-contiguous:
-            ``samples.T`` is C-contiguous, so transposed views of the
-            draws are cheap.
+            scale of the link. Draw-contiguous
+            (``samples.T`` is C-contiguous).
 
         See Also
         --------
@@ -3052,9 +3042,8 @@ scipy.sparse.csc_array
         -------
         samples : ndarray of shape (size, n_samples)
             Predicted values for each posterior sample, on the response
-            scale of the link. Draw-contiguous:
-            ``samples.T`` is C-contiguous, so transposed views of the
-            draws are cheap.
+            scale of the link. Draw-contiguous
+            (``samples.T`` is C-contiguous).
 
         See Also
         --------

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -32,6 +32,7 @@ from ._blas_helpers import (
     compute_eta_dense,
     dense_matvec,
     lower_predictive_sqrt,
+    project_draws,
     standard_normal_f,
     update_precision_dense,
 )
@@ -1094,16 +1095,17 @@ def _blocked_colorize(
     """Apply per-block lower factors: ``(L_b @ z_{s,b})`` for every draw.
 
     ``L`` has shape ``(n_blocks, k, k)``, ``z`` has shape
-    ``(n_blocks, size, k)``; returns shape ``(size, n_blocks * k)``. The
-    result is written straight into a C-order ``(size, n_blocks, k)``
-    array, so neither the draw tensor nor the result is copied through
-    a transposed intermediate.
+    ``(n_blocks, size, k)``; returns shape ``(size, n_blocks * k)``,
+    draw-contiguous (``result.T`` is C-contiguous) per the sampling
+    layout contract: the batched GEMM writes each block's rows with
+    their draws adjacent, so neither the draw tensor nor the result is
+    copied through a transposed intermediate.
     """
     n_blocks, size, k = z.shape
-    out = np.empty((size, n_blocks, k))
-    np.matmul(z, L.transpose(0, 2, 1), out=out.transpose(1, 0, 2))
-    # explicit column count: reshape(size, -1) is ambiguous when size == 0
-    return out.reshape(size, n_blocks * k)
+    out = np.empty((n_blocks, k, size))
+    np.matmul(L, z.transpose(0, 2, 1), out=out)
+    # explicit column count: reshape(-1, size) is ambiguous when size == 0
+    return out.reshape(n_blocks * k, size).T
 
 
 class _RewardSpacePredictiveMixin:
@@ -1598,7 +1600,9 @@ scipy.sparse.csc_array
         Returns
         -------
         samples : ndarray of shape (size, n_samples)
-            Predicted values for each posterior draw.
+            Predicted values for each posterior draw. Draw-contiguous:
+            ``samples.T`` is C-contiguous, so transposed views of the
+            draws are cheap.
 
         See Also
         --------
@@ -1642,7 +1646,7 @@ scipy.sparse.csc_array
             )
         )
 
-        return samples @ X_sample.T  # type: ignore
+        return project_draws(samples, X_sample)
 
     def sample_marginal(
         self, X: Union[NDArray[Any], csc_array], size: int = 1
@@ -1677,7 +1681,9 @@ scipy.sparse.csc_array
         Returns
         -------
         samples : ndarray of shape (size, n_samples)
-            Independent marginal draws for each row.
+            Independent marginal draws for each row. Draw-contiguous:
+            ``samples.T`` is C-contiguous, so transposed views of the
+            draws are cheap.
 
         See Also
         --------
@@ -1685,7 +1691,7 @@ scipy.sparse.csc_array
         predict : Point predictions using the posterior mean.
         """
         mean, sd = _validated_marginal_mean_sd(self, X)
-        z = self.random_state_.standard_normal((size, mean.shape[0]))
+        z = standard_normal_f(self.random_state_, size, mean.shape[0])
         return cast(NDArray[np.float64], mean + sd * z)
 
     def sample_reward_space(
@@ -1747,7 +1753,9 @@ scipy.sparse.csc_array
         Returns
         -------
         samples : ndarray of shape (size, n_samples)
-            Predicted values for each posterior draw.
+            Predicted values for each posterior draw. Draw-contiguous:
+            ``samples.T`` is C-contiguous, so transposed views of the
+            draws are cheap.
 
         See Also
         --------
@@ -2165,7 +2173,9 @@ scipy.sparse.csc_array
         Returns
         -------
         samples : ndarray of shape (size, n_samples)
-            Predicted values for each posterior draw.
+            Predicted values for each posterior draw. Draw-contiguous:
+            ``samples.T`` is C-contiguous, so transposed views of the
+            draws are cheap.
 
         See Also
         --------
@@ -2216,7 +2226,7 @@ scipy.sparse.csc_array
         if self.n_features_ == 1:
             samples = np.expand_dims(samples, -1)
 
-        return np.atleast_2d(samples @ X_sample.T)  # type: ignore
+        return project_draws(np.atleast_2d(samples), X_sample)
 
     def sample_marginal(
         self, X: Union[NDArray[Any], csc_array], size: int = 1
@@ -2246,7 +2256,9 @@ scipy.sparse.csc_array
         Returns
         -------
         samples : ndarray of shape (size, n_samples)
-            Independent marginal draws for each row.
+            Independent marginal draws for each row. Draw-contiguous:
+            ``samples.T`` is C-contiguous, so transposed views of the
+            draws are cheap.
 
         See Also
         --------
@@ -2255,10 +2267,11 @@ scipy.sparse.csc_array
         """
         mean, sd = _validated_marginal_mean_sd(self, X)
         df = 2.0 * self.a_
-        z = self.random_state_.standard_normal((size, mean.shape[0]))
+        z = standard_normal_f(self.random_state_, size, mean.shape[0])
         # one chi-square per (draw, row) cell: rows must be fully
-        # independent, not merely marginally exact
-        g = self.random_state_.chisquare(df, size=(size, mean.shape[0]))
+        # independent, not merely marginally exact; drawn transposed so
+        # the result inherits the draw-contiguous layout contract
+        g = self.random_state_.chisquare(df, size=(mean.shape[0], size)).T
         # the (b/a) scale factor and the df/g mixing fold into one
         # per-cell scale
         scale = np.sqrt((self.b_ / self.a_) * df / g)
@@ -2304,7 +2317,9 @@ scipy.sparse.csc_array
         Returns
         -------
         samples : ndarray of shape (size, n_samples)
-            Predicted values for each posterior draw.
+            Predicted values for each posterior draw. Draw-contiguous:
+            ``samples.T`` is C-contiguous, so transposed views of the
+            draws are cheap.
 
         See Also
         --------
@@ -2915,7 +2930,9 @@ scipy.sparse.csc_array
         samples : ndarray of shape (size, n_samples)
             Predicted values for each posterior sample. For
             ``link='logit'``, probabilities in [0, 1]. For
-            ``link='log'``, expected counts (positive reals).
+            ``link='log'``, expected counts (positive reals). Draw-contiguous:
+            ``samples.T`` is C-contiguous, so transposed views of the
+            draws are cheap.
 
         See Also
         --------
@@ -2956,9 +2973,9 @@ scipy.sparse.csc_array
         )
 
         # Vectorized: (size, n_features) @ (n_features, n_samples) -> (size, n_samples)
-        eta = param_samples @ X_sample.T
+        eta = project_draws(param_samples, X_sample)
 
-        return self._inverse_link(cast(NDArray[np.float64], eta))
+        return self._inverse_link(eta)
 
     def sample_marginal(
         self, X: Union[NDArray[Any], csc_array], size: int = 1
@@ -2988,7 +3005,9 @@ scipy.sparse.csc_array
         -------
         samples : ndarray of shape (size, n_samples)
             Independent marginal draws for each row, on the response
-            scale of the link.
+            scale of the link. Draw-contiguous:
+            ``samples.T`` is C-contiguous, so transposed views of the
+            draws are cheap.
 
         See Also
         --------
@@ -2996,7 +3015,7 @@ scipy.sparse.csc_array
         predict : Point predictions using the posterior mean.
         """
         mean, sd = _validated_marginal_mean_sd(self, X)
-        z = self.random_state_.standard_normal((size, mean.shape[0]))
+        z = standard_normal_f(self.random_state_, size, mean.shape[0])
         return self._inverse_link(mean + sd * z)
 
     def sample_reward_space(
@@ -3033,7 +3052,9 @@ scipy.sparse.csc_array
         -------
         samples : ndarray of shape (size, n_samples)
             Predicted values for each posterior sample, on the response
-            scale of the link.
+            scale of the link. Draw-contiguous:
+            ``samples.T`` is C-contiguous, so transposed views of the
+            draws are cheap.
 
         See Also
         --------

--- a/src/bayesianbandits/_support_covariance.py
+++ b/src/bayesianbandits/_support_covariance.py
@@ -136,10 +136,8 @@ class SupportDraw:
         """``size`` jointly-distributed draws, shape ``(size, n_rows)``.
 
         Rows within one draw share a weight vector, matching ``sample``.
-        Returned draw-contiguous (``result.T`` is C-contiguous), per the
-        sampling layout contract: the projection is computed transposed,
-        which is the same inner products written row-major by prediction
-        row rather than by draw.
+        Projected transposed so the result is draw-contiguous (see
+        :func:`~bayesianbandits._blas_helpers.project_draws`).
         """
         ZC = rng.standard_normal((size, self._C.shape[0])) @ self._C.T
         out = np.empty((self._n_rows, size), dtype=np.float64)

--- a/src/bayesianbandits/_support_covariance.py
+++ b/src/bayesianbandits/_support_covariance.py
@@ -136,16 +136,20 @@ class SupportDraw:
         """``size`` jointly-distributed draws, shape ``(size, n_rows)``.
 
         Rows within one draw share a weight vector, matching ``sample``.
+        Returned draw-contiguous (``result.T`` is C-contiguous), per the
+        sampling layout contract: the projection is computed transposed,
+        which is the same inner products written row-major by prediction
+        row rather than by draw.
         """
         ZC = rng.standard_normal((size, self._C.shape[0])) @ self._C.T
-        out = np.empty((size, self._n_rows), dtype=np.float64)
+        out = np.empty((self._n_rows, size), dtype=np.float64)
         block = self._row_block()
         for start in range(0, self._n_rows, block):
             stop = min(self._n_rows, start + block)
-            out[:, start:stop] = (
-                ZC @ np.asarray(self._XU[start:stop].todense(), dtype=np.float64).T
+            out[start:stop] = (
+                np.asarray(self._XU[start:stop].todense(), dtype=np.float64) @ ZC.T
             )
-        return out
+        return out.T
 
     def sd(self) -> NDArray[np.float64]:
         """Per-row predictive standard deviations, shape ``(n_rows,)``."""

--- a/src/bayesianbandits/api.py
+++ b/src/bayesianbandits/api.py
@@ -117,11 +117,8 @@ class PolicyProtocol(Protocol[ContextType, TokenType]):
     always correct and never the cheapest; a policy scoring each arm
     on its own should say ``MARGINAL_ONLY``.
 
-    Alongside this distributional contract the agents keep a *layout*
-    contract: the ``(n_arms, n_contexts, samples_needed)`` tensor
-    handed to ``select`` always has a unit-stride draw axis, so
-    reductions and contractions over draws run at full speed. Policies
-    may rely on it and never need defensive copies.
+    The agents also keep a layout contract: the tensor handed to
+    ``select`` always has a unit-stride draw axis.
     """
 
     @overload
@@ -1165,12 +1162,9 @@ class LipschitzContextualAgent(Generic[TokenType]):
             Reshaped array with shape (n_arms, n_contexts, size, ...)
         """
         if samples.ndim == 2:
-            # 2D case: (size, n_contexts*n_arms) -> (n_arms, n_contexts, size).
-            # For a learner honoring the layout contract (draw-contiguous
-            # output, i.e. samples.T C-contiguous) this view is already
-            # draw-contiguous; draw_contiguous is then a no-op flags check,
-            # and otherwise normalizes with one slabbed copy so policies
-            # never see a draw axis with the largest stride.
+            # 2D case: (size, n_contexts*n_arms) -> (n_arms, n_contexts, size);
+            # draw_contiguous no-ops for contract-conforming learners and
+            # normalizes the layout otherwise
             return draw_contiguous(samples.T.reshape(n_arms, n_contexts, -1))
         else:
             # 3D+ case: (size, n_contexts*n_arms, ...) -> (n_arms, n_contexts, size, ...)

--- a/src/bayesianbandits/api.py
+++ b/src/bayesianbandits/api.py
@@ -88,6 +88,7 @@ from ._arm import (
     resolve_reward_space_sampler,
 )
 from ._arm_featurizer import ArmFeaturizer
+from ._blas_helpers import draw_contiguous
 from ._draw_kind import DrawKind
 from .policies import (  # noqa: F401
     EpsilonGreedy,
@@ -115,6 +116,12 @@ class PolicyProtocol(Protocol[ContextType, TokenType]):
     Defaults to ``JOINT`` on :class:`PolicyDefaultUpdate`, which is
     always correct and never the cheapest; a policy scoring each arm
     on its own should say ``MARGINAL_ONLY``.
+
+    Alongside this distributional contract the agents keep a *layout*
+    contract: the ``(n_arms, n_contexts, samples_needed)`` tensor
+    handed to ``select`` always has a unit-stride draw axis, so
+    reductions and contractions over draws run at full speed. Policies
+    may rely on it and never need defensive copies.
     """
 
     @overload
@@ -1158,8 +1165,13 @@ class LipschitzContextualAgent(Generic[TokenType]):
             Reshaped array with shape (n_arms, n_contexts, size, ...)
         """
         if samples.ndim == 2:
-            # 2D case: (size, n_contexts*n_arms) -> (n_arms, n_contexts, size)
-            return samples.T.reshape(n_arms, n_contexts, -1)
+            # 2D case: (size, n_contexts*n_arms) -> (n_arms, n_contexts, size).
+            # For a learner honoring the layout contract (draw-contiguous
+            # output, i.e. samples.T C-contiguous) this view is already
+            # draw-contiguous; draw_contiguous is then a no-op flags check,
+            # and otherwise normalizes with one slabbed copy so policies
+            # never see a draw axis with the largest stride.
+            return draw_contiguous(samples.T.reshape(n_arms, n_contexts, -1))
         else:
             # 3D+ case: (size, n_contexts*n_arms, ...) -> (n_arms, n_contexts, size, ...)
             samples_moved = np.moveaxis(samples, 0, 1)  # Move size to position 1

--- a/src/bayesianbandits/policies/_base.py
+++ b/src/bayesianbandits/policies/_base.py
@@ -46,10 +46,8 @@ class PolicyDefaultUpdate(Generic[ContextType, TokenType]):
         samples that learner once for all arms rather than coming
         through here.
         """
-        # Stacking each arm's (size, n_contexts) draws transposed writes
-        # the (n_arms, n_contexts, size) tensor directly in C order: the
-        # same single copy the stack always was, but the draw axis comes
-        # out contiguous, per the policy boundary's layout contract.
+        # Stacking transposed builds (n_arms, n_contexts, size) in one
+        # copy with the draw axis contiguous (the layout contract).
         return np.array(
             [
                 (

--- a/src/bayesianbandits/policies/_base.py
+++ b/src/bayesianbandits/policies/_base.py
@@ -46,18 +46,20 @@ class PolicyDefaultUpdate(Generic[ContextType, TokenType]):
         samples that learner once for all arms rather than coming
         through here.
         """
-        samples = np.array(
+        # Stacking each arm's (size, n_contexts) draws transposed writes
+        # the (n_arms, n_contexts, size) tensor directly in C order: the
+        # same single copy the stack always was, but the draw axis comes
+        # out contiguous, per the policy boundary's layout contract.
+        return np.array(
             [
                 (
                     arm.sample_marginal
                     if self.consumes == DrawKind.MARGINAL_ONLY
                     else arm.sample
-                )(X, size)
+                )(X, size).T
                 for arm in arms
             ]
         )
-        # Convert from (n_arms, size, n_contexts) to (n_arms, n_contexts, size)
-        return samples.transpose(0, 2, 1)
 
     def update(
         self,

--- a/src/bayesianbandits/policies/_information_directed_sampling.py
+++ b/src/bayesianbandits/policies/_information_directed_sampling.py
@@ -14,39 +14,9 @@ import numpy as np
 from numpy.typing import NDArray
 
 from .._arm import Arm, ContextType, TokenType
+from .._blas_helpers import draw_contiguous
 from .._draw_kind import DrawKind
 from ._base import PolicyDefaultUpdate
-
-#: Byte budget for one slab of the draw-major copy below. Sized to keep
-#: the source block of a slab resident in L2 while it is scattered out.
-_COPY_SLAB_BYTES = 1 << 20
-
-
-def _draw_contiguous(samples: NDArray[np.float64]) -> NDArray[np.float64]:
-    """``samples`` as a C-ordered ``(n_arms, n_contexts, n_draws)`` tensor.
-
-    Agents hand this tensor to a policy as a transposed view of the
-    learner's ``(size, n_rows)`` output, which leaves the draw axis with
-    the *largest* stride. Every statistic below reduces or contracts over
-    draws, and the conditional-mean GEMM falls off BLAS entirely in that
-    layout: materializing the natural order first costs one pass and buys
-    back two orders of magnitude.
-
-    numpy's own copy walks the draw axis outermost and so touches a fresh
-    cache line per element. Copying a slab of draws at a time keeps the
-    source block resident while it is scattered out, which runs about
-    three times faster on the large shapes. Already-contiguous input is
-    returned untouched.
-    """
-    if samples.dtype == np.float64 and samples.flags.c_contiguous:
-        return samples
-    n_arms, n_contexts, n_draws = samples.shape
-    out = np.empty(samples.shape, dtype=np.float64)
-    slab = max(1, min(n_draws, _COPY_SLAB_BYTES // max(1, n_arms * n_contexts * 8)))
-    for start in range(0, n_draws, slab):
-        stop = start + slab
-        out[:, :, start:stop] = samples[:, :, start:stop]
-    return out
 
 
 def _vids_statistics(
@@ -116,7 +86,7 @@ def _vids_statistics(
     # produces the indicator directly.
     rho = masked.max(axis=0)  # (n_contexts, n_draws)
     is_opt: NDArray[np.bool_] = (
-        np.empty(samples.shape, dtype=np.bool_) if indicator is None else indicator
+        np.empty_like(samples, dtype=np.bool_) if indicator is None else indicator
     )
     np.equal(masked, rho, out=is_opt)
     # summing bool promotes elementwise to int64 and runs ~4x slower than
@@ -515,7 +485,7 @@ class InformationDirectedSampling(PolicyDefaultUpdate[ContextType, TokenType]):
         List[Arm[ContextType, TokenType]], List[List[Arm[ContextType, TokenType]]]
     ]:
         """Select arms by minimizing the information ratio over pre-generated samples."""
-        samples = _draw_contiguous(samples)
+        samples = draw_contiguous(samples)
         n_arms, n_contexts, _ = samples.shape
         n_slots = 1 if top_k is None else min(top_k, n_arms)
 
@@ -526,7 +496,7 @@ class InformationDirectedSampling(PolicyDefaultUpdate[ContextType, TokenType]):
         masked = samples if n_slots == 1 else samples.copy()
         # the argmax indicator is the largest array the statistics touch;
         # allocate it once and let every slot write into it
-        indicator = np.empty(samples.shape, dtype=np.bool_)
+        indicator = np.empty_like(samples, dtype=np.bool_)
         ctx_idx = np.arange(n_contexts)
         choices = np.empty((n_slots, n_contexts), dtype=np.intp)
         for slot in range(n_slots):

--- a/tests/test_information_directed_sampling.py
+++ b/tests/test_information_directed_sampling.py
@@ -17,8 +17,8 @@ from bayesianbandits import (
     NormalInverseGammaRegressor,
     NormalRegressor,
 )
+from bayesianbandits._blas_helpers import draw_contiguous
 from bayesianbandits.policies._information_directed_sampling import (
-    _draw_contiguous,
     _optimal_two_point,
     _sample_information_ratio_minimizer,
     _vids_statistics,
@@ -357,34 +357,43 @@ class TestVidsStatistics:
 
 
 class TestDrawContiguous:
-    """The draw-major copy that fronts ``select``."""
+    """The layout normalization that fronts ``select``."""
 
     @pytest.mark.parametrize("shape", [(7, 5, 61), (1, 1, 3), (4, 1, 130), (3, 9, 1)])
-    def test_matches_ascontiguousarray(self, shape):
+    def test_normalizes_a_draw_major_view(self, shape):
         n_arms, n_contexts, n_draws = shape
         drawn = np.random.default_rng(0).normal(size=(n_draws, n_arms, n_contexts))
         view = drawn.transpose(1, 2, 0)
-        out = _draw_contiguous(view)
-        assert out.flags.c_contiguous
+        out = draw_contiguous(view)
+        assert out.strides[-1] == out.itemsize
         np.testing.assert_array_equal(out, view)
 
     def test_contiguous_input_is_not_copied(self):
         samples = np.zeros((3, 2, 5))
-        assert _draw_contiguous(samples) is samples
+        assert draw_contiguous(samples) is samples
+
+    def test_draw_contiguous_view_is_not_copied(self):
+        # The blocked reward-space route yields an (arm, context, draw)
+        # view whose draw axis is contiguous but whose leading axes are
+        # swapped in memory. That satisfies the layout contract as-is.
+        drawn = np.zeros((4, 3, 11))  # (C, K, S) in memory
+        view = drawn.transpose(1, 0, 2)
+        assert not view.flags.c_contiguous
+        assert draw_contiguous(view) is view
 
     def test_slabbing_covers_every_draw(self):
         # A shape whose slab size does not divide the draw count: the
         # final short slab must still be copied.
-        from bayesianbandits.policies import _information_directed_sampling as ids
+        from bayesianbandits import _blas_helpers
 
         drawn = np.random.default_rng(1).normal(size=(37, 4, 3))
         view = drawn.transpose(1, 2, 0)
-        original = ids._COPY_SLAB_BYTES
+        original = _blas_helpers._COPY_SLAB_BYTES
         try:
-            ids._COPY_SLAB_BYTES = 4 * 3 * 8 * 5  # five draws per slab
-            out = ids._draw_contiguous(view)
+            _blas_helpers._COPY_SLAB_BYTES = 4 * 3 * 8 * 5  # five draws per slab
+            out = _blas_helpers.draw_contiguous(view)
         finally:
-            ids._COPY_SLAB_BYTES = original
+            _blas_helpers._COPY_SLAB_BYTES = original
         np.testing.assert_array_equal(out, view)
 
 

--- a/tests/test_sample_layout.py
+++ b/tests/test_sample_layout.py
@@ -1,23 +1,12 @@
 """The sampling layout contract.
 
-Two guarantees, at the two boundaries where draws change hands:
-
-**Learner boundary.** The ``(size, n)`` sampling entry points --
-``sample``, ``sample_marginal``, ``sample_reward_space`` -- return
-draw-contiguous arrays: ``samples.T`` is C-contiguous, i.e. each
-prediction row's draws are adjacent in memory. This costs nothing (the
-final projection is computed transposed, the same inner products the
-other way round) and makes every downstream transposed reshape
-contiguous for free. ``size == 1`` satisfies the contract in either
-orientation, which is what lets Thompson sampling's exact BLAS call --
-and hence its bit-for-bit draw stream -- stay untouched.
-
-**Policy boundary.** Agents hand ``select`` an
-``(n_arms, n_contexts, size)`` tensor whose draw axis is unit-stride.
-For conforming learners this is the free consequence of the learner
-contract; for a learner that only promises shape, the agent normalizes
-with one slabbed copy rather than letting a policy discover that
-draw-axis reductions run against the largest stride in the tensor.
+Learner boundary: ``sample``, ``sample_marginal``, and
+``sample_reward_space`` return ``(size, n)`` draws with ``samples.T``
+C-contiguous (each row's draws adjacent), at no cost -- the projection
+is computed transposed. Policy boundary: agents hand ``select`` a
+tensor with a unit-stride draw axis, normalizing only for learners that
+break the contract. ``size == 1`` is contiguous either way, which is
+what keeps Thompson sampling's draw stream bit-for-bit stable.
 """
 
 from typing import Any, List

--- a/tests/test_sample_layout.py
+++ b/tests/test_sample_layout.py
@@ -1,0 +1,229 @@
+"""The sampling layout contract.
+
+Two guarantees, at the two boundaries where draws change hands:
+
+**Learner boundary.** The ``(size, n)`` sampling entry points --
+``sample``, ``sample_marginal``, ``sample_reward_space`` -- return
+draw-contiguous arrays: ``samples.T`` is C-contiguous, i.e. each
+prediction row's draws are adjacent in memory. This costs nothing (the
+final projection is computed transposed, the same inner products the
+other way round) and makes every downstream transposed reshape
+contiguous for free. ``size == 1`` satisfies the contract in either
+orientation, which is what lets Thompson sampling's exact BLAS call --
+and hence its bit-for-bit draw stream -- stay untouched.
+
+**Policy boundary.** Agents hand ``select`` an
+``(n_arms, n_contexts, size)`` tensor whose draw axis is unit-stride.
+For conforming learners this is the free consequence of the learner
+contract; for a learner that only promises shape, the agent normalizes
+with one slabbed copy rather than letting a policy discover that
+draw-axis reductions run against the largest stride in the tensor.
+"""
+
+from typing import Any, List
+
+import numpy as np
+import pytest
+from scipy.sparse import csc_array
+from scipy.sparse import random as sparse_random
+
+from bayesianbandits import (
+    Arm,
+    ArmColumnFeaturizer,
+    BayesianGLM,
+    ContextualAgent,
+    LipschitzContextualAgent,
+    NormalInverseGammaRegressor,
+    NormalRegressor,
+    ThompsonSampling,
+)
+
+
+def make_learner(kind: str, sparse: bool):
+    if kind == "normal":
+        return NormalRegressor(alpha=1.0, beta=1.0, sparse=sparse, random_state=7)
+    if kind == "nig":
+        return NormalInverseGammaRegressor(sparse=sparse, random_state=7)
+    if kind == "glm_logit":
+        return BayesianGLM(alpha=1.0, link="logit", sparse=sparse, random_state=7)
+    if kind == "glm_log":
+        return BayesianGLM(alpha=1.0, link="log", sparse=sparse, random_state=7)
+    raise ValueError(kind)
+
+
+def make_X(n_rows: int, n_feats: int, sparse: bool):
+    if sparse:
+        return csc_array(
+            sparse_random(n_rows, n_feats, density=0.5, random_state=3, format="csc")
+        )
+    return np.random.default_rng(3).normal(size=(n_rows, n_feats))
+
+
+def fit(learner, n_feats: int, sparse: bool):
+    X = make_X(6, n_feats, sparse)
+    y = np.arange(6, dtype=np.float64)
+    learner.partial_fit(X, y)
+    return learner
+
+
+def assert_draw_contiguous(samples: np.ndarray, size: int, n_rows: int):
+    assert samples.shape == (size, n_rows)
+    assert samples.T.flags.c_contiguous
+
+
+LEARNERS = ["normal", "nig", "glm_logit", "glm_log"]
+
+
+class TestLearnerContract:
+    """(size, n) entry points return draw-contiguous arrays."""
+
+    @pytest.mark.parametrize("kind", LEARNERS)
+    @pytest.mark.parametrize("sparse", [False, True])
+    @pytest.mark.parametrize("size", [1, 7])
+    @pytest.mark.parametrize("fitted", [True, False])
+    def test_sample(self, kind: str, sparse: bool, size: int, fitted: bool):
+        learner = make_learner(kind, sparse)
+        if fitted:
+            fit(learner, 5, sparse)
+        X = make_X(4, 5, sparse)
+        assert_draw_contiguous(learner.sample(X, size=size), size, 4)
+
+    @pytest.mark.parametrize("kind", LEARNERS)
+    @pytest.mark.parametrize("sparse", [False, True])
+    @pytest.mark.parametrize("size", [1, 7])
+    def test_sample_marginal(self, kind: str, sparse: bool, size: int):
+        learner = fit(make_learner(kind, sparse), 5, sparse)
+        X = make_X(4, 5, sparse)
+        assert_draw_contiguous(learner.sample_marginal(X, size=size), size, 4)
+
+    @pytest.mark.parametrize("kind", LEARNERS)
+    @pytest.mark.parametrize("sparse", [False, True])
+    @pytest.mark.parametrize("size", [1, 7])
+    @pytest.mark.parametrize("block_size", [None, 2])
+    def test_sample_reward_space(
+        self, kind: str, sparse: bool, size: int, block_size: Any
+    ):
+        learner = fit(make_learner(kind, sparse), 5, sparse)
+        X = make_X(4, 5, sparse)
+        assert_draw_contiguous(
+            learner.sample_reward_space(X, size, block_size=block_size), size, 4
+        )
+
+    @pytest.mark.parametrize("kind", ["normal", "nig", "glm_logit"])
+    def test_sample_through_the_row_reduction(self, kind: str):
+        # Two rows and many draws routes sample() through the row-side
+        # support reduction; the contract must hold through that path too.
+        learner = fit(make_learner(kind, True), 40, True)
+        X = make_X(2, 40, True)
+        samples = learner.sample(X, size=50)
+        assert_draw_contiguous(samples, 50, 2)
+
+
+class RecordingPolicy(ThompsonSampling):
+    """Thompson sampling that records the stride of what select receives."""
+
+    def __init__(self, samples_needed_override: int):
+        super().__init__()
+        self._samples_needed = samples_needed_override
+        self.seen: List[Any] = []
+
+    @property
+    def samples_needed(self) -> int:
+        return self._samples_needed
+
+    def select(self, samples, arms, rng, top_k=None):  # type: ignore[override]
+        self.seen.append((samples.shape, samples.strides[-1] == samples.itemsize))
+        return [arms[0] for _ in range(samples.shape[1])]
+
+
+class TestPolicyBoundary:
+    """Agents hand select a tensor whose draw axis is unit-stride."""
+
+    def test_shared_learner_agent(self):
+        policy = RecordingPolicy(samples_needed_override=9)
+        agent = LipschitzContextualAgent(
+            arms=[Arm(i, reward_function=None, learner=None) for i in range(5)],
+            policy=policy,
+            arm_featurizer=ArmColumnFeaturizer(column_name="pid"),
+            learner=NormalRegressor(alpha=1.0, beta=1.0),
+            random_seed=0,
+        )
+        X = np.random.default_rng(0).normal(size=(3, 2))
+        agent.pull(X)
+        agent.update(X, np.zeros(3))
+        agent.pull(X)
+        assert policy.seen and all(ok for _, ok in policy.seen)
+        assert all(shape == (5, 3, 9) for shape, _ in policy.seen)
+
+    def test_per_arm_agent(self):
+        policy = RecordingPolicy(samples_needed_override=9)
+        agent = ContextualAgent(
+            arms=[
+                Arm(i, learner=NormalInverseGammaRegressor(random_state=i))
+                for i in range(4)
+            ],
+            policy=policy,
+            random_seed=0,
+        )
+        X = np.random.default_rng(0).normal(size=(3, 2))
+        agent.pull(X)
+        assert policy.seen and all(ok for _, ok in policy.seen)
+        assert all(shape == (4, 3, 9) for shape, _ in policy.seen)
+
+    def test_nonconforming_learner_is_normalized(self):
+        class COrderNormal(NormalRegressor):
+            """Violates the learner contract: C-ordered (size, n)."""
+
+            def sample(self, X, size=1):
+                return np.ascontiguousarray(super().sample(X, size))
+
+        policy = RecordingPolicy(samples_needed_override=9)
+        agent = LipschitzContextualAgent(
+            arms=[Arm(i, reward_function=None, learner=None) for i in range(5)],
+            policy=policy,
+            arm_featurizer=ArmColumnFeaturizer(column_name="pid"),
+            learner=COrderNormal(alpha=1.0, beta=1.0),
+            random_seed=0,
+        )
+        X = np.random.default_rng(0).normal(size=(3, 2))
+        agent.pull(X)
+        assert policy.seen and all(ok for _, ok in policy.seen)
+
+
+class TestValuesUnchangedByOrientation:
+    """The flipped projections are the same inner products."""
+
+    @pytest.mark.parametrize("kind", ["normal", "nig"])
+    def test_weight_space_projection_matches_manual(self, kind: str):
+        # Drawing weights with one seed and projecting must equal the
+        # C-ordered product of the same weights with the same X. Dense
+        # only: these shapes route the sparse models through the support
+        # reduction, whose stream this replay would not match.
+        sparse = False
+        learner = fit(make_learner(kind, sparse), 5, sparse)
+        X = make_X(4, 5, sparse)
+        seen = learner.sample(X, size=7)
+
+        twin = fit(make_learner(kind, sparse), 5, sparse)
+        # consume the same stream, then project the C-ordered way
+        from bayesianbandits._estimators import (
+            multivariate_normal_sample_from_precision,
+            multivariate_t_sample_from_precision,
+        )
+
+        if kind == "normal":
+            w = np.atleast_2d(
+                multivariate_normal_sample_from_precision(
+                    twin.coef_,
+                    twin._precision_factor,
+                    size=7,
+                    random_state=twin.random_state_,
+                )
+            )
+        else:
+            w = np.atleast_2d(
+                multivariate_t_sample_from_precision(
+                    twin.coef_, twin.shape_, 2.0 * twin.a_, 7, twin.random_state_
+                )
+            )
+        np.testing.assert_allclose(seen, w @ X.T, rtol=1e-12, atol=1e-14)


### PR DESCRIPTION
Stacked on #270; this diff is against it.

Every sampling route returned `(size, n)` C-ordered, so the transposed `(n_arms, n_contexts, size)` views agents hand policies left the draw axis with the largest stride in the tensor — the cause of the 907ms-vs-0.8ms GEMM cliff #270 worked around inside IDS, and a ~44ms quantile penalty in UCB.

This makes the layout a contract instead of an accident:

- **Learner boundary**: `sample` / `sample_marginal` / `sample_reward_space` return draws with `samples.T` C-contiguous, by computing the final projection transposed — same inner products, no extra cost. (The reward-space route already did this; `standard_normal_f` existed for exactly this reason.)
- **Policy boundary**: agents guarantee a unit-stride draw axis to `select`, normalizing with one copy only for learners that break the contract (`draw_contiguous`, promoted from IDS to `_blas_helpers`).

Pinned by a parametrized contract test (learner × route × sparse/dense × size × fitted/prior). `size=1` is contiguous in either orientation, so its BLAS call is untouched and Thompson sampling stays bit-for-bit identical; the full suite passes without test modifications. Seeded draws on the (unreleased) marginal and blocked paths shift; distributions unchanged.

Dense 96-arm, 64-context agent at `samples=1000`: IDS pull 75 → 44 ms (its #270 layout copy disappears entirely), UCB 238 → 206 ms. Also scopes bare `pytest` to `tests/` via `testpaths` — the benchmark suite's 1M-feature cases were collected and run by unqualified invocations.
