### PR TITLE
Bound the Takahashi workspace, and stop a failed update from corrupting the posterior

### DIFF
--- a/src/bayesianbandits/_eb_estimators.py
+++ b/src/bayesianbandits/_eb_estimators.py
@@ -609,10 +609,7 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
             X_weighted = X.multiply(w_sqrt.reshape(-1, 1)).tocsc()
             prior = cast(csc_array, self.cov_inv_)
             if prior_decay != 1.0:
-                # A new data array over the same pattern rather than an
-                # in-place scale, so a solve that fails below leaves cov_inv_
-                # where it was instead of decayed by one step with no data to
-                # show for it. Costs nnz against the addition that follows.
+                # New data array, not in-place: leaves cov_inv_ untouched if the solve below fails.
                 prior = csc_array(
                     (prior.data * prior_decay, prior.indices, prior.indptr),
                     shape=prior.shape,
@@ -634,8 +631,7 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
                     prior_decay, self.cov_inv_, self.coef_, self.beta, X, y_weighted
                 )
             else:
-                # As compute_eta_dense, with its dsymv already done: dgemv
-                # accumulates the data term into the same buffer.
+                # As compute_eta_dense, but dgemv accumulates onto the already-done dsymv term.
                 eta = dgemv(
                     self.beta,
                     X,
@@ -645,10 +641,8 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
                     y=prior_decay * pending_eta,
                     overwrite_y=True,
                 )
-            # A copy, not a view: the scale, the diagonal re-injection and
-            # dsyrk all write this buffer, so aliasing cov_inv_ would destroy
-            # the posterior before cho_factor has had the chance to reject
-            # the update. cov_inv_ moves at the assignment below or not at all.
+            # Copy, not a view: dsyrk below writes this buffer, so aliasing cov_inv_
+            # would corrupt it before cho_factor gets a chance to reject the update.
             prior_scaled = np.array(self.cov_inv_, order="F", copy=True)
             if prior_decay != 1.0:
                 prior_scaled *= prior_decay

--- a/src/bayesianbandits/_eb_estimators.py
+++ b/src/bayesianbandits/_eb_estimators.py
@@ -609,7 +609,14 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
             X_weighted = X.multiply(w_sqrt.reshape(-1, 1)).tocsc()
             prior = cast(csc_array, self.cov_inv_)
             if prior_decay != 1.0:
-                prior.data *= prior_decay  # in place; prior_eta below uses it too
+                # A new data array over the same pattern rather than an
+                # in-place scale, so a solve that fails below leaves cov_inv_
+                # where it was instead of decayed by one step with no data to
+                # show for it. Costs nnz against the addition that follows.
+                prior = csc_array(
+                    (prior.data * prior_decay, prior.indices, prior.indptr),
+                    shape=prior.shape,
+                )
             prior_eta = (
                 prior @ self.coef_ if pending_eta is None else prior_decay * pending_eta
             )
@@ -622,7 +629,6 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
         else:
             w_sqrt = np.sqrt(effective_weights)
             X_weighted = X * w_sqrt[:, np.newaxis]
-            # before the in-place update of cov_inv_ below
             if pending_eta is None:
                 eta = compute_eta_dense(
                     prior_decay, self.cov_inv_, self.coef_, self.beta, X, y_weighted
@@ -639,7 +645,11 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
                     y=prior_decay * pending_eta,
                     overwrite_y=True,
                 )
-            prior_scaled = np.asfortranarray(self.cov_inv_)
+            # A copy, not a view: the scale, the diagonal re-injection and
+            # dsyrk all write this buffer, so aliasing cov_inv_ would destroy
+            # the posterior before cho_factor has had the chance to reject
+            # the update. cov_inv_ moves at the assignment below or not at all.
+            prior_scaled = np.array(self.cov_inv_, order="F", copy=True)
             if prior_decay != 1.0:
                 prior_scaled *= prior_decay
             if reinjection != 0.0:

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -1610,11 +1610,15 @@ scipy.sparse.csc_array
         else:
             w_sqrt = np.sqrt(effective_weights)
             X_weighted = X * w_sqrt[:, np.newaxis]
-            # before the in-place update of cov_inv_ below
             eta = compute_eta_dense(
                 prior_decay, self.cov_inv_, self.coef_, self.beta, X, y_weighted
             )
-            prior_scaled = np.asfortranarray(self.cov_inv_)
+            # A copy, not a view: dsyrk overwrites this buffer, so aliasing
+            # cov_inv_ would destroy the posterior before cho_factor has had
+            # the chance to reject the update, leaving the new precision
+            # beside the old coef_. cov_inv_ moves at the assignment below or
+            # not at all.
+            prior_scaled = np.array(self.cov_inv_, order="F", copy=True)
             if prior_decay != 1.0:
                 prior_scaled *= prior_decay
             # Fused X^T W X + prior via dsyrk (upper triangle only)

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -1613,11 +1613,8 @@ scipy.sparse.csc_array
             eta = compute_eta_dense(
                 prior_decay, self.cov_inv_, self.coef_, self.beta, X, y_weighted
             )
-            # A copy, not a view: dsyrk overwrites this buffer, so aliasing
-            # cov_inv_ would destroy the posterior before cho_factor has had
-            # the chance to reject the update, leaving the new precision
-            # beside the old coef_. cov_inv_ moves at the assignment below or
-            # not at all.
+            # Copy, not a view: dsyrk below writes this buffer, so aliasing cov_inv_
+            # would corrupt it before cho_factor gets a chance to reject the update.
             prior_scaled = np.array(self.cov_inv_, order="F", copy=True)
             if prior_decay != 1.0:
                 prior_scaled *= prior_decay

--- a/src/bayesianbandits/_sparse_bayesian_linear_regression.py
+++ b/src/bayesianbandits/_sparse_bayesian_linear_regression.py
@@ -79,10 +79,13 @@ def takahashi_diagonal(L_csc: csc_array) -> NDArray[np.float64]:
     diagonal of ``A⁻¹`` exactly by backward recursion through ``L``'s
     sparsity structure. Cost is ``O(Σⱼ nⱼ²)`` in the sub-diagonal counts
     ``nⱼ``, the same order as the Cholesky that produced ``L``; columns
-    sharing a sub-diagonal structure (a supernode) go through BLAS as
-    one dense block, above a threshold chosen to pay even with an
-    oversubscribed BLAS thread pool (callers that pin BLAS to one
-    thread can lower ``min_dense_work``).
+    sharing a sub-diagonal structure (a supernode) go through BLAS as one
+    dense block, from four columns up, which is where the copy into that
+    block starts to pay. Wide supernodes are cut into block columns and the
+    dense ``Z_RR`` is formed one column panel at a time, so the scratch a
+    block asks for is bounded by what it already occupies in ``L`` plus a
+    fixed panel, however badly the factor fills in. How many threads the
+    BLAS underneath uses is the caller's to set.
 
     Delegates to a Cython implementation. Lives beside the factors
     because it reads a Cholesky factor and nothing else; consumers want

--- a/src/bayesianbandits/_sparse_bayesian_linear_regression.py
+++ b/src/bayesianbandits/_sparse_bayesian_linear_regression.py
@@ -80,12 +80,9 @@ def takahashi_diagonal(L_csc: csc_array) -> NDArray[np.float64]:
     sparsity structure. Cost is ``O(Σⱼ nⱼ²)`` in the sub-diagonal counts
     ``nⱼ``, the same order as the Cholesky that produced ``L``; columns
     sharing a sub-diagonal structure (a supernode) go through BLAS as one
-    dense block, from four columns up, which is where the copy into that
-    block starts to pay. Wide supernodes are cut into block columns and the
-    dense ``Z_RR`` is formed one column panel at a time, so the scratch a
-    block asks for is bounded by what it already occupies in ``L`` plus a
-    fixed panel, however badly the factor fills in. How many threads the
-    BLAS underneath uses is the caller's to set.
+    dense block. Wide supernodes are split into block columns and their
+    dense ``Z_RR`` is formed one column panel at a time, so workspace stays
+    bounded regardless of fill-in.
 
     Delegates to a Cython implementation. Lives beside the factors
     because it reads a Cholesky factor and nothing else; consumers want

--- a/src/bayesianbandits/_takahashi.pyx
+++ b/src/bayesianbandits/_takahashi.pyx
@@ -139,13 +139,41 @@ cdef inline void _scalar_column(
     z_diag[j] = inv_l_jj * inv_l_jj * (1.0 + dot)
 
 
+# Workspace for one supernode's dense block, in doubles. The block is laid
+# out flat, Fortran-ordered, each piece with the exact leading dimension of
+# its own shape:
+#
+#     L_SS (S x S) | M (S x S) | L_RS (m x S) | W (m x S) | Z_B (m x cols)
+#
+# The first four are the supernode's own data, or the output written back
+# over it, so they are bounded by what it already occupies in ``data``.
+# ``Z_B`` is a column panel of the symmetric ``Z_RR``, and its width is
+# chosen so the panel costs a fixed number of bytes however tall the
+# supernode is. No term grows with ``m * m``, which is what keeps the peak
+# independent of how badly the factor fills in.
+cdef inline Py_ssize_t _dense_work(
+    int S, int m, Py_ssize_t panel_bytes, int *panel_cols
+) noexcept nogil:
+    cdef Py_ssize_t cols = 0
+    if m > 0:
+        cols = panel_bytes // (<Py_ssize_t>sizeof(double) * <Py_ssize_t>m)
+        if cols < 1:
+            cols = 1
+        elif cols > m:
+            cols = m
+    panel_cols[0] = <int>cols
+    return (2 * (<Py_ssize_t>S) * S + 2 * (<Py_ssize_t>m) * S
+            + cols * (<Py_ssize_t>m))
+
+
 def takahashi_diagonal(
     const double[::1] data,
     const int[::1] indices,
     const int[::1] indptr,
     int p,
-    int min_dense_work=16384,
     int min_dense_cols=4,
+    int max_dense_cols=1024,
+    Py_ssize_t panel_bytes=8388608,
 ):
     """Compute diag((LL')⁻¹) from CSC arrays of a lower-triangular L.
 
@@ -155,22 +183,35 @@ def takahashi_diagonal(
     indices : int32 array — CSC row indices
     indptr : int32 array — CSC column pointers
     p : int — matrix dimension
-    min_dense_work, min_dense_cols : int — a supernode of ``S`` columns
-        over ``m`` rows takes the dense BLAS path when ``S >= min_dense_cols``
-        and ``S * (S + m) >= min_dense_work``; smaller ones run the scalar
-        recursion per column.
+    min_dense_cols : int — a supernode of this many columns or more goes
+        through the dense BLAS kernel; narrower ones run the scalar
+        recursion per column, having too few columns to amortize the copy
+        into the dense block. Internal: exposed so tests can force the
+        scalar path and compare, not as a tuning knob.
+    max_dense_cols : int — widest block column handed to the dense kernel.
+        Wider supernodes are split into block columns of this width, which
+        bounds the ``S x S`` buffers at ``2 * max_dense_cols ** 2``, about
+        17 MB at the default. Every value in 512..2048 measured the same on
+        factors whose supernodes fit anyway; the cap is what keeps a
+        fill-heavy factor from asking for gigabytes. Internal, in the same
+        sense.
+    panel_bytes : int — cache-blocking size for the ``Z_RR`` column panel,
+        in bytes. Internal, in the same sense.
 
     Returns
     -------
     ndarray of float64, length p
     """
+    if p == 0:
+        return np.zeros(0, dtype=np.float64)
+
     cdef int nnz = data.shape[0]
     cdef double[::1] z_data = np.zeros(nnz, dtype=np.float64)
     cdef double[::1] z_diag = np.zeros(p, dtype=np.float64)
     cdef double[::1] z_work = np.zeros(p, dtype=np.float64)
 
     cdef int j, a, b, k, col_len, n_sub, col_start, max_sub
-    cdef double l_jj, z_ab
+    cdef double l_jj
 
     # First pass: handle trivial columns, find max_sub for z_col buffer.
     max_sub = 0
@@ -184,110 +225,163 @@ def takahashi_diagonal(
             if n_sub > max_sub:
                 max_sub = n_sub
 
-    cdef double[::1] z_col = np.zeros(max_sub, dtype=np.float64)
+    cdef double[::1] z_col = np.zeros(max(max_sub, 1), dtype=np.float64)
 
     # Supernode partition.
     cdef int[::1] starts = np.empty(p + 1, dtype=np.int32)
     cdef int n_super = _supernode_starts(indices, indptr, p, starts)
 
-    # Dense workspace, Fortran order, sized by the largest supernode.
-    cdef int s, f, l, S, m, max_S = 1, max_m = 0
+    # Cap the width handed to the dense kernel. A block column of a
+    # supernode is itself a supernode of the columns to its right: its
+    # sub-diagonal pattern is exactly theirs plus those columns. So this is
+    # a refinement of the partition rather than a change of algorithm, and
+    # it is what bounds the S x S buffers however wide the real supernode
+    # is. Widths are balanced so a split never leaves a sliver too narrow
+    # for the dense path.
+    cdef int s, f, l, S, m, cols = 0
+    cdef int[::1] blocks = np.empty(p + 1, dtype=np.int32)
+    cdef int n_blocks = 0, pieces, width
     for s in range(n_super):
         f = starts[s]
-        S = starts[s + 1] - f
-        m = indptr[f + 1] - indptr[f] - S
-        if S > max_S:
-            max_S = S
-        if m > max_m:
-            max_m = m
-    cdef double[::1, :] LSS = np.zeros((max_S, max_S), dtype=np.float64, order="F")
-    cdef double[::1, :] Linv = np.zeros((max_S, max_S), dtype=np.float64, order="F")
-    cdef double[::1, :] M = np.zeros((max_S, max_S), dtype=np.float64, order="F")
-    cdef double[::1, :] LRS = np.zeros((max(max_m, 1), max_S), dtype=np.float64, order="F")
-    cdef double[::1, :] W = np.zeros((max(max_m, 1), max_S), dtype=np.float64, order="F")
-    cdef double[::1, :] ZRR = np.zeros((max(max_m, 1), max(max_m, 1)), dtype=np.float64, order="F")
+        l = starts[s + 1]
+        S = l - f
+        if S <= max_dense_cols:
+            blocks[n_blocks] = f
+            n_blocks += 1
+            continue
+        pieces = (S + max_dense_cols - 1) // max_dense_cols
+        width = (S + pieces - 1) // pieces
+        j = f
+        while j < l:
+            blocks[n_blocks] = j
+            n_blocks += 1
+            j += width
+    blocks[n_blocks] = p
 
-    cdef int c0, c1, r, r0, r1, i, info
-    cdef int lda = max(max_m, 1)
-    cdef double one = 1.0, zero = 0.0, minus_one = -1.0
+    # One flat workspace, in the LAPACK ``lwork`` sense: the largest single
+    # dense block, not a cross product of maxima taken over unrelated
+    # supernodes. ``_dense_work`` sizes it here and lays it out below, so the
+    # two cannot drift apart, and supernodes that take the scalar path are
+    # not counted at all.
+    cdef Py_ssize_t need, lwork = 0
+    for s in range(n_blocks):
+        f = blocks[s]
+        S = blocks[s + 1] - f
+        if S < min_dense_cols:
+            continue
+        m = indptr[f + 1] - indptr[f] - S
+        need = _dense_work(S, m, panel_bytes, &cols)
+        if need > lwork:
+            lwork = need
+    cdef double[::1] work = np.zeros(max(lwork, 1), dtype=np.float64)
+    cdef double *wbuf = &work[0]
+    cdef double *LSS
+    cdef double *M
+    cdef double *LRS
+    cdef double *W
+    cdef double *ZB
+
+    cdef int c0, r, r0, r1, i, info, q0, q1, nb
+    cdef double one = 1.0, minus_one = -1.0, zd, tmp
     cdef char *side_r = "R"
     cdef char *uplo_l = "L"
     cdef char *trans_n = "N"
     cdef char *trans_t = "T"
     cdef char *diag_n = "N"
 
-    # Backward pass over supernodes.
-    for s in range(n_super - 1, -1, -1):
-        f = starts[s]
-        l = starts[s + 1]
+    # Backward pass over block columns.
+    for s in range(n_blocks - 1, -1, -1):
+        f = blocks[s]
+        l = blocks[s + 1]
         S = l - f
         c0 = indptr[f]
-        c1 = indptr[f + 1]
-        m = c1 - c0 - S
+        m = indptr[f + 1] - c0 - S
 
-        if S < min_dense_cols or S * (S + m) < min_dense_work:
+        if S < min_dense_cols:
             for j in range(l - 1, f - 1, -1):  # column j reads Z's column j + 1
                 _scalar_column(j, data, indices, indptr, z_data, z_diag, z_work, z_col)
             continue
 
+        _dense_work(S, m, panel_bytes, &cols)
+        LSS = wbuf
+        M = LSS + (<Py_ssize_t>S) * S
+        LRS = M + (<Py_ssize_t>S) * S
+        W = LRS + (<Py_ssize_t>m) * S
+        ZB = W + (<Py_ssize_t>m) * S
+
         # Column f + k of L holds rows f+k .. l-1 (the lower triangle of
         # L_SS) followed by the m rows R below.
         for k in range(S):
-            j = f + k
-            col_start = indptr[j]
+            col_start = indptr[f + k]
             for i in range(k):
-                LSS[i, k] = 0.0
+                LSS[i + k * S] = 0.0
             for i in range(S - k):
-                LSS[k + i, k] = data[col_start + i]
+                LSS[k + i + k * S] = data[col_start + i]
             for i in range(m):
-                LRS[i, k] = data[col_start + S - k + i]
-
-        # Z_RR: every entry is in L's pattern and already computed.
-        for a in range(m):
-            r = indices[c0 + S + a]
-            ZRR[a, a] = z_diag[r]
-            r0 = indptr[r] + 1
-            r1 = indptr[r + 1]
-            for k in range(r0, r1):
-                z_work[indices[k]] = z_data[k]
-            for b in range(a + 1, m):
-                z_ab = z_work[indices[c0 + S + b]]
-                ZRR[b, a] = z_ab
-                ZRR[a, b] = z_ab
-            for k in range(r0, r1):
-                z_work[indices[k]] = 0.0
+                LRS[i + k * m] = data[col_start + S - k + i]
 
         if m > 0:
-            # W = Z_RR L_RS                                   (m x S)
-            dgemm(trans_n, trans_n, &m, &S, &m, &one, &ZRR[0, 0], &lda,
-                  &LRS[0, 0], &lda, &zero, &W[0, 0], &lda)
+            # W = Z_RR L_RS, without ever forming Z_RR. Split the symmetric
+            # Z_RR into D + Z + Z', Z strictly lower, and walk Z one column
+            # panel at a time: scattering Z's column r_b fills that panel
+            # column for every row below it, and the panel then feeds both
+            # gemms while it is still in cache.
+            for a in range(m):
+                zd = z_diag[indices[c0 + S + a]]
+                for k in range(S):
+                    W[a + k * m] = zd * LRS[a + k * m]
+            q0 = 0
+            while q0 < m:
+                q1 = q0 + cols
+                if q1 > m:
+                    q1 = m
+                nb = q1 - q0
+                for b in range(q0, q1):
+                    r = indices[c0 + S + b]
+                    r0 = indptr[r] + 1
+                    r1 = indptr[r + 1]
+                    for k in range(r0, r1):
+                        z_work[indices[k]] = z_data[k]
+                    for a in range(b + 1):
+                        ZB[a + (b - q0) * m] = 0.0
+                    for a in range(b + 1, m):
+                        ZB[a + (b - q0) * m] = z_work[indices[c0 + S + a]]
+                    for k in range(r0, r1):
+                        z_work[indices[k]] = 0.0
+                # W += Z_B L_RS[B, :]
+                dgemm(trans_n, trans_n, &m, &S, &nb, &one, ZB, &m,
+                      LRS + q0, &m, &one, W, &m)
+                # W += (Z_B)' L_RS, landing on rows B of W
+                dgemm(trans_t, trans_n, &nb, &S, &m, &one, ZB, &m,
+                      LRS, &m, &one, W + q0, &m)
+                q0 = q1
             # Z_RS = -W L_SS^{-1}                              (in place in W)
             dtrsm(side_r, uplo_l, trans_n, diag_n, &m, &S, &minus_one,
-                  &LSS[0, 0], &max_S, &W[0, 0], &lda)
+                  LSS, &S, W, &m)
 
-        # M = L_SS^{-T} - Z_RS^T L_RS                         (S x S)
-        for k in range(S):
-            for i in range(S):
-                Linv[i, k] = LSS[i, k]
-        dtrtri(uplo_l, diag_n, &S, &Linv[0, 0], &max_S, &info)
-        for k in range(S):
-            for i in range(S):
-                M[i, k] = Linv[k, i]
+        # M = L_SS^{-T} - Z_RS' L_RS                          (S x S)
+        for i in range((<Py_ssize_t>S) * S):
+            M[i] = LSS[i]
+        dtrtri(uplo_l, diag_n, &S, M, &S, &info)
+        for k in range(S):  # transpose in place; dtrtri left the zeros above
+            for i in range(k + 1, S):
+                tmp = M[i + k * S]
+                M[i + k * S] = M[k + i * S]
+                M[k + i * S] = tmp
         if m > 0:
-            dgemm(trans_t, trans_n, &S, &S, &m, &minus_one, &W[0, 0], &lda,
-                  &LRS[0, 0], &lda, &one, &M[0, 0], &max_S)
+            dgemm(trans_t, trans_n, &S, &S, &m, &minus_one, W, &m,
+                  LRS, &m, &one, M, &S)
         # Z_SS = M L_SS^{-1}
         dtrsm(side_r, uplo_l, trans_n, diag_n, &S, &S, &one,
-              &LSS[0, 0], &max_S, &M[0, 0], &max_S)
+              LSS, &S, M, &S)
 
         # Store Z's columns in L's pattern.
         for k in range(S):
-            j = f + k
-            col_start = indptr[j]
-            z_diag[j] = M[k, k]
+            col_start = indptr[f + k]
+            z_diag[f + k] = M[k + k * S]
             for i in range(1, S - k):
-                z_data[col_start + i] = M[k + i, k]
+                z_data[col_start + i] = M[k + i + k * S]
             for i in range(m):
-                z_data[col_start + S - k + i] = W[i, k]
+                z_data[col_start + S - k + i] = W[i + k * m]
 
     return np.asarray(z_diag)

--- a/src/bayesianbandits/_takahashi.pyx
+++ b/src/bayesianbandits/_takahashi.pyx
@@ -139,18 +139,11 @@ cdef inline void _scalar_column(
     z_diag[j] = inv_l_jj * inv_l_jj * (1.0 + dot)
 
 
-# Workspace for one supernode's dense block, in doubles. The block is laid
-# out flat, Fortran-ordered, each piece with the exact leading dimension of
-# its own shape:
-#
-#     L_SS (S x S) | M (S x S) | L_RS (m x S) | W (m x S) | Z_B (m x cols)
-#
-# The first four are the supernode's own data, or the output written back
-# over it, so they are bounded by what it already occupies in ``data``.
-# ``Z_B`` is a column panel of the symmetric ``Z_RR``, and its width is
-# chosen so the panel costs a fixed number of bytes however tall the
-# supernode is. No term grows with ``m * m``, which is what keeps the peak
-# independent of how badly the factor fills in.
+# Workspace for one supernode's dense block, in doubles, laid out flat and
+# Fortran-ordered: L_SS (S x S) | M (S x S) | L_RS (m x S) | W (m x S) |
+# Z_B (m x cols). Z_B is a column panel of the symmetric Z_RR, sized so no
+# term grows with m * m — that's what keeps the peak workspace bounded
+# regardless of fill-in.
 cdef inline Py_ssize_t _dense_work(
     int S, int m, Py_ssize_t panel_bytes, int *panel_cols
 ) noexcept nogil:
@@ -183,20 +176,15 @@ def takahashi_diagonal(
     indices : int32 array — CSC row indices
     indptr : int32 array — CSC column pointers
     p : int — matrix dimension
-    min_dense_cols : int — a supernode of this many columns or more goes
-        through the dense BLAS kernel; narrower ones run the scalar
-        recursion per column, having too few columns to amortize the copy
-        into the dense block. Internal: exposed so tests can force the
-        scalar path and compare, not as a tuning knob.
-    max_dense_cols : int — widest block column handed to the dense kernel.
-        Wider supernodes are split into block columns of this width, which
-        bounds the ``S x S`` buffers at ``2 * max_dense_cols ** 2``, about
-        17 MB at the default. Every value in 512..2048 measured the same on
-        factors whose supernodes fit anyway; the cap is what keeps a
-        fill-heavy factor from asking for gigabytes. Internal, in the same
-        sense.
+    min_dense_cols : int — supernodes with at least this many columns take
+        the dense BLAS path; narrower ones run the scalar recursion.
+        Internal: exposed for tests, not a tuning knob.
+    max_dense_cols : int — widest block column handed to the dense kernel;
+        wider supernodes are split. Bounds the ``S x S`` buffers at
+        ``2 * max_dense_cols ** 2`` (~17 MB at the default) regardless of
+        fill-in. Internal.
     panel_bytes : int — cache-blocking size for the ``Z_RR`` column panel,
-        in bytes. Internal, in the same sense.
+        in bytes. Internal.
 
     Returns
     -------
@@ -231,13 +219,9 @@ def takahashi_diagonal(
     cdef int[::1] starts = np.empty(p + 1, dtype=np.int32)
     cdef int n_super = _supernode_starts(indices, indptr, p, starts)
 
-    # Cap the width handed to the dense kernel. A block column of a
-    # supernode is itself a supernode of the columns to its right: its
-    # sub-diagonal pattern is exactly theirs plus those columns. So this is
-    # a refinement of the partition rather than a change of algorithm, and
-    # it is what bounds the S x S buffers however wide the real supernode
-    # is. Widths are balanced so a split never leaves a sliver too narrow
-    # for the dense path.
+    # Split wide supernodes into balanced block columns, each itself a valid
+    # supernode of the columns to its right, so this bounds the S x S
+    # buffers without changing the algorithm.
     cdef int s, f, l, S, m, cols = 0
     cdef int[::1] blocks = np.empty(p + 1, dtype=np.int32)
     cdef int n_blocks = 0, pieces, width
@@ -258,11 +242,8 @@ def takahashi_diagonal(
             j += width
     blocks[n_blocks] = p
 
-    # One flat workspace, in the LAPACK ``lwork`` sense: the largest single
-    # dense block, not a cross product of maxima taken over unrelated
-    # supernodes. ``_dense_work`` sizes it here and lays it out below, so the
-    # two cannot drift apart, and supernodes that take the scalar path are
-    # not counted at all.
+    # One flat workspace sized to the largest single dense block (LAPACK
+    # ``lwork`` style), not a cross product of maxima over unrelated blocks.
     cdef Py_ssize_t need, lwork = 0
     for s in range(n_blocks):
         f = blocks[s]
@@ -321,11 +302,8 @@ def takahashi_diagonal(
                 LRS[i + k * m] = data[col_start + S - k + i]
 
         if m > 0:
-            # W = Z_RR L_RS, without ever forming Z_RR. Split the symmetric
-            # Z_RR into D + Z + Z', Z strictly lower, and walk Z one column
-            # panel at a time: scattering Z's column r_b fills that panel
-            # column for every row below it, and the panel then feeds both
-            # gemms while it is still in cache.
+            # W = Z_RR L_RS without forming Z_RR: split it into D + Z + Z'
+            # (Z strictly lower) and walk Z one column panel at a time.
             for a in range(m):
                 zd = z_diag[indices[c0 + S + a]]
                 for k in range(S):

--- a/tests/test_eb_estimators.py
+++ b/tests/test_eb_estimators.py
@@ -1629,15 +1629,7 @@ class TestEBGammaRegressor:
 
 
 class TestFailedUpdateLeavesEstimatorIntact:
-    """A ``partial_fit`` that raises must not have moved the posterior.
-
-    The dense update writes the new precision over ``cov_inv_``'s own buffer
-    (``dsyrk`` overwrites its ``C``), and the sparse EB update scales
-    ``cov_inv_.data``. Both happen before the factorization that can reject
-    the update, so without a copy a raise leaves the new precision sitting
-    beside the old ``coef_``: a posterior that was never anybody's, and one
-    a long-running agent would keep drawing from.
-    """
+    """A ``partial_fit`` that raises must not have moved the posterior."""
 
     @pytest.mark.parametrize("cls", [NormalRegressor, EmpiricalBayesNormalRegressor])
     @pytest.mark.parametrize("sparse", [False, True])

--- a/tests/test_eb_estimators.py
+++ b/tests/test_eb_estimators.py
@@ -1626,3 +1626,58 @@ class TestEBGammaRegressor:
             f"Newton did not converge: log(a)-psi(a)={np.log(result[0]) - float(digamma(result[0])):.10f}, "
             f"target={target:.10f}, residual={residual:.2e}"
         )
+
+
+class TestFailedUpdateLeavesEstimatorIntact:
+    """A ``partial_fit`` that raises must not have moved the posterior.
+
+    The dense update writes the new precision over ``cov_inv_``'s own buffer
+    (``dsyrk`` overwrites its ``C``), and the sparse EB update scales
+    ``cov_inv_.data``. Both happen before the factorization that can reject
+    the update, so without a copy a raise leaves the new precision sitting
+    beside the old ``coef_``: a posterior that was never anybody's, and one
+    a long-running agent would keep drawing from.
+    """
+
+    @pytest.mark.parametrize("cls", [NormalRegressor, EmpiricalBayesNormalRegressor])
+    @pytest.mark.parametrize("sparse", [False, True])
+    def test_partial_fit_that_raises_changes_nothing(self, cls, sparse) -> None:
+        rng = np.random.default_rng(0)
+        X = rng.standard_normal((30, 4))
+        y = rng.standard_normal(30)
+        X_fit = sp.csc_array(X) if sparse else X
+
+        est = cls(alpha=1.0, beta=1.0, learning_rate=0.9, sparse=sparse)
+        est.partial_fit(X_fit[:15], y[:15])
+
+        def _dense(matrix):
+            return np.asarray(
+                matrix.todense() if sparse else matrix, dtype=np.float64
+            ).copy()
+
+        prec_before = _dense(est.cov_inv_)
+        coef_before = est.coef_.copy()
+
+        if sparse:
+            # Inherited, so patching it on the base covers both estimators.
+            failure = mock.patch.object(
+                NormalRegressor,
+                "_sparse_factor",
+                side_effect=np.linalg.LinAlgError("boom"),
+            )
+        else:
+            module = (
+                "bayesianbandits._eb_estimators"
+                if cls is EmpiricalBayesNormalRegressor
+                else "bayesianbandits._estimators"
+            )
+            failure = mock.patch(
+                f"{module}.cho_factor", side_effect=np.linalg.LinAlgError("boom")
+            )
+
+        with failure, pytest.raises(np.linalg.LinAlgError):
+            est.partial_fit(X_fit[15:], y[15:])
+
+        # Only the upper triangle of the dense precision is meaningful.
+        assert np.array_equal(np.triu(_dense(est.cov_inv_)), np.triu(prec_before))
+        assert np.array_equal(est.coef_, coef_before)

--- a/tests/test_empirical_bayes.py
+++ b/tests/test_empirical_bayes.py
@@ -235,9 +235,6 @@ class TestScaledFactorLogdet:
 def _takahashi_raw(L_csc: csc_array, **kwargs: int) -> NDArray[np.float64]:
     """Call the Cython kernel directly, so tests can reach its blocking
     parameters. The public wrapper deliberately does not expose them."""
-    if not L_csc.has_sorted_indices:
-        L_csc = L_csc.copy()
-        L_csc.sort_indices()
     return _cy_takahashi(
         L_csc.data,
         L_csc.indices.astype(np.int32),
@@ -247,11 +244,8 @@ def _takahashi_raw(L_csc: csc_array, **kwargs: int) -> NDArray[np.float64]:
     )
 
 
-# The dense BLAS kernel and the scalar recursion have to agree, and neither
-# may depend on how the block is carved up: ``min_dense_cols`` chooses
-# between the two paths, ``max_dense_cols`` splits a supernode into block
-# columns, and ``panel_bytes`` sets how many columns of Z_RR are formed at a
-# time. Widths of 1 force the most fragmented layout the kernel can take.
+# Each entry exercises a different block/panel width, including width-1
+# splits, so results can't depend on how the dense kernel carves up work.
 _BLOCKINGS = [
     pytest.param({"min_dense_cols": 10**8}, id="scalar-only"),
     pytest.param({"min_dense_cols": 2}, id="dense-from-2-cols"),
@@ -325,38 +319,6 @@ class TestTakahashiDiagonal:
         multiple of the identity."""
         result = _takahashi_raw(csc_array(np.eye(5) * 2.0))
         np.testing.assert_allclose(result, np.full(5, 0.25), atol=1e-14)
-
-    @pytest.mark.cython
-    def test_dense_spd_matches_inv(self) -> None:
-        """Takahashi diagonal matches np.linalg.inv diagonal for small dense SPD."""
-        rng = np.random.default_rng(42)
-        p = 6
-        A = rng.standard_normal((p, p))
-        M = A.T @ A + 3.0 * np.eye(p)
-
-        expected_diag = np.diag(np.linalg.inv(M))
-
-        L_dense = np.linalg.cholesky(M)
-        L_csc = csc_array(L_dense)
-        result_diag = takahashi_diagonal(L_csc)
-
-        np.testing.assert_allclose(result_diag, expected_diag, atol=1e-10)
-
-    @pytest.mark.cython
-    def test_sparse_tridiagonal_no_factor(self) -> None:
-        """Takahashi on a tridiagonal L constructed directly (no suitesparse)."""
-        p = 50
-        diag = np.full(p, 4.0)
-        off_diag = np.full(p - 1, -1.0)
-        M_dense = np.diag(diag) + np.diag(off_diag, 1) + np.diag(off_diag, -1)
-
-        expected_diag = np.diag(np.linalg.inv(M_dense))
-
-        L_dense = np.linalg.cholesky(M_dense)
-        L_csc = csc_array(L_dense)
-        result_diag = takahashi_diagonal(L_csc)
-
-        np.testing.assert_allclose(result_diag, expected_diag, atol=1e-10)
 
     @pytest.mark.cython
     def test_identity_no_factor(self) -> None:

--- a/tests/test_empirical_bayes.py
+++ b/tests/test_empirical_bayes.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 import numpy as np
 import pytest
+from bayesianbandits._takahashi import takahashi_diagonal as _cy_takahashi
 from numpy.typing import NDArray
 from scipy.linalg import cho_factor, solve
+from scipy.sparse import block_diag as sp_block_diag
 from scipy.sparse import csc_array
 from scipy.special import expit, gammaln
 
@@ -228,12 +232,100 @@ class TestScaledFactorLogdet:
         np.testing.assert_allclose(scaled_factor.logdet(), dense_expected, atol=1e-10)
 
 
+def _takahashi_raw(L_csc: csc_array, **kwargs: int) -> NDArray[np.float64]:
+    """Call the Cython kernel directly, so tests can reach its blocking
+    parameters. The public wrapper deliberately does not expose them."""
+    if not L_csc.has_sorted_indices:
+        L_csc = L_csc.copy()
+        L_csc.sort_indices()
+    return _cy_takahashi(
+        L_csc.data,
+        L_csc.indices.astype(np.int32),
+        L_csc.indptr.astype(np.int32),
+        cast("tuple[int, int]", L_csc.shape)[0],
+        **kwargs,
+    )
+
+
+# The dense BLAS kernel and the scalar recursion have to agree, and neither
+# may depend on how the block is carved up: ``min_dense_cols`` chooses
+# between the two paths, ``max_dense_cols`` splits a supernode into block
+# columns, and ``panel_bytes`` sets how many columns of Z_RR are formed at a
+# time. Widths of 1 force the most fragmented layout the kernel can take.
+_BLOCKINGS = [
+    pytest.param({"min_dense_cols": 10**8}, id="scalar-only"),
+    pytest.param({"min_dense_cols": 2}, id="dense-from-2-cols"),
+    pytest.param({"min_dense_cols": 2, "max_dense_cols": 1}, id="one-col-blocks"),
+    pytest.param({"min_dense_cols": 2, "max_dense_cols": 3}, id="three-col-blocks"),
+    pytest.param({"min_dense_cols": 2, "panel_bytes": 8}, id="one-col-z-panel"),
+    pytest.param(
+        {"min_dense_cols": 2, "max_dense_cols": 2, "panel_bytes": 24},
+        id="split-block-and-panel",
+    ),
+]
+
+
 # ---------------------------------------------------------------------------
 # 3. Takahashi diagonal recursion
 # ---------------------------------------------------------------------------
 
 
 class TestTakahashiDiagonal:
+    @pytest.mark.cython
+    @pytest.mark.parametrize("blocking", _BLOCKINGS)
+    @pytest.mark.parametrize(
+        "kind", ["dense", "tridiagonal", "banded", "sparse_gram", "block_diagonal"]
+    )
+    def test_every_blocking_agrees_with_dense_inverse(
+        self, kind: str, blocking: dict[str, int]
+    ) -> None:
+        """Both paths, at every block and panel width, match np.linalg.inv."""
+        rng = np.random.default_rng(4)
+        if kind == "dense":
+            A = rng.standard_normal((17, 17))
+            M = A @ A.T + 17.0 * np.eye(17)
+        elif kind == "tridiagonal":
+            off = np.full(29, -1.0)
+            M = np.diag(np.full(30, 4.0)) + np.diag(off, 1) + np.diag(off, -1)
+        elif kind == "banded":
+            M = np.zeros((40, 40))
+            for d in range(-5, 6):
+                M += np.diag(rng.standard_normal(40 - abs(d)) * 0.3, d)
+            M = M @ M.T + 40.0 * np.eye(40)
+        elif kind == "sparse_gram":
+            X = rng.standard_normal((60, 30)) * (rng.random((60, 30)) < 0.1)
+            M = X.T @ X + np.eye(30)
+        else:
+            blocks = []
+            for k in (1, 2, 3, 5, 9, 14):
+                B = rng.standard_normal((k, k))
+                blocks.append(B @ B.T + k * np.eye(k))
+            M = sp_block_diag(blocks).toarray()
+
+        expected = np.diag(np.linalg.inv(M))
+        L_csc = csc_array(np.linalg.cholesky(M))
+
+        result = _takahashi_raw(L_csc, **blocking)
+
+        np.testing.assert_allclose(result, expected, atol=1e-10)
+
+    @pytest.mark.cython
+    def test_empty_matrix(self) -> None:
+        """A 0 x 0 factor returns an empty diagonal rather than reading past
+        the end of its own index arrays."""
+        result = _cy_takahashi(
+            np.zeros(0), np.zeros(0, np.int32), np.zeros(1, np.int32), 0
+        )
+        assert result.shape == (0,)
+
+    @pytest.mark.cython
+    def test_all_columns_trivial(self) -> None:
+        """A diagonal factor has no sub-diagonal structure at all, so every
+        supernode is empty. Reachable whenever a precision is still a
+        multiple of the identity."""
+        result = _takahashi_raw(csc_array(np.eye(5) * 2.0))
+        np.testing.assert_allclose(result, np.full(5, 0.25), atol=1e-14)
+
     @pytest.mark.cython
     def test_dense_spd_matches_inv(self) -> None:
         """Takahashi diagonal matches np.linalg.inv diagonal for small dense SPD."""


### PR DESCRIPTION
Two fixes to what landed in #276 and #277. Both touch code paths that already ship, so they are separate from the EmpiricalBayesGLM work on `eb-sparse-partial-fit-perf`, which is purely additive and stacks on top of this.

## Bound the supernodal Takahashi workspace instead of gating on it

The dense path asked for whatever the supernode happened to be, and `min_dense_work` existed to refuse the ones that were too big. Sweeping it showed every value above ~128 costs time and buys nothing (p=100k n=200 goes 511ms to 158ms with the condition removed). It was really bounding memory: the dense path formed an `m x m` `Z_RR` and preallocated a cross product of maxima taken over unrelated supernodes, 3+ GB on a fill-heavy p=10k factor, and `MemoryError` outright at 100k features.

Inverted, so the kernel gets a bounded workspace and blocks to fit:

- `Z_RR` is never formed. The symmetric matrix splits as `D + Z + Z'` with `Z` strictly lower, and `Z` is walked one column panel at a time, two gemms per panel. Panel width comes from a fixed byte budget, so it costs the same however tall the supernode is.
- Supernodes wider than `max_dense_cols` split into balanced block columns. A block column of a supernode is itself a supernode of the columns to its right, its sub-diagonal pattern being exactly theirs plus those columns, so this refines the partition rather than changing the algorithm, and it bounds the `S x S` buffers.

The invariant that replaces the gate: **the dense path's scratch is bounded by what the block already occupies in `data`, plus one fixed panel.** So the gate collapses to one structural condition, `S >= 4`, which is where the copy into the dense block starts to pay, and there is nothing left to tune.

The workspace is now a single flat allocation in the LAPACK `lwork` sense, with `_dense_work` both sizing it and laying it out so the two cannot drift, scalar-path supernodes not counted at all, and each piece carved with the exact leading dimension of its own shape. `Linv` folds into an in-place transpose of `M`. `p == 0` no longer runs off the end of its index arrays, and neither does a precision that is still a multiple of the identity.

Pinned, like-for-like, which keeps OpenBLAS's own scratch out of the peak:

| case | before | after |
|---|---|---|
| p=1k n=300 | 23.5ms / 10MB | 18.1ms / 8MB |
| p=10k n=600 | 29.6ms / 10MB | 14.8ms / 6MB |
| p=100k n=200 | 373.5ms / 48MB | 114.6ms / 31MB |
| p=4k n=1500 | 2073ms / 436MB | 1695ms / 134MB |
| p=5k n=1000 | 4010ms / 864MB | 3594ms / 183MB |
| p=10k n=2000 | 29505ms / 3379MB | 29167ms / 537MB |

`max_dense_cols` is 1024 because every value in 512..2048 measured the same on factors whose supernodes fit anyway; 1024 keeps the `S x S` buffers L3-sized and was never the worst in any run.

The dense branch previously had no test coverage at all, needing a supernode ~4000 rows deep to reach. With the gate at `S >= 4` it is reachable from ordinary small matrices, so the tests now cross-check both paths against `np.linalg.inv` at every block and panel width, down to one column each.

Also drops the wrapper docstring's offer to let callers lower `min_dense_work`: it never forwarded the parameter, and the sweep picks the same constant pinned or not, so there was no thread-dependent decision to hand over. How many threads the BLAS underneath uses stays the caller's to set.

## Copy the prior before overwriting it

The dense update builds the new precision with `dsyrk`, which overwrites its `C` operand in place. That operand used to be a copy, because the expression was `asfortranarray(prior_decay * self.cov_inv_)` and the multiply always produced a temporary. #276 moved the multiply out to skip that copy when `prior_decay` is 1.0, which left `prior_scaled` aliasing `cov_inv_` in every case, and the in-place `*=` corrupting it outright when `prior_decay` is not 1.

So the sequence became: overwrite `cov_inv_` with the new precision, then factorize, then solve for the new `coef_`. If the factorization raises, the estimator keeps the new precision beside the old `coef_`, a posterior that was never anybody's, and a long-running agent goes on drawing from it. The sparse EB path had the milder version of the same thing: `prior.data *= prior_decay` left `cov_inv_` decayed by one step with no data to show for it.

Three of the four dense/sparse x `NormalRegressor`/EB paths were affected; `NormalRegressor`'s sparse path was already safe, its `prior_decay * self.cov_inv_` still producing a temporary. Now `cov_inv_` moves at the assignment that ends the update, or not at all.

The sparse fix is nearly free: a new data array over the same pattern costs `nnz`, against the addition that follows. **The dense fix costs a `d^2` copy, 15-22% of a single-row dense `NormalRegressor` update at `d >= 500`**, and inside the noise for the EB variant and for small `d`. Worth flagging since it undoes a deliberate optimization from #276. I took it because this is the one path where a raise can silently poison an estimator that outlives the call, and the dense path is not where this library scales, but it is a reasonable thing to argue about.

## Checks

- 2619 passed, 26 skipped
- Takahashi output verified exact to 1e-15 against both the scalar recursion and `np.linalg.inv`, across dense / tridiagonal / banded / sparse-gram / block-diagonal, at every combination of path, block width and panel width
- 8 new parametrized tests for the failed-update invariant, 6 of which fail before the fix; the 2 that pass are exactly the already-safe path
- pyright unchanged at its existing count, ruff clean