### PR TITLE
Re-solve coef_ after MacKay rescales the EB precision

### DIFF
--- a/src/bayesianbandits/_blas_helpers.py
+++ b/src/bayesianbandits/_blas_helpers.py
@@ -11,6 +11,7 @@ from scipy.linalg.lapack import dgeqrf, dgeqrf_lwork  # type: ignore[attr-define
 from scipy.sparse import csc_array
 
 __all__ = [
+    "dgemv",
     "dsymv",
     "dsyrk",
     "update_precision_dense",

--- a/src/bayesianbandits/_eb_estimators.py
+++ b/src/bayesianbandits/_eb_estimators.py
@@ -17,7 +17,7 @@ from scipy.sparse import csc_array
 from sklearn.utils.validation import check_X_y
 from typing_extensions import Self
 
-from ._blas_helpers import compute_eta_dense, update_precision_dense
+from ._blas_helpers import compute_eta_dense, dsymv, update_precision_dense
 from ._empirical_bayes import (
     accumulate_sufficient_stats,
     mackay_update_normal_online,
@@ -390,13 +390,25 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
             Λ = _prior_scalar·I + data_component
 
         After MacKay changes α and β, rescale both components so the
-        matrix is consistent with the new hyperparameters.
+        matrix is consistent with the new hyperparameters, then re-solve
+        the posterior mean against the rescaled matrix.
+
+        The mean is ``Λ⁻¹·η`` with ``η = β·Xᵀy`` (decayed): the prior has
+        zero mean, so it contributes nothing to the information vector.
+        Leaving ``coef_`` as it was would make the next ``partial_fit``
+        read ``Λ_new·θ_old`` as the prior information, silently
+        re-applying the old shrinkage and the old β. Since
+        ``Λ_old·θ_old = η_old`` exactly, the information under the new
+        noise precision is ``η_new = (β_new/β_old)·Λ_old·θ_old`` and the
+        corrected mean is ``Λ_new⁻¹·η_new``.
 
         A pure rescale (``diag_correction == 0``, i.e. α and β moved by
         the same ratio) is absorbed by the cached factorization, the way
-        ``decay`` absorbs its own. A diagonal shift is a rank-p change
-        that no cheap factor update covers, so there the factor is
-        dropped and the next ``sample()`` pays for a fresh one.
+        ``decay`` absorbs its own, and leaves the mean unchanged
+        (``Λ_new`` and ``η_new`` share the ratio). A diagonal shift is a
+        rank-p change that no cheap factor update covers, so there the
+        factor is dropped and rebuilt for the solve (``sample()`` would
+        need it anyway).
         """
         alpha_new = self.alpha
         beta_new = self.beta
@@ -409,25 +421,48 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
         new_prior_scalar = prior_scalar * (alpha_new / alpha_old)
         diag_correction = new_prior_scalar - beta_ratio * prior_scalar
 
-        if self.sparse:
-            cov_inv = cast(csc_array, self.cov_inv_)
-            cov_inv *= beta_ratio
-            self._shift_diagonal(cov_inv, diag_correction)
-            self.cov_inv_ = cov_inv
-        else:
-            self.cov_inv_ *= beta_ratio
-            if diag_correction != 0.0:
-                diag_idx = np.diag_indices_from(self.cov_inv_)
-                self.cov_inv_[diag_idx] += diag_correction
-
-        self._prior_scalar = new_prior_scalar
-        if "_precision_factor" in self.__dict__:
-            if diag_correction == 0.0:
+        if diag_correction == 0.0:
+            # Pure rescale: Λ and η share the ratio, so the mean is unchanged.
+            self._scale_precision(beta_ratio)
+            self._prior_scalar = new_prior_scalar
+            if "_precision_factor" in self.__dict__:
                 self._precision_factor = scale_factor(
                     self._precision_factor, beta_ratio
                 )
-            else:
-                self._drop_factor()
+            return
+
+        # Λ_old·θ_old, read before Λ is touched. The dense matrix is
+        # upper-triangle-only (dsyrk), which dsymv handles.
+        if self.sparse:
+            eta_old = np.asarray(
+                cast(csc_array, self.cov_inv_) @ self.coef_, dtype=np.float64
+            )
+        else:
+            eta_old = dsymv(1.0, self.cov_inv_, self.coef_)
+        eta_new = beta_ratio * eta_old
+
+        self._scale_precision(beta_ratio)
+        if self.sparse:
+            cov_inv = cast(csc_array, self.cov_inv_)
+            self._shift_diagonal(cov_inv, diag_correction)
+            self.cov_inv_ = cov_inv
+        else:
+            diag_idx = np.diag_indices_from(self.cov_inv_)
+            self.cov_inv_[diag_idx] += diag_correction
+
+        self._prior_scalar = new_prior_scalar
+        if "_precision_factor" in self.__dict__:
+            self._drop_factor()
+        self.coef_ = self._precision_factor.solve(eta_new)
+
+    def _scale_precision(self, ratio: float) -> None:
+        """Multiply ``cov_inv_`` in place by ``ratio``."""
+        if self.sparse:
+            cov_inv = cast(csc_array, self.cov_inv_)
+            cov_inv *= ratio
+            self.cov_inv_ = cov_inv
+        else:
+            self.cov_inv_ *= ratio
 
     def _drop_factor(self) -> None:
         """Drop the cached factor, keeping it as the hint ``_sparse_factor``

--- a/src/bayesianbandits/_eb_estimators.py
+++ b/src/bayesianbandits/_eb_estimators.py
@@ -17,7 +17,7 @@ from scipy.sparse import csc_array
 from sklearn.utils.validation import check_X_y
 from typing_extensions import Self
 
-from ._blas_helpers import compute_eta_dense, dsymv, update_precision_dense
+from ._blas_helpers import compute_eta_dense, dgemv, dsymv, update_precision_dense
 from ._empirical_bayes import (
     accumulate_sufficient_stats,
     mackay_update_normal_online,
@@ -216,6 +216,38 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
         self.eb_tol = eb_tol
         self.trace_method = trace_method
 
+    @property
+    def coef_(self) -> NDArray[np.float64]:
+        """Posterior mean, written by every fit like the plain attribute
+        it replaces -- with one solve deferred behind it.
+
+        When a MacKay step shifts the precision diagonal,
+        :meth:`_correct_precision` has to re-solve the mean against the
+        rescaled precision, and that solve needs a factorization the
+        cheap factor updates do not cover.  The next ``partial_fit``
+        factors its own updated precision anyway and needs only
+        ``Λ·coef_`` from this one -- which is the information vector the
+        solve was against.  So the solve is left pending here and paid
+        only when something actually reads the mean: ``predict``,
+        ``sample`` and ``decay`` all reach it through their fitted
+        checks, and ``partial_fit`` hands the pending vector straight to
+        :meth:`_fit_helper` instead.
+        """
+        eta = self.__dict__.pop("_pending_eta", None)
+        if eta is not None:
+            self.__dict__["_coef"] = self._precision_factor.solve(eta)
+        try:
+            return self.__dict__["_coef"]
+        except KeyError:
+            raise AttributeError(
+                f"{type(self).__name__!r} object has no attribute 'coef_'"
+            ) from None
+
+    @coef_.setter
+    def coef_(self, value: NDArray[np.float64]) -> None:
+        self.__dict__.pop("_pending_eta", None)
+        self.__dict__["_coef"] = value
+
     def _eb_mackay_step_online(self) -> None:
         """MacKay step using accumulated sufficient statistics for beta.
 
@@ -407,8 +439,8 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
         ``decay`` absorbs its own, and leaves the mean unchanged
         (``Λ_new`` and ``η_new`` share the ratio). A diagonal shift is a
         rank-p change that no cheap factor update covers, so there the
-        factor is dropped and rebuilt for the solve (``sample()`` would
-        need it anyway).
+        factor is dropped and the solve is deferred to whoever reads
+        ``coef_`` -- ``partial_fit`` needs only ``η_new`` and skips it.
         """
         alpha_new = self.alpha
         beta_new = self.beta
@@ -453,7 +485,9 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
         self._prior_scalar = new_prior_scalar
         if "_precision_factor" in self.__dict__:
             self._drop_factor()
-        self.coef_ = self._precision_factor.solve(eta_new)
+        # Leave the solve pending: see the ``coef_`` property.  Written
+        # past the setter, which clears exactly this.
+        self.__dict__["_pending_eta"] = eta_new
 
     def _scale_precision(self, ratio: float) -> None:
         """Multiply ``cov_inv_`` in place by ``ratio``."""
@@ -521,17 +555,28 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
         y: NDArray[Any],
         sample_weight: Optional[NDArray[Any]] = None,
     ) -> None:  # type: ignore[override]
-        """Override to fold prior reinjection into precision construction.
+        """Override to fold prior reinjection into precision construction,
+        and to take the prior information vector from ``partial_fit``.
 
         When ``_pending_reinjection > 0``, adds ``(1 - γ) · α · I`` to
         the precision during the decay + data update.  This means the
         factorization for the linear solve already reflects the
         reinjected prior — no separate ``_reinject_prior`` call or
         refactorization needed.
+
+        When ``_pending_prior_eta`` is set, a MacKay correction left the
+        posterior mean unsolved (see the ``coef_`` property) and handed
+        the information vector here instead.  ``Λ·coef_`` is exactly
+        that vector, so using it skips both the deferred solve and the
+        matvec that would undo it.
         """
         reinjection = getattr(self, "_pending_reinjection", 0.0)
-        if reinjection == 0.0:
-            # No reinjection needed — delegate to base class.
+        pending_eta = getattr(self, "_pending_prior_eta", None)
+        # Consumed here, so partial_fit can tell an update that raised
+        # before this point from one that used the vector.
+        self._pending_prior_eta = None
+        if reinjection == 0.0 and pending_eta is None:
+            # Nothing to fold in — delegate to base class.
             super()._fit_helper(X, y, sample_weight)
             return
 
@@ -564,12 +609,13 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
             X_weighted = X.multiply(w_sqrt.reshape(-1, 1)).tocsc()
             prior = cast(csc_array, self.cov_inv_)
             if prior_decay != 1.0:
-                prior.data *= prior_decay  # in place; eta below uses it too
+                prior.data *= prior_decay  # in place; prior_eta below uses it too
+            prior_eta = (
+                prior @ self.coef_ if pending_eta is None else prior_decay * pending_eta
+            )
             cov_inv = cast(csc_array, prior + X_weighted.T @ X_weighted)
             self._shift_diagonal(cov_inv, reinjection)
-            eta = cast(
-                NDArray[np.float64], prior @ self.coef_ + X.T @ (self.beta * y_weighted)
-            )
+            eta = cast(NDArray[np.float64], prior_eta + X.T @ (self.beta * y_weighted))
             factor: PrecisionFactor = self._sparse_factor(cov_inv)
             coef = factor.solve(eta)
             self._precision_factor = factor
@@ -577,14 +623,28 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
             w_sqrt = np.sqrt(effective_weights)
             X_weighted = X * w_sqrt[:, np.newaxis]
             # before the in-place update of cov_inv_ below
-            eta = compute_eta_dense(
-                prior_decay, self.cov_inv_, self.coef_, self.beta, X, y_weighted
-            )
+            if pending_eta is None:
+                eta = compute_eta_dense(
+                    prior_decay, self.cov_inv_, self.coef_, self.beta, X, y_weighted
+                )
+            else:
+                # As compute_eta_dense, with its dsymv already done: dgemv
+                # accumulates the data term into the same buffer.
+                eta = dgemv(
+                    self.beta,
+                    X,
+                    y_weighted,
+                    trans=1,
+                    beta=1.0,
+                    y=prior_decay * pending_eta,
+                    overwrite_y=True,
+                )
             prior_scaled = np.asfortranarray(self.cov_inv_)
             if prior_decay != 1.0:
                 prior_scaled *= prior_decay
-            diag_idx = np.diag_indices_from(prior_scaled)
-            prior_scaled[diag_idx] += reinjection
+            if reinjection != 0.0:
+                diag_idx = np.diag_indices_from(prior_scaled)
+                prior_scaled[diag_idx] += reinjection
             # Fused X^T W X + prior via dsyrk (upper triangle only)
             cov_inv = update_precision_dense(self.beta, X_weighted, prior_scaled)
             # Cache the Cholesky factor for reuse in cov_/sample
@@ -656,12 +716,25 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
             (1 - prior_decay) * self.alpha if had_prior_scalar else 0.0
         )
 
+        # Hand any solve the last MacKay correction left pending to
+        # _fit_helper as the prior information vector -- it is Λ·coef_
+        # exactly.  Taken out of __dict__ here, before super()'s
+        # check_is_fitted would read coef_ and force the solve.
+        self._pending_prior_eta = self.__dict__.pop("_pending_eta", None)
+
         alpha_old = self.alpha
         beta_old = self.beta
 
-        result = super().partial_fit(X, y, sample_weight)
-
-        self._pending_reinjection = 0.0
+        try:
+            result = super().partial_fit(X, y, sample_weight)
+        finally:
+            self._pending_reinjection = 0.0
+            if self._pending_prior_eta is not None:
+                # The update raised before _fit_helper consumed it; hand
+                # it back so coef_ stays solvable and the correction is
+                # not silently dropped.
+                self.__dict__["_pending_eta"] = self._pending_prior_eta
+                self._pending_prior_eta = None
 
         if not had_prior_scalar:
             if hasattr(self, "_prior_scalar"):

--- a/tests/test_eb_estimators.py
+++ b/tests/test_eb_estimators.py
@@ -14,6 +14,7 @@ from bayesianbandits import (
     EmpiricalBayesGammaRegressor,
     EmpiricalBayesNormalRegressor,
 )
+from bayesianbandits._estimators import NormalRegressor
 from bayesianbandits._sparse_bayesian_linear_regression import SparseSolver
 
 suitespare_envvar_params = [
@@ -404,10 +405,13 @@ class TestEBNormalRegressor:
         X, y = regression_data
         model = EmpiricalBayesNormalRegressor(alpha=1.0, beta=1.0, sparse=sparse)
         model.fit(X[:50], y[:50])
+        # fit() has already moved both, so the ratios that decide the
+        # branch are relative to here, not to the constructor arguments.
+        alpha_old, beta_old = model.alpha, model.beta
         model.partial_fit(X[50:], y[50:])
 
-        ratio_alpha = model.alpha / 1.0
-        ratio_beta = model.beta / 1.0
+        ratio_alpha = model.alpha / alpha_old
+        ratio_beta = model.beta / beta_old
         assert not np.isclose(ratio_alpha, ratio_beta)  # a real diagonal shift
 
         precision = self._dense_precision(model)
@@ -477,6 +481,150 @@ class TestEBNormalRegressor:
         np.testing.assert_allclose(online.alpha, full.alpha, rtol=1e-2)
         np.testing.assert_allclose(online.beta, full.beta, rtol=1e-2)
         np.testing.assert_allclose(online.coef_, full.coef_, atol=1e-3)
+
+    def test_correct_precision_pure_rescale(self, regression_data, sparse):
+        """α and β moving by the same ratio is a pure rescale.
+
+        ``diag_correction`` is then exactly zero: the whole precision
+        shares one factor, so the cached factorization absorbs it and
+        the mean is unchanged (``Λ`` and ``η`` scale together).
+        """
+        X, y = regression_data
+        model = EmpiricalBayesNormalRegressor(
+            alpha=1.0, beta=1.0, n_eb_iter=0, sparse=sparse
+        )
+        model.fit(X, y)
+        factor_before = model._precision_factor  # populate the cache
+
+        alpha_old, beta_old = model.alpha, model.beta
+        prec_old = self._dense_precision(model)
+        coef_old = model.coef_.copy()
+        prior_old = model._prior_scalar
+
+        # A power of two keeps both ratios exactly 4.0, so
+        # diag_correction lands on 0.0 rather than near it.
+        model.alpha = alpha_old * 4.0
+        model.beta = beta_old * 4.0
+        model._correct_precision(alpha_old, beta_old)
+
+        np.testing.assert_allclose(
+            self._dense_precision(model), 4.0 * prec_old, rtol=1e-12, atol=1e-12
+        )
+        np.testing.assert_allclose(model._prior_scalar, 4.0 * prior_old)
+        # The mean is untouched -- no solve, and no drift either.
+        np.testing.assert_array_equal(model.coef_, coef_old)
+        # The factor was scaled in place, not dropped and rebuilt.
+        assert "_precision_factor" in model.__dict__
+        assert model._precision_factor is not factor_before
+        np.testing.assert_allclose(
+            model._precision_factor.solve(4.0 * (prec_old @ coef_old)),
+            coef_old,
+            rtol=1e-8,
+            atol=1e-10,
+        )
+
+    def test_partial_fit_never_forces_a_factorization(self, regression_data, sparse):
+        """``partial_fit`` must not build a factorization it will not use.
+
+        The MacKay correction re-solves ``coef_`` against a diagonally
+        shifted precision, but the next ``partial_fit`` factors its own
+        updated precision and needs only the information vector -- so
+        the solve is deferred rather than paid here.  Every
+        factorization a ``partial_fit`` does need, ``_fit_helper``
+        builds as a byproduct of its own solve and caches eagerly; a
+        lazy rebuild means one was thrown away.
+        """
+        X, y = regression_data
+        model = EmpiricalBayesNormalRegressor(alpha=1.0, beta=1.0, sparse=sparse)
+        model.fit(X[:20], y[:20])
+
+        cached = NormalRegressor.__dict__["_precision_factor"]
+        original = cached.func
+        rebuilds = []
+
+        def counting(self):
+            rebuilds.append(1)
+            return original(self)
+
+        cached.func = counting
+        try:
+            for start in range(20, 100, 20):
+                model.partial_fit(X[start : start + 20], y[start : start + 20])
+            assert rebuilds == []
+            # Reading the mean is what pays for the deferred solve.
+            model.coef_
+            assert len(rebuilds) == 1
+        finally:
+            cached.func = original
+
+    def test_reading_coef_between_updates_changes_nothing(
+        self, regression_data, sparse
+    ):
+        """The deferred solve is invisible: predicting, sampling or
+        decaying between updates must not move the trajectory."""
+        X, y = regression_data
+
+        def run(peek):
+            model = EmpiricalBayesNormalRegressor(
+                alpha=1.0, beta=1.0, sparse=sparse, random_state=0
+            )
+            model.fit(X[:20], y[:20])
+            for start in range(20, 100, 20):
+                model.partial_fit(X[start : start + 20], y[start : start + 20])
+                if peek:
+                    model.predict(X[:1])
+            return model
+
+        quiet, peeked = run(peek=False), run(peek=True)
+        np.testing.assert_allclose(peeked.coef_, quiet.coef_, rtol=1e-12, atol=1e-14)
+        np.testing.assert_allclose(peeked.alpha, quiet.alpha, rtol=1e-12)
+        np.testing.assert_allclose(peeked.beta, quiet.beta, rtol=1e-12)
+        np.testing.assert_allclose(
+            self._dense_precision(peeked),
+            self._dense_precision(quiet),
+            rtol=1e-12,
+            atol=1e-12,
+        )
+
+    def test_pending_coef_solve_survives_pickling(self, regression_data, sparse):
+        """A pickle taken with the solve still pending restores a model
+        that resolves to the same mean -- the factor is not pickled, so
+        the information vector has to travel with it."""
+        X, y = regression_data
+        model = EmpiricalBayesNormalRegressor(alpha=1.0, beta=1.0, sparse=sparse)
+        model.fit(X[:50], y[:50])
+        model.partial_fit(X[50:], y[50:])
+        assert "_pending_eta" in model.__dict__  # nothing has read coef_ yet
+
+        restored = pickle.loads(pickle.dumps(model))
+        np.testing.assert_allclose(restored.coef_, model.coef_, rtol=1e-8, atol=1e-10)
+
+    def test_failed_partial_fit_keeps_the_pending_solve(self, regression_data, sparse):
+        """A rejected update must not swallow the pending correction:
+        ``coef_`` is still solvable, and still the corrected mean."""
+        X, y = regression_data
+        model = EmpiricalBayesNormalRegressor(alpha=1.0, beta=1.0, sparse=sparse)
+        model.fit(X[:50], y[:50])
+        model.partial_fit(X[50:], y[50:])
+        assert "_pending_eta" in model.__dict__
+        expected = model.__dict__["_pending_eta"].copy()
+
+        with pytest.raises(ValueError):
+            model.partial_fit(X[:10], y[:5])  # mismatched lengths
+
+        assert "_pending_eta" in model.__dict__
+        np.testing.assert_array_equal(model.__dict__["_pending_eta"], expected)
+        precision = self._dense_precision(model)
+        np.testing.assert_allclose(
+            precision @ model.coef_, expected, rtol=1e-8, atol=1e-8
+        )
+
+    def test_coef_raises_before_fitting(self, sparse):
+        """An unfitted model has no mean to report, deferred or not."""
+        model = EmpiricalBayesNormalRegressor(alpha=1.0, beta=1.0, sparse=sparse)
+        assert not hasattr(model, "coef_")
+        with pytest.raises(AttributeError, match="coef_"):
+            model.coef_
 
 
 @pytest.mark.parametrize("sparse", [True, False])

--- a/tests/test_eb_estimators.py
+++ b/tests/test_eb_estimators.py
@@ -388,6 +388,96 @@ class TestEBNormalRegressor:
         assert hasattr(model, "_eff_XTy")
         assert model._eff_XTy.shape == (X.shape[1],)
 
+    @staticmethod
+    def _dense_precision(model):
+        """Full symmetric precision (dense cov_inv_ is upper-triangle-only)."""
+        if model.sparse:
+            return model.cov_inv_.toarray()
+        upper = np.triu(model.cov_inv_)
+        return upper + upper.T - np.diag(np.diag(upper))
+
+    def test_partial_fit_keeps_coef_consistent_with_information(
+        self, regression_data, sparse
+    ):
+        """After a MacKay step, Λ·coef_ must equal β·(Xᵀy): the posterior
+        mean has to be re-solved against the rescaled precision."""
+        X, y = regression_data
+        model = EmpiricalBayesNormalRegressor(alpha=1.0, beta=1.0, sparse=sparse)
+        model.fit(X[:50], y[:50])
+        model.partial_fit(X[50:], y[50:])
+
+        ratio_alpha = model.alpha / 1.0
+        ratio_beta = model.beta / 1.0
+        assert not np.isclose(ratio_alpha, ratio_beta)  # a real diagonal shift
+
+        precision = self._dense_precision(model)
+        np.testing.assert_allclose(
+            precision @ model.coef_,
+            model.beta * model._eff_XTy,
+            rtol=1e-8,
+            atol=1e-8,
+        )
+
+    def test_correct_precision_resolves_coef(self, regression_data, sparse):
+        """Direct check of _correct_precision with a forced α/β change."""
+        X, y = regression_data
+        model = EmpiricalBayesNormalRegressor(
+            alpha=1.0, beta=1.0, n_eb_iter=0, sparse=sparse
+        )
+        model.fit(X, y)
+
+        alpha_old, beta_old = model.alpha, model.beta
+        prec_old = self._dense_precision(model)
+        coef_old = model.coef_.copy()
+        prior_old = model._prior_scalar
+        data_old = prec_old - prior_old * np.eye(prec_old.shape[0])
+
+        model.alpha = alpha_old * 3.0
+        model.beta = beta_old * 0.5
+        model._correct_precision(alpha_old, beta_old)
+
+        prec_new = self._dense_precision(model)
+        data_new = prec_new - model._prior_scalar * np.eye(prec_new.shape[0])
+        np.testing.assert_allclose(data_new, 0.5 * data_old, rtol=1e-10, atol=1e-12)
+        np.testing.assert_allclose(model._prior_scalar, 3.0 * prior_old)
+
+        eta_new = 0.5 * (prec_old @ coef_old)
+        expected = np.linalg.solve(prec_new, eta_new)
+        np.testing.assert_allclose(model.coef_, expected, rtol=1e-8, atol=1e-10)
+        # The cached factor (rebuilt on demand) agrees with the raw matrix.
+        np.testing.assert_allclose(
+            model._precision_factor.solve(eta_new), expected, rtol=1e-8, atol=1e-10
+        )
+
+    def test_partial_fit_tracks_full_fit(self, sparse):
+        """Chunked partial_fit from far-off α, β must land on the full fit.
+
+        With ``learning_rate=1`` the online learner sees the same
+        sufficient statistics as ``fit``, so its MacKay fixed point is
+        the same one. Before ``_correct_precision`` re-solved ``coef_``
+        it drifted (α off by 1.8x, β off by 0.5x, coef off by 0.3).
+        """
+        rng = np.random.default_rng(7)
+        n, p = 2000, 10
+        X = rng.standard_normal((n, p))
+        w_true = rng.standard_normal(p)
+        y = X @ w_true + 0.5 * rng.standard_normal(n)
+
+        full = EmpiricalBayesNormalRegressor(alpha=1e4, beta=1e-3, sparse=sparse)
+        full.fit(X, y)
+
+        # n_eb_iter=1 keeps the first chunk (which routes to fit) from
+        # converging on its own, so every chunk takes one MacKay step.
+        online = EmpiricalBayesNormalRegressor(
+            alpha=1e4, beta=1e-3, n_eb_iter=1, sparse=sparse
+        )
+        for start in range(0, n, 50):
+            online.partial_fit(X[start : start + 50], y[start : start + 50])
+
+        np.testing.assert_allclose(online.alpha, full.alpha, rtol=1e-2)
+        np.testing.assert_allclose(online.beta, full.beta, rtol=1e-2)
+        np.testing.assert_allclose(online.coef_, full.coef_, atol=1e-3)
+
 
 @pytest.mark.parametrize("sparse", [True, False])
 @pytest.mark.parametrize("trace_method", ["auto", "diagonal"])


### PR DESCRIPTION
## Summary

`EmpiricalBayesNormalRegressor._correct_precision` rescales the precision after a MacKay step (prior part by `alpha_new/alpha_old`, data part by `beta_new/beta_old`) but left `coef_` at the mean under the old hyperparameters. The next `partial_fit` reconstructs the prior's information as `Λ_new·θ_old` instead of the data's actual information `Λ_old·θ_old`, silently re-applying the old shrinkage and the old beta on every step.

Fix: in the diagonal-shift branch, read `η_old = Λ_old·θ_old` before mutating, then set `coef_ = Λ_new⁻¹·(β_new/β_old)·η_old` using the factor that `sample()` needs anyway. The pure-rescale branch (alpha and beta moved by the same ratio) correctly leaves `coef_` alone.

## Effect

Chunked `partial_fit` (2000 rows, p=10, `n_eb_iter=1`, starting at alpha=1e4, beta=1e-3) vs `fit` on everything:

| | alpha (online / full) | beta (online / full) | max coef diff |
|---|---|---|---|
| before | 4.409 / 2.447 | 2.042 / 4.127 | 0.31 |
| after | 2.447 / 2.447 | 4.127 / 4.127 | 1.5e-10 |

With `learning_rate=1` the online learner now lands exactly on the batch fixed point: it sees the same sufficient statistics and the corrected state is a true posterior under the current hyperparameters.

## Tests

- `Λ·coef_ == β·_eff_XTy` after fit + partial_fit
- forced alpha×3 / beta×0.5: data component scaled by exactly 0.5, `coef_` equals the solve, rebuilt factor agrees
- chunked-vs-full tracking test above (fails without the fix, alpha off by 80%)

Found while building `EmpiricalBayesGLM` (#235), which has the same structure and ships with the equivalent solve.