### PR TITLE
Use the real prior scalar in MacKay's gamma, and report the EB objective

### DIFF
--- a/src/bayesianbandits/_eb_estimators.py
+++ b/src/bayesianbandits/_eb_estimators.py
@@ -97,13 +97,22 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
     Attributes
     ----------
     log_evidence_ : float
-        Log marginal likelihood at convergence (after ``fit``), or
-        ``-inf`` if ``n_eb_iter=0``.
+        Log marginal likelihood at the most recent MacKay step --
+        the last iteration of ``fit``, then refreshed by every
+        ``partial_fit`` -- or ``-inf`` if ``n_eb_iter=0``. Under
+        forgetting this is the evidence of the *decayed* data.
     n_eb_iterations_ : int
         Number of EB iterations performed during the last ``fit``.
     eb_converged_ : bool
         Whether the EB loop converged within ``eb_tol`` during
         the last ``fit``.
+    eb_updates_rejected_ : int
+        Number of MacKay updates declined by the ill-conditioning
+        guardrail since the last ``fit``, counting both ``fit``'s own
+        iterations and every ``partial_fit`` since. A nonzero and
+        growing count means the hyperparameters are pinned and the
+        estimator is no longer maximizing the evidence -- see the
+        ``beta``/``alpha`` guardrail in :mod:`._empirical_bayes`.
 
     See Also
     --------
@@ -209,8 +218,14 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
         self.trace_method = trace_method
 
     def _eb_mackay_step_online(self) -> None:
-        """MacKay step using accumulated sufficient statistics for beta."""
-        alpha_new, beta_new, _ = mackay_update_normal_online(
+        """MacKay step using accumulated sufficient statistics for beta.
+
+        Records the log evidence and whether the guardrail declined the
+        update, so a stalled EB loop is visible rather than silent --
+        the Dirichlet and Gamma estimators already keep their evidence
+        across ``partial_fit``.
+        """
+        update = mackay_update_normal_online(
             self.coef_,
             self.cov_inv_,
             self.alpha,
@@ -222,8 +237,11 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
             factor=self._precision_factor,
             trace_method=self.trace_method,
         )
-        self.alpha = alpha_new
-        self.beta = beta_new
+        self.alpha = update.alpha
+        self.beta = update.beta
+        self.log_evidence_ = update.log_evidence
+        if update.rejected:
+            self.eb_updates_rejected_ += 1
 
     def _accumulate_stats(
         self,
@@ -285,6 +303,8 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
 
         prior_decay = self.learning_rate ** y.shape[0]
 
+        self.eb_updates_rejected_ = 0
+
         if self.n_eb_iter > 0:
             # Sufficient stats are constant during batch fitting (no decay)
             effective_n = float(y.shape[0])
@@ -305,7 +325,7 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
                 # After a fresh fit: Λ = prior_decay·α·I + β·XᵀWX
                 self._prior_scalar = prior_decay * self.alpha
 
-                alpha_new, beta_new, log_ev = mackay_update_normal_online(
+                update = mackay_update_normal_online(
                     self.coef_,
                     self.cov_inv_,
                     self.alpha,
@@ -317,8 +337,11 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
                     factor=self._precision_factor,
                     trace_method=self.trace_method,
                 )
-                self.alpha = alpha_new
-                self.beta = beta_new
+                self.alpha = update.alpha
+                self.beta = update.beta
+                log_ev = update.log_evidence
+                if update.rejected:
+                    self.eb_updates_rejected_ += 1
                 iterations = i + 1
 
                 if abs(log_ev - prev_evidence) < self.eb_tol:
@@ -605,6 +628,11 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
             #   cov_inv_ = prior_decay * alpha_old * I + beta_old * X^T X
             # so the prior contribution to the diagonal is prior_decay * alpha_old.
             self._prior_scalar = prior_decay * alpha_old
+            # fit() never ran on this path, so the EB reporting state that
+            # _eb_mackay_step_online maintains has to start here.
+            self.eb_updates_rejected_ = 0
+            self.n_eb_iterations_ = 0
+            self.eb_converged_ = False
 
         X_fit, y = check_X_y(
             X,  # type: ignore

--- a/src/bayesianbandits/_eb_estimators.py
+++ b/src/bayesianbandits/_eb_estimators.py
@@ -35,6 +35,7 @@ from ._sparse_bayesian_linear_regression import (
     DenseFactor,
     PrecisionFactor,
     create_sparse_factor,
+    scale_factor,
 )
 
 
@@ -282,6 +283,8 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
             accept_sparse="csc" if self.sparse else False,
         )
 
+        prior_decay = self.learning_rate ** y.shape[0]
+
         if self.n_eb_iter > 0:
             # Sufficient stats are constant during batch fitting (no decay)
             effective_n = float(y.shape[0])
@@ -299,8 +302,8 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
             for i in range(self.n_eb_iter):
                 self._initialize_prior(X_fit)
                 self._fit_helper(X_fit, y, sample_weight)
-                # After fresh fit: Λ = α·I + β·XᵀX
-                self._prior_scalar = self.alpha
+                # After a fresh fit: Λ = prior_decay·α·I + β·XᵀWX
+                self._prior_scalar = prior_decay * self.alpha
 
                 alpha_new, beta_new, log_ev = mackay_update_normal_online(
                     self.coef_,
@@ -337,8 +340,9 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
             self.n_eb_iterations_ = 0
             self.eb_converged_ = False
 
-        # After fit, the precision matrix is consistent with self.alpha.
-        self._prior_scalar = self.alpha
+        # The prior's contribution to the diagonal is the decayed alpha,
+        # not alpha itself -- _fit_helper scales the prior by prior_decay.
+        self._prior_scalar = prior_decay * self.alpha
 
         # Initialize sufficient statistics from the fit data.
         self._effective_n = float(y.shape[0])
@@ -366,8 +370,11 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
         After MacKay changes α and β, rescale both components so the
         matrix is consistent with the new hyperparameters.
 
-        After correction, eagerly refactorizes so the factor is ready
-        for ``sample()`` without an extra factorization.
+        A pure rescale (``diag_correction == 0``, i.e. α and β moved by
+        the same ratio) is absorbed by the cached factorization, the way
+        ``decay`` absorbs its own. A diagonal shift is a rank-p change
+        that no cheap factor update covers, so there the factor is
+        dropped and the next ``sample()`` pays for a fresh one.
         """
         alpha_new = self.alpha
         beta_new = self.beta
@@ -394,7 +401,12 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
 
         self._prior_scalar = new_prior_scalar
         if "_precision_factor" in self.__dict__:
-            del self._precision_factor
+            if diag_correction == 0.0:
+                self._precision_factor = scale_factor(
+                    self._precision_factor, beta_ratio
+                )
+            else:
+                del self._precision_factor
 
     def _reinject_prior(self, prior_reinjection: float) -> None:
         """Add stabilized prior re-injection to the precision diagonal.

--- a/src/bayesianbandits/_empirical_bayes.py
+++ b/src/bayesianbandits/_empirical_bayes.py
@@ -11,7 +11,7 @@ Provides:
 from __future__ import annotations
 
 import math
-from typing import Union, cast
+from typing import NamedTuple, Union, cast
 
 import numpy as np
 from numpy.typing import NDArray
@@ -24,6 +24,23 @@ from ._sparse_bayesian_linear_regression import (
 )
 
 _LOG_2PI = math.log(2.0 * math.pi)
+
+
+class MacKayUpdate(NamedTuple):
+    """One MacKay hyperparameter update.
+
+    ``rejected`` marks an update the ill-conditioning guardrail declined:
+    ``alpha`` and ``beta`` come back unchanged, so the estimator did not
+    maximize the evidence on that step.  It is reported rather than
+    inferred from the returned values so callers can surface a stalled
+    EB loop instead of it failing silently.
+    """
+
+    alpha: float
+    beta: float
+    log_evidence: float
+    rejected: bool
+
 
 # Guardrails for MacKay hyperparameter updates.
 # In the underdetermined regime (p >> n), MacKay can drive α→0 and β→∞.
@@ -124,7 +141,7 @@ def mackay_update_normal_online(
     eff_XTy: NDArray[np.float64],
     factor: PrecisionFactor,
     trace_method: str = "auto",
-) -> tuple[float, float, float]:
+) -> MacKayUpdate:
     """MacKay update using accumulated sufficient statistics for beta.
 
     Uses decayed sufficient statistics (effective_n, yᵀy, Xᵀy) and
@@ -151,7 +168,9 @@ def mackay_update_normal_online(
 
     Returns
     -------
-    (alpha_new, beta_new, log_evidence)
+    MacKayUpdate
+        The new hyperparameters, the log evidence at the *current* ones,
+        and whether the guardrail rejected the update.
     """
     p = cast(tuple[int, int], precision.shape)[0]
     mu_norm_sq = float(mu_n @ mu_n)
@@ -197,7 +216,8 @@ def mackay_update_normal_online(
         beta_new = beta
 
     # Reject pathological updates.
-    if beta_new / alpha_new > _MAX_BETA_ALPHA_RATIO:
+    rejected = beta_new / alpha_new > _MAX_BETA_ALPHA_RATIO
+    if rejected:
         alpha_new = alpha
         beta_new = beta
 
@@ -209,7 +229,7 @@ def mackay_update_normal_online(
         - 0.5 * effective_n * _LOG_2PI
     )
 
-    return alpha_new, beta_new, log_ev
+    return MacKayUpdate(alpha_new, beta_new, log_ev, rejected)
 
 
 def _dirichlet_multinomial_log_evidence(

--- a/src/bayesianbandits/_empirical_bayes.py
+++ b/src/bayesianbandits/_empirical_bayes.py
@@ -160,8 +160,16 @@ def mackay_update_normal_online(
 
     # gamma is the effective number of well-determined parameters,
     # bounded by (0, min(effective_n, p)].
+    #
+    # gamma = tr(Lambda^-1 . beta X^T X) = p - prior_scalar . tr(Lambda^-1),
+    # where prior_scalar is the prior's actual contribution to Lambda's
+    # diagonal.  Under forgetting that is learning_rate^n . alpha rather
+    # than alpha itself, and using alpha here drives gamma negative
+    # whenever many features are unobserved: every unobserved column
+    # contributes exactly 1 / prior_scalar to the trace, so the sum
+    # overshoots p and the clip below pins gamma to _EPS.
     _EPS = 1e-8
-    gamma = float(np.clip(p - alpha * tr_inv, _EPS, min(effective_n, p)))
+    gamma = float(np.clip(p - prior_scalar * tr_inv, _EPS, min(effective_n, p)))
 
     # Alpha update.
     alpha_new = gamma / mu_norm_sq if mu_norm_sq > 0 else alpha

--- a/src/bayesianbandits/_sparse_bayesian_linear_regression.py
+++ b/src/bayesianbandits/_sparse_bayesian_linear_regression.py
@@ -18,6 +18,7 @@ import numpy as np
 from numpy.typing import NDArray
 from scipy.linalg import LinAlgError, cho_solve, solve_triangular  # type: ignore
 from scipy.linalg.blas import dtrsm  # type: ignore[attr-defined]
+from scipy.linalg.lapack import dlantr as _dlantr  # type: ignore[attr-defined]
 from scipy.linalg.lapack import dtrtri  # type: ignore[attr-defined]
 from scipy.sparse import (  # type: ignore  # type: ignore
     block_diag,
@@ -842,14 +843,15 @@ class DenseFactor(MemoryUsageMixin):
         ``dtrtri`` inverts the triangle at a third of the flops of
         solving against a dense identity, but writes only the upper
         triangle of its result, leaving whatever ``cho_factor`` left
-        below the diagonal, hence the ``triu``.  ``_U`` itself is not
-        overwritten.
+        below the diagonal.  The strict lower triangle is therefore
+        garbage; every consumer reads the upper one only.  ``_U``
+        itself is not overwritten.
 
         A singular ``U`` is reported through ``info`` rather than
-        raised, and leaves the triangle untouched -- so the ``triu``
-        below would return ``U`` itself, and :meth:`trace_inv` a
-        plausible number rather than an error.  Raise instead, matching
-        the ``solve_triangular`` this replaced.
+        raised, and leaves the triangle untouched -- so this
+        would return ``U`` itself, and :meth:`trace_inv` a plausible
+        number rather than an error.  Raise instead, matching the
+        ``solve_triangular`` this replaced.
         """
         U_inv, info = dtrtri(self._U, lower=0)
         if info > 0:
@@ -858,7 +860,7 @@ class DenseFactor(MemoryUsageMixin):
             )
         if info < 0:
             raise ValueError(f"dtrtri: illegal value in argument {-info}")
-        return cast(NDArray[np.float64], np.triu(U_inv))
+        return cast(NDArray[np.float64], U_inv)
 
     def solve(self, b: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
         out = cho_solve((self._U, False), b, check_finite=False)
@@ -910,8 +912,15 @@ class DenseFactor(MemoryUsageMixin):
         )
 
     def trace_inv(self) -> float:
-        """tr((sΛ)⁻¹) = ||U⁻¹||²_F / s."""
-        return float(np.sum(self._U_inv**2)) / self._scale
+        """tr((sΛ)⁻¹) = ||U⁻¹||²_F / s.
+
+        ``dlantr`` reads the triangle in place, so the Frobenius norm
+        costs neither the ``triu`` copy nor the squared temporary that
+        ``sum(U_inv ** 2)`` allocates -- two p x p arrays that dominate
+        this call once the inverse itself is in cache.
+        """
+        norm = _dlantr("F", self._U_inv, uplo="U", diag="N")
+        return float(norm) ** 2 / self._scale
 
 
 PrecisionFactor = SparseFactor | DenseFactor

--- a/tests/test_eb_estimators.py
+++ b/tests/test_eb_estimators.py
@@ -581,6 +581,108 @@ class TestPriorScalar:
         assert (model.alpha, model.beta) != before
 
 
+@pytest.mark.parametrize("sparse", [True, False])
+class TestEBReporting:
+    """EB should expose the objective it maximizes, and say when it stops.
+
+    ``_eb_mackay_step_online`` used to discard the log evidence it had
+    already computed, so ``log_evidence_`` went stale after ``fit`` --
+    unlike the Dirichlet and Gamma estimators, which refresh theirs on
+    every ``partial_fit`` -- and a guardrail rejection left no trace at
+    all.
+    """
+
+    @staticmethod
+    def _data(seed=0):
+        rng = np.random.default_rng(seed)
+        X = rng.standard_normal((60, 5))
+        y = X @ rng.standard_normal(5) + 0.1 * rng.standard_normal(60)
+        return X, y
+
+    def test_log_evidence_is_refreshed_by_partial_fit(self, sparse):
+        X, y = self._data()
+        model = EmpiricalBayesNormalRegressor(alpha=1.0, beta=1.0, sparse=sparse)
+        model.fit(X[:30], y[:30])
+        after_fit = model.log_evidence_
+
+        model.partial_fit(X[30:], y[30:])
+        assert np.isfinite(model.log_evidence_)
+        assert model.log_evidence_ != after_fit
+
+    def test_log_evidence_matches_the_online_update(self, sparse):
+        """The recorded value is the one the MacKay step computed."""
+        from bayesianbandits._empirical_bayes import mackay_update_normal_online
+
+        X, y = self._data()
+        model = EmpiricalBayesNormalRegressor(alpha=1.0, beta=1.0, sparse=sparse)
+        model.fit(X[:30], y[:30])
+
+        captured = {}
+        real = mackay_update_normal_online
+
+        def spy(*args, **kwargs):
+            result = real(*args, **kwargs)
+            captured["log_evidence"] = result.log_evidence
+            return result
+
+        with mock.patch(
+            "bayesianbandits._eb_estimators.mackay_update_normal_online", spy
+        ):
+            model.partial_fit(X[30:], y[30:])
+
+        assert model.log_evidence_ == captured["log_evidence"]
+
+    def test_healthy_fit_rejects_nothing(self, sparse):
+        X, y = self._data()
+        model = EmpiricalBayesNormalRegressor(alpha=1.0, beta=1.0, sparse=sparse)
+        model.fit(X, y)
+        assert model.eb_updates_rejected_ == 0
+
+        model.partial_fit(X[:5], y[:5])
+        assert model.eb_updates_rejected_ == 0
+
+    def test_rejected_updates_are_counted_and_leave_hyperparameters_alone(self, sparse):
+        """A guardrail rejection is visible instead of silent."""
+        from bayesianbandits._empirical_bayes import MacKayUpdate
+
+        X, y = self._data()
+        model = EmpiricalBayesNormalRegressor(alpha=1.0, beta=1.0, sparse=sparse)
+        model.fit(X[:30], y[:30])
+        alpha, beta = model.alpha, model.beta
+        before = model.eb_updates_rejected_
+
+        rejection = MacKayUpdate(alpha, beta, -123.5, True)
+        with mock.patch(
+            "bayesianbandits._eb_estimators.mackay_update_normal_online",
+            return_value=rejection,
+        ):
+            model.partial_fit(X[30:40], y[30:40])
+            model.partial_fit(X[40:50], y[40:50])
+
+        assert model.eb_updates_rejected_ == before + 2
+        assert model.alpha == alpha
+        assert model.beta == beta
+        assert model.log_evidence_ == -123.5
+
+    def test_fit_resets_the_rejection_count(self, sparse):
+        X, y = self._data()
+        model = EmpiricalBayesNormalRegressor(alpha=1.0, beta=1.0, sparse=sparse)
+        model.fit(X[:30], y[:30])
+        model.eb_updates_rejected_ = 7
+        model.fit(X, y)
+        assert model.eb_updates_rejected_ == 0
+
+    def test_reporting_state_exists_without_an_explicit_fit(self, sparse):
+        """sample() then partial_fit skips fit(), so the state starts there."""
+        X, y = self._data()
+        model = EmpiricalBayesNormalRegressor(alpha=1.0, beta=1.0, sparse=sparse)
+        model.sample(X[:1])  # initializes the prior without fitting
+        model.partial_fit(X, y)
+
+        assert model.eb_updates_rejected_ >= 0
+        assert np.isfinite(model.log_evidence_)
+
+
 # ---------------------------------------------------------------------------
 # EmpiricalBayesDirichletClassifier
 # ---------------------------------------------------------------------------

--- a/tests/test_eb_estimators.py
+++ b/tests/test_eb_estimators.py
@@ -498,6 +498,89 @@ class TestSampleWeight:
         assert not np.allclose(model_uniform.coef_, model_weighted.coef_)
 
 
+@pytest.mark.parametrize("sparse", [True, False])
+class TestPriorScalar:
+    """``_prior_scalar`` is the prior's real contribution to Λ's diagonal.
+
+    Under forgetting ``_fit_helper`` scales the prior by
+    ``learning_rate ** n_samples``, so ``alpha`` itself overstates it.
+    MacKay's ``gamma = p - prior_scalar * tr(Λ⁻¹)`` is sensitive to
+    that: every unobserved feature contributes exactly
+    ``1 / prior_scalar`` to the trace, so overstating the scalar pushes
+    the sum past ``p`` and drives gamma negative.
+    """
+
+    def test_prior_scalar_matches_precision_diagonal(self, sparse):
+        """The tracked scalar equals the prior floor of Λ's diagonal."""
+        rng = np.random.default_rng(0)
+        X = rng.standard_normal((200, 8))
+        y = X @ rng.standard_normal(8) + 0.1 * rng.standard_normal(200)
+
+        model = EmpiricalBayesNormalRegressor(
+            alpha=1.0, beta=1.0, learning_rate=0.99, sparse=sparse
+        )
+        model.fit(X, y)
+
+        diagonal = model.cov_inv_.diagonal() if sparse else np.diag(model.cov_inv_)
+        assert model._prior_scalar <= np.min(diagonal) * (1 + 1e-9)
+        assert model._prior_scalar == pytest.approx(
+            model.learning_rate ** X.shape[0] * model.alpha
+        )
+
+    def test_gamma_stays_in_range_when_features_are_unobserved(self, sparse):
+        """Wide data with all-zero columns keeps gamma in (0, min(n, p)].
+
+        With ``alpha`` in place of ``prior_scalar`` the trace overshoots
+        ``p``, gamma goes negative, and the clip plus the beta/alpha
+        guardrail silently reject every update -- EB becomes a no-op
+        exactly where it matters most.
+        """
+        rng = np.random.default_rng(0)
+        n_samples, n_features = 30, 400
+        X = np.zeros((n_samples, n_features))
+        # Only the first 20 features are ever observed.
+        X[:, :20] = rng.standard_normal((n_samples, 20))
+        y = X[:, :20] @ rng.standard_normal(20) + 0.1 * rng.standard_normal(n_samples)
+
+        model = EmpiricalBayesNormalRegressor(
+            alpha=1.0, beta=1.0, learning_rate=0.99999, sparse=sparse
+        )
+        model.fit(X, y)
+
+        gamma = n_features - model._prior_scalar * model._precision_factor.trace_inv()
+        assert 0 < gamma <= min(n_samples, n_features)
+
+    def test_eb_is_not_a_noop_on_wide_data(self, sparse):
+        """Hyperparameters actually move when most features are unobserved."""
+        rng = np.random.default_rng(0)
+        X = np.zeros((30, 400))
+        X[:, :20] = rng.standard_normal((30, 20))
+        y = X[:, :20] @ rng.standard_normal(20) + 0.1 * rng.standard_normal(30)
+
+        model = EmpiricalBayesNormalRegressor(
+            alpha=1.0, beta=1.0, learning_rate=0.99999, sparse=sparse
+        )
+        model.fit(X, y)
+
+        assert model.alpha != 1.0 or model.beta != 1.0
+        assert np.isfinite(model.log_evidence_)
+
+    def test_partial_fit_updates_hyperparameters_on_wide_data(self, sparse):
+        """The online MacKay step is not a no-op either."""
+        rng = np.random.default_rng(0)
+        X = np.zeros((30, 400))
+        X[:, :20] = rng.standard_normal((30, 20))
+        y = X[:, :20] @ rng.standard_normal(20) + 0.1 * rng.standard_normal(30)
+
+        model = EmpiricalBayesNormalRegressor(
+            alpha=1.0, beta=1.0, learning_rate=0.99999, sparse=sparse
+        )
+        model.fit(X[:20], y[:20])
+        before = (model.alpha, model.beta)
+        model.partial_fit(X[20:], y[20:])
+        assert (model.alpha, model.beta) != before
+
+
 # ---------------------------------------------------------------------------
 # EmpiricalBayesDirichletClassifier
 # ---------------------------------------------------------------------------

--- a/tests/test_empirical_bayes.py
+++ b/tests/test_empirical_bayes.py
@@ -438,7 +438,7 @@ class TestLogEvidenceFromUpdates:
         y = X @ w + rng.standard_normal(n) * 0.5
         mu_n, precision = _compute_posterior_normal(X, y, alpha, beta)
 
-        _, _, result = mackay_update_normal_online(
+        result = mackay_update_normal_online(
             mu_n,
             precision,
             alpha,
@@ -450,7 +450,7 @@ class TestLogEvidenceFromUpdates:
             factor=_make_dense_factor(precision),
         )
         expected = _log_evidence_normal_hand(X, y, mu_n, precision, alpha, beta)
-        np.testing.assert_allclose(result, expected, atol=1e-10)
+        np.testing.assert_allclose(result.log_evidence, expected, atol=1e-10)
 
 
 # ---------------------------------------------------------------------------
@@ -508,7 +508,7 @@ class TestSufficientStats:
 
         # Craft sufficient stats so RSS = yTy - 2*m'XTy + m'XTXm <= 0.
         # Set eff_yTy = 0 and eff_XTy large so RSS goes negative.
-        alpha_new, beta_new, _ = mackay_update_normal_online(
+        update = mackay_update_normal_online(
             mu_n,
             precision,
             alpha,
@@ -519,7 +519,8 @@ class TestSufficientStats:
             eff_XTy=mu_n * 1000.0,
             factor=_make_dense_factor(precision),
         )
-        assert beta_new == beta
+        assert update.beta == beta
+        assert not update.rejected
 
     def test_online_rejects_pathological_beta_alpha_ratio(self) -> None:
         """When beta_new/alpha_new would exceed the guardrail, keep old hyperparams."""
@@ -537,7 +538,7 @@ class TestSufficientStats:
         # Set yTy = 3e16 + 1e-20 so RSS = 1e-20
         eff_yTy = mTXTXm + 1e-20
 
-        alpha_new, beta_new, _ = mackay_update_normal_online(
+        update = mackay_update_normal_online(
             mu_n,
             precision,
             alpha,
@@ -549,8 +550,9 @@ class TestSufficientStats:
             factor=_make_dense_factor(precision),
         )
         # beta_new/alpha_new would be astronomically large; guardrail rejects
-        assert alpha_new == alpha
-        assert beta_new == beta
+        assert update.alpha == alpha
+        assert update.beta == beta
+        assert update.rejected
 
     def test_online_sparse_precision_matvec(self) -> None:
         """mackay_update_normal_online handles sparse precision @ dense mu_n."""
@@ -566,7 +568,7 @@ class TestSufficientStats:
         precision_sparse = csc_array(precision_dense)
 
         # Dense reference
-        alpha_dense, beta_dense, _ = mackay_update_normal_online(
+        dense_update = mackay_update_normal_online(
             mu_n,
             precision_dense,
             alpha,
@@ -579,7 +581,7 @@ class TestSufficientStats:
         )
 
         # Sparse path (now exact via Takahashi)
-        alpha_sparse, beta_sparse, _ = mackay_update_normal_online(
+        sparse_update = mackay_update_normal_online(
             mu_n,
             precision_sparse,
             alpha,
@@ -591,8 +593,8 @@ class TestSufficientStats:
             factor=create_sparse_factor(precision_sparse),
         )
 
-        np.testing.assert_allclose(alpha_sparse, alpha_dense, atol=1e-10)
-        np.testing.assert_allclose(beta_sparse, beta_dense, atol=1e-10)
+        np.testing.assert_allclose(sparse_update.alpha, dense_update.alpha, atol=1e-10)
+        np.testing.assert_allclose(sparse_update.beta, dense_update.beta, atol=1e-10)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two correctness fixes to `EmpiricalBayesNormalRegressor`'s empirical Bayes loop, plus two small cleanups. No performance work — the batch-fit optimizations from earlier revisions of this branch are dropped, since `fit()` runs once per arm and isn't what a bandit workload pays.

## 1. `gamma` used `alpha` where it meant the prior scalar

MacKay's effective parameter count is

```
gamma = p − prior_scalar · tr(Λ⁻¹)
```

where `prior_scalar` is the prior's *actual* contribution to `Λ`'s diagonal. `_fit_helper` builds `Λ` as `prior_decay · (α·I) + β·XᵀWX`, so that contribution is `learning_rate ** n_samples · α`, not `α` — but `fit()` recorded `_prior_scalar = alpha` anyway, and the `gamma` line read `alpha` rather than the tracked scalar.

**The failure mode is a feature that is never observed.** Its column of `XᵀWX` is zero, so its diagonal entry of `Λ` is exactly the prior contribution, and it adds exactly `1/prior_scalar` to the trace. Its share of `gamma` should be exactly zero — and with the right scalar it is, `1 − prior_scalar/prior_scalar`. With `alpha` it is `1 − 1/prior_decay`, a small negative number, once per unobserved feature.

On the `eb_normal_sparse_100k` shape that's ~82,000 unobserved features against ~200 legitimate positive contributions:

```
tr(Λ⁻¹)                 = 100005.75
gamma with alpha        =     -5.75   → clipped to 1e-8, update rejected
gamma with prior_scalar =    194.06   ✓ must lie in (0, min(n, p)] = (0, 200]
```

`gamma` was then clipped to `_EPS`, `alpha_new` collapsed, and the `_MAX_BETA_ALPHA_RATIO` guardrail rejected the update — so **EB silently did nothing at all**, on exactly the wide, sparsely-observed designs it exists for. The error scales as `1 − learning_rate**n`: 0.2% at n=200, 18% at n=20000.

**This costs time rather than saving it.** Accepting the update means `_correct_precision` shifts the precision diagonal, and the next `sample()` pays for a refactorization the previous no-op skipped. One `partial_fit` + `sample` on sparse-100k goes from **1951 ms to 2325 ms**. That's the price of EB actually working.

## 2. The EB loop could stall without saying so

`_eb_mackay_step_online` computed the log evidence and threw it away, so `log_evidence_` went stale after `fit` — unlike the Dirichlet and Gamma EB estimators, which already refresh theirs on every `partial_fit`. And a guardrail rejection left no trace at all: the hyperparameters simply stopped moving.

For an empirical Bayes estimator that's the wrong default. The contract is that `alpha`/`beta` maximize the evidence for the data seen; when the implementation declines to do that, it should say so.

- `mackay_update_normal_online` now returns a `MacKayUpdate` named tuple carrying the rejection flag alongside the values. Reported rather than inferred from unchanged hyperparameters, since a converged update produces those too.
- `partial_fit` keeps the log evidence, so `log_evidence_` tracks the most recent MacKay step.
- New `eb_updates_rejected_` counts declined updates since the last `fit`, so a pinned EB loop is visible.

## 3 & 4. Two cleanups on the update path

**`trace_inv` allocated two p×p temporaries for a norm.** The Frobenius norm of `U⁻¹` went through `np.triu(U_inv)` and then `U_inv ** 2`; `dlantr` reads the triangle in place, so `_U_inv` no longer needs the `triu` copy either. One `partial_fit` + `sample` at dense p=1000 goes from **69.6 ms to 62.3 ms** (warm-min, `OMP_NUM_THREADS=1`). Sparse is unchanged — its trace comes from the Takahashi recursion, not `dtrtri`.

**`_correct_precision` discarded a factorization it didn't have to.** A pure rescale (`diag_correction == 0`, α and β moving by the same ratio) is a scalar multiple of the factored matrix, so `scale_factor` absorbs it as `decay` already does. Only a diagonal shift — a rank-p change no cheap factor update covers — needs the factor dropped. The docstring claiming eager refactorization described behavior the code didn't have.

## Tests

- **`TestPriorScalar`** — `gamma` stays in `(0, min(n, p)]` when most features are unobserved; `_prior_scalar` tracks the real precision diagonal; neither `fit` nor `partial_fit` is a no-op on wide data.
- **`TestEBReporting`** — `log_evidence_` is refreshed by `partial_fit` and matches what the MacKay step computed; rejections are counted and leave the hyperparameters alone; `fit` resets the count; the reporting state exists on the `sample()`-then-`partial_fit` path where `fit` never runs.

Full suite: 2163 → 2193 passing, no new failures outside CHOLMOD-parametrised cases, which fail identically on master in this environment (`NameError: name 'cholmod_cho_factor' is not defined` — scikit-sparse is optional and not installed here). `ruff format`, `ruff check` clean; `pyright` error count unchanged from master at 285.

## Note on the performance work explored on this branch

Timings above are from a 4-CPU shared container where an unpinned `cho_factor(p=1000)` varied 8.8–78.6 ms across back-to-back calls — directions are solid, absolute milliseconds are indicative.

Profiling the sparse-100k update cycle: `takahashi_diagonal` 1.35 s (50%), two SuperLU factorizations 0.80 s (30%), sparse assembly 0.55 s (20%). Several approaches to that were prototyped and set aside:

- **Rank-k Woodbury trace recursion** — exact, `O(kp²)` dense / `O(k·nnz(L))` sparse, prototyped at 30×/240–300× on `trace_inv` alone. It requires `Λ` to change only by scale plus rank-k, but a diagonal shift currently fires on every `partial_fit` at every learning rate (including 1.0, since α and β move by different ratios). Deferring the correction to make room for it has a positive-definiteness deadline set by `learning_rate` — a deferred run at `lr=0.9` produced `LinAlgError: 374-th leading minor of the array is not positive definite` — and leaves `self.alpha` ahead of `cov_inv_`, which breaks the EB contract that the reported posterior is conditional on the reported hyperparameters.
- **Simply retuning less often** measures *better* than any of that: skipping the EB step entirely is 4.64× on the sparse-100k cycle, versus a ~4× ceiling for the full Woodbury build, and needs a counter rather than a state machine. Since each MacKay step is a complete fixed-point iteration on the full-data evidence, iteration frequency is a convergence-rate choice rather than a correctness one — a schedule tied to growth in `_effective_n` would be defensible in both the stationary and forgetting regimes.

That last option is the one worth pursuing, and it's independent of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1JrBa9X96WfR92oQQbZjY