### PR TITLE
Let the Gaussian update fold a caller's diagonal shift into its own factorization

### DIFF
--- a/src/bayesianbandits/_eb_estimators.py
+++ b/src/bayesianbandits/_eb_estimators.py
@@ -75,7 +75,7 @@ class _StabilizedPriorMixin:
 
     def _hyperparams(self) -> tuple[float, ...]:
         """The hyperparameters the online step moves, ``alpha`` first."""
-        return (self.alpha,)
+        raise NotImplementedError
 
     def _start_stats(self) -> None:
         """Zero the running statistics, for a first observation."""

--- a/src/bayesianbandits/_eb_estimators.py
+++ b/src/bayesianbandits/_eb_estimators.py
@@ -40,7 +40,276 @@ from ._sparse_bayesian_linear_regression import (
 )
 
 
-class EmpiricalBayesNormalRegressor(NormalRegressor):
+class _StabilizedPriorMixin:
+    """Stabilized forgetting for the EB estimators whose posterior precision
+    is ``_prior_scalar · I + data``.
+
+    Owns the ``partial_fit``/``decay`` bookkeeping that every such
+    estimator shares: advancing ``_prior_scalar`` by ``γⁿ`` with
+    ``(1 - γⁿ)·alpha`` re-injected (Kulhavy & Zarrop 1993), rolling the
+    advance back when the base-class update raises, starting the EB
+    state when ``sample()`` initialized the prior before any fit, and
+    the in-place diagonal shifts.  The estimator supplies the hooks:
+    what to book for ``_fit_helper``, its running statistics, and the
+    online EB step itself.
+    """
+
+    sparse: bool
+    cov_inv_: Any
+    alpha: float
+    learning_rate: float
+    _factor_hint: Any
+    _prior_scalar: float
+    _effective_n: float
+    eb_updates_rejected_: int
+    n_eb_iterations_: int
+    eb_converged_: bool
+
+    # ---- hooks -----------------------------------------------------------
+
+    def _book_update(self, prior_decay: float, had_prior_scalar: bool) -> None:
+        """Stash what ``_fit_helper`` folds into the coming update."""
+
+    def _unbook_update(self) -> None:
+        """Clear the stash, whether or not the update succeeded."""
+
+    def _hyperparams(self) -> tuple[float, ...]:
+        """The hyperparameters the online step moves, ``alpha`` first."""
+        return (self.alpha,)
+
+    def _start_stats(self) -> None:
+        """Zero the running statistics, for a first observation."""
+        raise NotImplementedError
+
+    def _update_stats(
+        self,
+        X: Union[NDArray[Any], csc_array],
+        y: NDArray[Any],
+        prior_decay: float,
+        sample_weight: Optional[NDArray[Any]],
+    ) -> None:
+        """Decay the running statistics by ``prior_decay`` and add the batch."""
+        raise NotImplementedError
+
+    def _decay_stats(self, prior_decay: float) -> None:
+        raise NotImplementedError
+
+    def _online_eb_step(self, old: tuple[float, ...]) -> None:
+        """Retune from the running statistics and correct the precision,
+        given the hyperparameters the stored posterior was built under."""
+        raise NotImplementedError
+
+    # ---- template --------------------------------------------------------
+
+    def partial_fit(
+        self,
+        X: Union[NDArray[Any], csc_array],
+        y: NDArray[Any],
+        sample_weight: Optional[NDArray[Any]] = None,
+    ) -> Self:
+        """
+        Incrementally update the posterior and retune the hyperparameters.
+
+        Performs the base-class recursive Bayesian update, then one
+        online EB step from the running statistics, and corrects the
+        precision to the retuned hyperparameters.
+
+        When ``learning_rate < 1``, stabilized forgetting (Kulhavy &
+        Zarrop 1993) re-injects ``(1 - γⁿ)·alpha`` into the precision
+        diagonal so that the prior contribution converges to ``alpha``
+        instead of decaying to zero.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training data.
+        y : array-like of shape (n_samples,)
+            Target values.
+        sample_weight : array-like of shape (n_samples,), optional
+            Individual weights for each sample. If None, all samples
+            are given weight 1.0.
+
+        Returns
+        -------
+        self
+            Updated estimator with retuned hyperparameters.
+
+        See Also
+        --------
+        fit : Fit from scratch with the full EB iteration loop.
+        decay : Increase uncertainty without observing new data.
+        """
+        had_prior_scalar = hasattr(self, "_prior_scalar")
+        prior_scalar_old = self.__dict__.get("_prior_scalar")
+
+        n_samples = X.shape[0] if hasattr(X, "shape") else len(X)  # type: ignore[arg-type]
+        prior_decay = self.learning_rate**n_samples
+
+        if had_prior_scalar:
+            self._prior_scalar = (
+                prior_decay * self._prior_scalar + (1 - prior_decay) * self.alpha
+            )
+        self._book_update(prior_decay, had_prior_scalar)
+        old = self._hyperparams()
+
+        try:
+            result = cast(Any, super()).partial_fit(X, y, sample_weight)
+        except Exception:
+            # cov_inv_ never moved, so an advanced _prior_scalar would name a
+            # prior contribution the precision does not have.
+            self._restore_prior_scalar(prior_scalar_old)
+            raise
+        finally:
+            self._unbook_update()
+
+        if not had_prior_scalar:
+            if hasattr(self, "_prior_scalar"):
+                # fit() ran inside super().partial_fit() and did the EB loop.
+                return result
+
+            # sample()/predict() previously called _initialize_prior, so the
+            # base class took the incremental path instead of fit(). The
+            # precision is prior_decay·alpha_old·I + data; start the EB
+            # state here, including what the EB loop would have reported.
+            self._prior_scalar = prior_decay * old[0]
+            self.eb_updates_rejected_ = 0
+            self.n_eb_iterations_ = 0
+            self.eb_converged_ = False
+            self._start_stats()
+
+        X_fit, y = check_X_y(
+            X,  # type: ignore
+            y,
+            copy=False,
+            ensure_2d=True,
+            dtype=np.float64,
+            accept_sparse="csc" if self.sparse else False,
+        )
+
+        self._update_stats(X_fit, y, prior_decay, sample_weight)
+        self._online_eb_step(old)
+
+        return result
+
+    def decay(
+        self,
+        X: Union[NDArray[Any], csc_array],
+        *,
+        decay_rate: Optional[float] = None,
+    ) -> None:
+        """
+        Decay the precision matrix with stabilized prior re-injection.
+
+        Applies ``Λ_new = γⁿ·Λ_old`` and re-injects ``(1 - γⁿ)·alpha``
+        onto the diagonal (Kulhavy & Zarrop 1993), so the prior's
+        contribution converges to ``alpha`` rather than zero. The
+        running statistics behind the online EB step decay alongside.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Used only for its number of rows ``n``.
+        decay_rate : float, default=None
+            Decay factor in (0, 1]. If None, uses ``learning_rate``.
+
+        See Also
+        --------
+        partial_fit : Update the model with new observations.
+        """
+        if not hasattr(self, "coef_"):
+            return
+
+        if decay_rate is None:
+            decay_rate = self.learning_rate
+
+        assert X.shape is not None
+        prior_decay = decay_rate ** X.shape[0]
+
+        prior_reinjection = 0.0
+        if hasattr(self, "_prior_scalar"):
+            self._prior_scalar = (
+                prior_decay * self._prior_scalar + (1 - prior_decay) * self.alpha
+            )
+            prior_reinjection = (1 - prior_decay) * self.alpha
+        if hasattr(self, "_effective_n"):
+            self._decay_stats(prior_decay)
+
+        # Base class applies uniform decay: cov_inv_ *= prior_decay
+        cast(Any, super()).decay(X, decay_rate=decay_rate)
+
+        self._reinject_prior(prior_reinjection)
+
+    # ---- shared mechanics -------------------------------------------------
+
+    def _row_weights(
+        self, n_samples: int, sample_weight: Optional[NDArray[Any]]
+    ) -> NDArray[np.float64]:
+        """The effective row weights the precision is built with: sample
+        weight times within-batch decay. Every EB statistic that is set
+        against the precision has to carry the same weights."""
+        return compute_effective_weights(n_samples, sample_weight, self.learning_rate)
+
+    def _restore_prior_scalar(self, prior_scalar_old: Optional[float]) -> None:
+        """Put ``_prior_scalar`` back where a failed update found it, and
+        remove it entirely if the update was the one that would have
+        created it."""
+        if prior_scalar_old is None:
+            self.__dict__.pop("_prior_scalar", None)
+        else:
+            self.__dict__["_prior_scalar"] = prior_scalar_old
+
+    def _drop_factor(self) -> None:
+        """Drop the cached factor, keeping it as the hint ``_sparse_factor``
+        refactorizes from: a diagonal shift leaves the pattern alone."""
+        factor = self.__dict__.pop("_precision_factor")
+        if self.sparse:
+            self._factor_hint = factor
+
+    def _reinject_prior(self, prior_reinjection: float) -> None:
+        """Add stabilized prior re-injection to the precision diagonal.
+
+        After exponential decay the prior contribution shrinks toward zero.
+        This adds back ``prior_reinjection`` to every diagonal entry so that
+        the prior converges to ``alpha`` instead (Kulhavy & Zarrop, 1993).
+        """
+        if prior_reinjection == 0.0:
+            return
+        if self.sparse:
+            cov_inv = cast(csc_array, self.cov_inv_)
+            self._shift_diagonal(cov_inv, prior_reinjection)
+            self.cov_inv_ = cov_inv
+        else:
+            diag_idx = np.diag_indices_from(self.cov_inv_)
+            self.cov_inv_[diag_idx] += prior_reinjection
+        if "_precision_factor" in self.__dict__:
+            self._drop_factor()
+
+    def _shift_diagonal(self, cov_inv: csc_array, shift: float) -> None:
+        """``cov_inv += shift * I`` in place.
+
+        The diagonal is always stored (the prior is ``alpha * I``), so
+        its positions, found once per pattern by running ``diagonal()``
+        over entry numbers and cached against the index array's
+        identity, make this a gather-add; ``setdiag`` relocates it on
+        every call.
+        """
+        if shift == 0.0:
+            return
+        cached = self.__dict__.get("_diag_pos")
+        if cached is None or cached[0] is not cov_inv.indices:
+            values = cov_inv.data
+            cov_inv.data = np.arange(1, values.size + 1, dtype=np.float64)
+            pos = cov_inv.diagonal().astype(np.intp) - 1
+            cov_inv.data = values
+            if np.any(pos < 0):  # missing diagonal entry: let scipy insert it
+                cov_inv.setdiag(cov_inv.diagonal() + shift)
+                return
+            cached = (cov_inv.indices, pos)
+            self._diag_pos = cached
+        cov_inv.data[cached[1]] += shift
+
+
+class EmpiricalBayesNormalRegressor(_StabilizedPriorMixin, NormalRegressor):
     """Bayesian linear regression with empirical Bayes hyperparameter tuning.
 
     Extends :class:`NormalRegressor` with automatic optimization of the
@@ -276,13 +545,6 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
         if update.rejected:
             self.eb_updates_rejected_ += 1
 
-    def _row_weights(
-        self, n_samples: int, sample_weight: Optional[NDArray[Any]]
-    ) -> NDArray[np.float64]:
-        """The effective row weights ``_fit_helper`` builds the precision
-        with: sample weight times within-batch decay."""
-        return compute_effective_weights(n_samples, sample_weight, self.learning_rate)
-
     def _seed_stats(
         self,
         X: Union[NDArray[Any], csc_array],
@@ -294,7 +556,7 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
             X, y, self._row_weights(y.shape[0], sample_weight)
         )
 
-    def _accumulate_stats(
+    def _update_stats(
         self,
         X: Union[NDArray[Any], csc_array],
         y: NDArray[Any],
@@ -510,56 +772,6 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
         else:
             self.cov_inv_ *= ratio
 
-    def _drop_factor(self) -> None:
-        """Drop the cached factor, keeping it as the hint ``_sparse_factor``
-        refactorizes from: a diagonal shift leaves the pattern alone."""
-        factor = self.__dict__.pop("_precision_factor")
-        if self.sparse:
-            self._factor_hint = factor
-
-    def _reinject_prior(self, prior_reinjection: float) -> None:
-        """Add stabilized prior re-injection to the precision diagonal.
-
-        After exponential decay the prior contribution shrinks toward zero.
-        This adds back ``prior_reinjection`` to every diagonal entry so that
-        the prior converges to ``alpha`` instead (Kulhavy & Zarrop, 1993).
-        """
-        if prior_reinjection == 0.0:
-            return
-        if self.sparse:
-            cov_inv = cast(csc_array, self.cov_inv_)
-            self._shift_diagonal(cov_inv, prior_reinjection)
-            self.cov_inv_ = cov_inv
-        else:
-            diag_idx = np.diag_indices_from(self.cov_inv_)
-            self.cov_inv_[diag_idx] += prior_reinjection
-        if "_precision_factor" in self.__dict__:
-            self._drop_factor()
-
-    def _shift_diagonal(self, cov_inv: csc_array, shift: float) -> None:
-        """``cov_inv += shift * I`` in place.
-
-        The diagonal is always stored (the prior is ``alpha * I``), so
-        its positions, found once per pattern by running ``diagonal()``
-        over entry numbers and cached against the index array's
-        identity, make this a gather-add; ``setdiag`` relocates it on
-        every call.
-        """
-        if shift == 0.0:
-            return
-        cached = self.__dict__.get("_diag_pos")
-        if cached is None or cached[0] is not cov_inv.indices:
-            values = cov_inv.data
-            cov_inv.data = np.arange(1, values.size + 1, dtype=np.float64)
-            pos = cov_inv.diagonal().astype(np.intp) - 1
-            cov_inv.data = values
-            if np.any(pos < 0):  # missing diagonal entry: let scipy insert it
-                cov_inv.setdiag(cov_inv.diagonal() + shift)
-                return
-            cached = (cov_inv.indices, pos)
-            self._diag_pos = cached
-        cov_inv.data[cached[1]] += shift
-
     @_invalidate_cached_properties
     def _fit_helper(
         self,
@@ -669,187 +881,43 @@ class EmpiricalBayesNormalRegressor(NormalRegressor):
         self.cov_inv_ = cov_inv
         self.coef_ = coef
 
-    def partial_fit(
-        self,
-        X: Union[NDArray[Any], csc_array],
-        y: NDArray[Any],
-        sample_weight: Optional[NDArray[Any]] = None,
-    ) -> Self:
-        """
-        Incrementally update the posterior and retune hyperparameters.
-
-        Performs a recursive Bayesian update (delegating to
-        ``NormalRegressor.partial_fit``), then runs one online MacKay
-        step to adjust ``alpha`` and ``beta`` using accumulated
-        sufficient statistics. The precision matrix is corrected to
-        reflect the updated hyperparameters.
-
-        When ``learning_rate < 1``, stabilized forgetting (Kulhavy &
-        Zarrop 1993) re-injects ``(1 - γ^n)·α`` into the precision
-        diagonal so that the prior contribution converges to ``alpha``
-        instead of decaying to zero.
-
-        Parameters
-        ----------
-        X : array-like of shape (n_samples, n_features)
-            Training data.
-        y : array-like of shape (n_samples,)
-            Target values.
-        sample_weight : array-like of shape (n_samples,), optional
-            Individual weights for each sample. If None, all samples
-            are given weight 1.0.
-
-        Returns
-        -------
-        self : EmpiricalBayesNormalRegressor
-            Updated estimator with retuned hyperparameters.
-
-        See Also
-        --------
-        fit : Fit from scratch with full EB iteration loop.
-        decay : Increase uncertainty without observing new data.
-        """
-        had_prior_scalar = hasattr(self, "_prior_scalar")
-
-        n_samples = X.shape[0] if hasattr(X, "shape") else len(X)  # type: ignore[arg-type]
-        prior_decay = self.learning_rate**n_samples
-
-        if had_prior_scalar:
-            # Stabilized forgetting: decay the tracked prior contribution but
-            # re-inject (1 - prior_decay) * alpha so it converges to alpha
-            # instead of decaying to zero.  This ensures the EB-tuned prior
-            # always regularizes new or dormant coefficients.
-            self._prior_scalar = (
-                prior_decay * self._prior_scalar + (1 - prior_decay) * self.alpha
-            )
-
-        # Store reinjection amount for _fit_helper to fold in.
-        # When > 0, _fit_helper adds this to the precision diagonal during
-        # construction, avoiding a separate _reinject_prior + refactorization.
+    def _book_update(self, prior_decay: float, had_prior_scalar: bool) -> None:
+        # _fit_helper adds the re-injection to the precision diagonal as it
+        # builds it, avoiding a separate _reinject_prior + refactorization,
+        # and takes any solve the last MacKay correction left pending as
+        # the prior information vector: it is Λ·coef_ exactly.  Popped here,
+        # before super()'s check_is_fitted would read coef_ and force it.
         self._pending_reinjection = (
             (1 - prior_decay) * self.alpha if had_prior_scalar else 0.0
         )
-
-        # Hand any solve the last MacKay correction left pending to
-        # _fit_helper as the prior information vector -- it is Λ·coef_
-        # exactly.  Taken out of __dict__ here, before super()'s
-        # check_is_fitted would read coef_ and force the solve.
         self._pending_prior_eta = self.__dict__.pop("_pending_eta", None)
 
-        alpha_old = self.alpha
-        beta_old = self.beta
+    def _unbook_update(self) -> None:
+        self._pending_reinjection = 0.0
+        if self._pending_prior_eta is not None:
+            # The update raised before _fit_helper consumed it; hand it
+            # back so coef_ stays solvable and the correction is not
+            # silently dropped.
+            self.__dict__["_pending_eta"] = self._pending_prior_eta
+            self._pending_prior_eta = None
 
-        try:
-            result = super().partial_fit(X, y, sample_weight)
-        finally:
-            self._pending_reinjection = 0.0
-            if self._pending_prior_eta is not None:
-                # The update raised before _fit_helper consumed it; hand
-                # it back so coef_ stays solvable and the correction is
-                # not silently dropped.
-                self.__dict__["_pending_eta"] = self._pending_prior_eta
-                self._pending_prior_eta = None
+    def _hyperparams(self) -> tuple[float, float]:
+        return (self.alpha, self.beta)
 
-        if not had_prior_scalar:
-            if hasattr(self, "_prior_scalar"):
-                # fit() was called by super().partial_fit() and already
-                # set _prior_scalar, sufficient stats, and ran the EB loop.
-                return result
+    def _start_stats(self) -> None:
+        self._effective_n = 0.0
+        self._eff_yTy = 0.0
+        self._eff_XTy = np.zeros(self.cov_inv_.shape[0], dtype=np.float64)
 
-            # sample() previously called _initialize_prior (setting coef_),
-            # so super().partial_fit() did an incremental update instead of
-            # calling fit(). Initialize EB state for the first time.
-            #
-            # After the incremental update the precision matrix is:
-            #   cov_inv_ = prior_decay * alpha_old * I + beta_old * X^T X
-            # so the prior contribution to the diagonal is prior_decay * alpha_old.
-            self._prior_scalar = prior_decay * alpha_old
-            # fit() never ran on this path, so the EB reporting state that
-            # _eb_mackay_step_online maintains has to start here.
-            self.eb_updates_rejected_ = 0
-            self.n_eb_iterations_ = 0
-            self.eb_converged_ = False
+    def _decay_stats(self, prior_decay: float) -> None:
+        self._effective_n *= prior_decay
+        self._eff_yTy *= prior_decay
+        self._eff_XTy *= prior_decay
 
-        X_fit, y = check_X_y(
-            X,  # type: ignore
-            y,
-            copy=False,
-            ensure_2d=True,
-            dtype=np.float64,
-            accept_sparse="csc" if self.sparse else False,
-        )
-
-        if not had_prior_scalar:
-            # First observation — initialize sufficient statistics.
-            self._effective_n, self._eff_yTy, self._eff_XTy = self._seed_stats(
-                X_fit, y, sample_weight
-            )
-        else:
-            # Accumulate sufficient statistics for the beta update.
-            self._accumulate_stats(X_fit, y, prior_decay, sample_weight)
-
+    def _online_eb_step(self, old: tuple[float, ...]) -> None:
+        alpha_old, beta_old = old
         self._eb_mackay_step_online()
         self._correct_precision(alpha_old, beta_old)
-
-        return result
-
-    def decay(
-        self,
-        X: Union[NDArray[Any], csc_array],
-        *,
-        decay_rate: Optional[float] = None,
-    ) -> None:
-        """
-        Decay the precision matrix with stabilized prior re-injection.
-
-        Applies exponential forgetting ``Λ_new = γ^n · Λ_old`` and
-        then re-injects ``(1 - γ^n)·α`` onto the diagonal, following
-        stabilized forgetting (Kulhavy & Zarrop 1993). This ensures
-        the prior contribution to the precision converges to ``alpha``
-        rather than decaying to zero under repeated decay steps.
-
-        Sufficient statistics (``_effective_n``, ``_eff_yTy``,
-        ``_eff_XTy``) used for the online MacKay beta update are
-        also decayed.
-
-        Parameters
-        ----------
-        X : array-like of shape (n_samples, n_features)
-            Used only to determine the number of time steps ``n`` for
-            the decay exponent ``γ^n``. The actual feature values are
-            not used.
-        decay_rate : float, default=None
-            Decay factor :math:`\\gamma` in (0, 1]. If None, uses
-            ``self.learning_rate``.
-
-        See Also
-        --------
-        partial_fit : Update the model with new observations.
-        """
-        if not hasattr(self, "coef_"):
-            return
-
-        if decay_rate is None:
-            decay_rate = self.learning_rate
-
-        assert X.shape is not None
-        prior_decay = decay_rate ** X.shape[0]
-
-        prior_reinjection = 0.0
-        if hasattr(self, "_prior_scalar"):
-            self._prior_scalar = (
-                prior_decay * self._prior_scalar + (1 - prior_decay) * self.alpha
-            )
-            prior_reinjection = (1 - prior_decay) * self.alpha
-        if hasattr(self, "_effective_n"):
-            self._effective_n *= prior_decay
-            self._eff_yTy *= prior_decay
-            self._eff_XTy *= prior_decay
-
-        # Base class applies uniform decay: cov_inv_ *= prior_decay
-        super().decay(X, decay_rate=decay_rate)
-
-        self._reinject_prior(prior_reinjection)
 
 
 class EmpiricalBayesDirichletClassifier(DirichletClassifier):

--- a/src/bayesianbandits/_gaussian.py
+++ b/src/bayesianbandits/_gaussian.py
@@ -7,7 +7,7 @@ from numpy.polynomial.hermite_e import hermegauss
 from numpy.typing import NDArray
 from scipy.linalg import cho_factor, cho_solve, solve_triangular
 from scipy.linalg.blas import dgemv, dsymv, dsyrk
-from scipy.sparse import csc_array
+from scipy.sparse import csc_array, eye
 from scipy.sparse import issparse as sp_issparse
 from scipy.special import expit
 
@@ -134,6 +134,64 @@ def _eval_link(link: LinkFunction, eta: NDArray[np.float64]) -> LinkOutput:
         raise ValueError(f"Unknown link function: {link}")
 
 
+def _prior_diag_shift(
+    prior_decay: float, prior_floor: float, prior_shift: float
+) -> float:
+    """Total shift to the decayed prior precision's diagonal.
+
+    ``(1 - γⁿ)·prior_floor`` is the stabilized-forgetting re-injection
+    (Kulhavy & Zarrop 1993); ``γⁿ·prior_shift`` is a shift the caller
+    owed the prior *before* decay (an empirical-Bayes change to the
+    prior precision, deferred to this update), so it decays with the
+    rest of the prior.
+    """
+    return (1.0 - prior_decay) * prior_floor + prior_decay * prior_shift
+
+
+def _stabilized_prior_dense(
+    prior_prec_F: NDArray[Any],
+    prior_precision: NDArray[Any],
+    prior_decay: float,
+    prior_floor: float,
+    prior_shift: float,
+) -> NDArray[Any]:
+    """Add :func:`_prior_diag_shift` to the diagonal of the decayed prior
+    precision.
+
+    Only the precision is shifted, never the prior's eta term, so the
+    re-injected prior is centered at zero: it shrinks dormant
+    coefficients rather than pinning them where they are.  Without
+    decay ``prior_prec_F`` may be the caller's own array; it is copied
+    before being touched.
+    """
+    shift = _prior_diag_shift(prior_decay, prior_floor, prior_shift)
+    if shift == 0.0:
+        return prior_prec_F
+    if np.shares_memory(prior_prec_F, prior_precision):
+        prior_prec_F = prior_prec_F.copy(order="F")
+    prior_prec_F[np.diag_indices_from(prior_prec_F)] += shift
+    return prior_prec_F
+
+
+def _stabilized_prior_sparse(
+    prior_precision_scaled: csc_array,
+    prior_decay: float,
+    prior_floor: float,
+    prior_shift: float,
+) -> csc_array:
+    """Sparse counterpart of :func:`_stabilized_prior_dense`.
+
+    Returns the input object itself when there is nothing to add, so
+    callers can detect by identity whether a cached factor is stale.
+    """
+    shift = _prior_diag_shift(prior_decay, prior_floor, prior_shift)
+    if shift == 0.0:
+        return prior_precision_scaled
+    assert prior_precision_scaled.shape is not None
+    n = prior_precision_scaled.shape[0]
+    return csc_array(prior_precision_scaled + shift * eye(n, format="csc"))
+
+
 def _irls_dense(
     X: NDArray[np.float64],
     y: NDArray[np.float64],
@@ -143,6 +201,8 @@ def _irls_dense(
     link: LinkFunction,
     effective_weights: NDArray[np.float64],
     prior_decay: float,
+    prior_floor: float,
+    prior_shift: float,
     n_iter: int,
     tol: float,
 ) -> GaussianPosterior:
@@ -156,7 +216,13 @@ def _irls_dense(
     prior_eta_scaled = dsymv(prior_decay, prior_precision, prior_mean)
 
     # F-order copy of prior precision for dsyrk accumulation buffer
-    prior_prec_F = np.asfortranarray(prior_precision_scaled)
+    prior_prec_F = _stabilized_prior_dense(
+        np.asfortranarray(prior_precision_scaled),
+        prior_precision,
+        prior_decay,
+        prior_floor,
+        prior_shift,
+    )
 
     X_weighted = np.empty_like(X)
     W_sqrt_buf = np.empty(n_samples, dtype=np.float64)
@@ -215,10 +281,20 @@ def _irls_sparse(
     link: LinkFunction,
     effective_weights: NDArray[np.float64],
     prior_decay: float,
+    prior_floor: float,
+    prior_shift: float,
     n_iter: int,
     tol: float,
+    prior_factor: Optional[Any] = None,
 ) -> GaussianPosterior:
-    """Sparse IRLS loop using CHOLMOD/SuperLU factorization."""
+    """Sparse IRLS loop using CHOLMOD/SuperLU factorization.
+
+    ``prior_factor``, when given, seeds the posterior's factorization:
+    ``refactorize`` reuses its symbolic analysis whenever the posterior
+    keeps the prior's sparsity pattern (every update after the first
+    touching a given feature set), and falls back to a fresh one when
+    the pattern grew.
+    """
     from ._sparse_bayesian_linear_regression import create_sparse_factor
 
     no_decay = prior_decay == 1.0
@@ -230,10 +306,13 @@ def _irls_sparse(
         if no_decay
         else prior_decay * (prior_precision @ prior_mean)
     )
+    prior_precision_scaled = _stabilized_prior_sparse(
+        prior_precision_scaled, prior_decay, prior_floor, prior_shift
+    )
 
     coef = prior_mean.copy()
     coef_old = coef
-    sparse_factor = None
+    sparse_factor = prior_factor
     posterior_precision = prior_precision
 
     for iteration in range(n_iter):
@@ -278,8 +357,11 @@ def update_gaussian_posterior_laplace(
     sample_weight: Optional[NDArray[np.float64]] = None,
     learning_rate: float = 1.0,
     sparse: bool = False,
+    prior_floor: float = 0.0,
+    prior_shift: float = 0.0,
     n_iter: int = 3,
     tol: float = 1e-4,
+    prior_factor: Optional[Any] = None,
 ) -> GaussianPosterior:
     """
     Update Gaussian posterior using Laplace approximation (IRLS).
@@ -356,8 +438,11 @@ def update_gaussian_posterior_laplace(
             link=link,
             effective_weights=effective_weights,
             prior_decay=prior_decay,
+            prior_floor=prior_floor,
+            prior_shift=prior_shift,
             n_iter=n_iter,
             tol=tol,
+            prior_factor=prior_factor,
         )
     else:
         return _irls_dense(
@@ -368,6 +453,8 @@ def update_gaussian_posterior_laplace(
             link=link,
             effective_weights=effective_weights,
             prior_decay=prior_decay,
+            prior_floor=prior_floor,
+            prior_shift=prior_shift,
             n_iter=n_iter,
             tol=tol,
         )
@@ -388,9 +475,21 @@ class PosteriorApproximator(Protocol):
     Notes
     -----
     ``prior_factor``, when provided, is a factorization of
-    ``prior_precision`` cached by the caller from the previous update.
-    Implementations may use it to skip refactorizing the prior; they
-    must not mutate it and may ignore it entirely.
+    ``prior_precision`` handed over by the caller from the previous
+    update. Implementations may solve against it, refactorize it in
+    place for the posterior (the caller no longer holds it as the
+    prior's factor), or ignore it entirely.
+
+    ``prior_floor``, when nonzero, requests stabilized forgetting
+    (Kulhavy & Zarrop 1993): after decaying the prior precision by
+    ``γⁿ``, ``(1 - γⁿ)·prior_floor`` is added back to its diagonal so
+    the prior's contribution converges to ``prior_floor·I`` instead of
+    vanishing.  ``prior_shift`` is a further diagonal shift the caller
+    owed the prior before decay (it is scaled by ``γⁿ`` with the rest of
+    the prior): how an empirical-Bayes estimator applies a change to its
+    prior precision without a factorization of its own.  Both shift the
+    precision only, never the prior's eta term, so the shifted prior is
+    centered at zero.
     """
 
     def update_posterior(
@@ -404,6 +503,8 @@ class PosteriorApproximator(Protocol):
         learning_rate: float,
         sparse: bool,
         prior_factor: Optional[Any] = None,
+        prior_floor: float = 0.0,
+        prior_shift: float = 0.0,
     ) -> GaussianPosterior: ...
 
 
@@ -473,8 +574,9 @@ class LaplaceApproximator(MemoryUsageMixin, PosteriorApproximator):
         learning_rate: float,
         sparse: bool,
         prior_factor: Optional[Any] = None,
+        prior_floor: float = 0.0,
+        prior_shift: float = 0.0,
     ) -> GaussianPosterior:
-        # prior_factor unused: IRLS builds its own factor each call.
         return update_gaussian_posterior_laplace(
             X,
             y,
@@ -484,8 +586,11 @@ class LaplaceApproximator(MemoryUsageMixin, PosteriorApproximator):
             sample_weight=sample_weight,
             learning_rate=learning_rate,
             sparse=sparse,
+            prior_floor=prior_floor,
+            prior_shift=prior_shift,
             n_iter=self.n_iter,
             tol=self.tol,
+            prior_factor=prior_factor,
         )
 
 
@@ -635,6 +740,8 @@ def _rvga_dense(
     link: LinkFunction,
     effective_weights: NDArray[np.float64],
     prior_decay: float,
+    prior_floor: float,
+    prior_shift: float,
     n_iter: int,
     tol: float,
     n_gh_nodes: int,
@@ -648,7 +755,13 @@ def _rvga_dense(
         prior_precision if no_decay else prior_decay * prior_precision
     )
     prior_eta_scaled = dsymv(prior_decay, prior_precision, prior_mean)
-    prior_prec_F = np.asfortranarray(prior_precision_scaled)
+    prior_prec_F = _stabilized_prior_dense(
+        np.asfortranarray(prior_precision_scaled),
+        prior_precision,
+        prior_decay,
+        prior_floor,
+        prior_shift,
+    )
 
     X_weighted = np.empty_like(X)
     m_buf = np.empty(n_samples, dtype=np.float64)
@@ -721,6 +834,8 @@ def _rvga_sparse(
     link: LinkFunction,
     effective_weights: NDArray[np.float64],
     prior_decay: float,
+    prior_floor: float,
+    prior_shift: float,
     n_iter: int,
     tol: float,
     n_gh_nodes: int,
@@ -751,6 +866,14 @@ def _rvga_sparse(
         from ._sparse_bayesian_linear_regression import scale_factor
 
         prior_factor = scale_factor(prior_factor, prior_decay)
+    shifted = _stabilized_prior_sparse(
+        prior_precision_scaled, prior_decay, prior_floor, prior_shift
+    )
+    if shifted is not prior_precision_scaled:
+        # A diagonal shift is a rank-p change no cheap factor update
+        # covers; the Gram matrix refactorizes from scratch.
+        prior_precision_scaled = shifted
+        prior_factor = None
 
     # Precompute G = X A^{-1} X^T (n×n, computed once).
     # Woodbury: Λ = A + X^T diag(W) X
@@ -759,7 +882,9 @@ def _rvga_sparse(
     diag_G = np.diag(G).copy()
 
     coef = prior_mean.copy()
-    sparse_factor = None
+    # The Gram matrix was the last use of the prior's factor as such;
+    # from here it seeds the posterior's (refactorize checks the pattern).
+    sparse_factor = prior_factor
     use_probit_path = use_probit and link == "logit"
     W_prev: Optional[NDArray[np.float64]] = None
 
@@ -827,6 +952,8 @@ def update_gaussian_posterior_rvga(
     sample_weight: Optional[NDArray[np.float64]] = None,
     learning_rate: float = 1.0,
     sparse: bool = False,
+    prior_floor: float = 0.0,
+    prior_shift: float = 0.0,
     n_iter: int = 5,
     tol: float = 1e-4,
     n_gh_nodes: int = 20,
@@ -874,6 +1001,8 @@ def update_gaussian_posterior_rvga(
                 ),
                 learning_rate=learning_rate,
                 sparse=True,
+                prior_floor=prior_floor,
+                prior_shift=prior_shift if start == 0 else 0.0,
                 n_iter=n_iter,
                 tol=tol,
                 n_gh_nodes=n_gh_nodes,
@@ -896,6 +1025,8 @@ def update_gaussian_posterior_rvga(
             link=link,
             effective_weights=effective_weights,
             prior_decay=prior_decay,
+            prior_floor=prior_floor,
+            prior_shift=prior_shift,
             n_iter=n_iter,
             tol=tol,
             n_gh_nodes=n_gh_nodes,
@@ -911,6 +1042,8 @@ def update_gaussian_posterior_rvga(
             link=link,
             effective_weights=effective_weights,
             prior_decay=prior_decay,
+            prior_floor=prior_floor,
+            prior_shift=prior_shift,
             n_iter=n_iter,
             tol=tol,
             n_gh_nodes=n_gh_nodes,
@@ -981,6 +1114,8 @@ class RVGAApproximator(MemoryUsageMixin, PosteriorApproximator):
         learning_rate: float,
         sparse: bool,
         prior_factor: Optional[Any] = None,
+        prior_floor: float = 0.0,
+        prior_shift: float = 0.0,
     ) -> GaussianPosterior:
         return update_gaussian_posterior_rvga(
             X,
@@ -991,6 +1126,8 @@ class RVGAApproximator(MemoryUsageMixin, PosteriorApproximator):
             sample_weight=sample_weight,
             learning_rate=learning_rate,
             sparse=sparse,
+            prior_floor=prior_floor,
+            prior_shift=prior_shift,
             n_iter=self.n_iter,
             tol=self.tol,
             n_gh_nodes=self.n_gh_nodes,

--- a/tests/test_eb_estimators.py
+++ b/tests/test_eb_estimators.py
@@ -1649,6 +1649,7 @@ class TestFailedUpdateLeavesEstimatorIntact:
 
         prec_before = _dense(est.cov_inv_)
         coef_before = est.coef_.copy()
+        prior_scalar_before = est.__dict__.get("_prior_scalar")
 
         if sparse:
             # Inherited, so patching it on the base covers both estimators.
@@ -1673,6 +1674,24 @@ class TestFailedUpdateLeavesEstimatorIntact:
         # Only the upper triangle of the dense precision is meaningful.
         assert np.array_equal(np.triu(_dense(est.cov_inv_)), np.triu(prec_before))
         assert np.array_equal(est.coef_, coef_before)
+        # Advanced before the update, so it has to be put back after a failure.
+        assert est.__dict__.get("_prior_scalar") == prior_scalar_before
+
+    def test_a_first_ever_partial_fit_that_raises_leaves_no_prior_scalar(self):
+        rng = np.random.default_rng(0)
+        X = rng.standard_normal((10, 4))
+        y = rng.standard_normal(10)
+        est = EmpiricalBayesNormalRegressor(learning_rate=0.9)
+
+        with mock.patch.object(
+            EmpiricalBayesNormalRegressor,
+            "fit",
+            side_effect=np.linalg.LinAlgError("boom"),
+        ):
+            with pytest.raises(np.linalg.LinAlgError):
+                est.partial_fit(X, y)
+
+        assert not hasattr(est, "_prior_scalar")
 
 
 @pytest.mark.parametrize("sparse", [True, False])

--- a/tests/test_prior_floor.py
+++ b/tests/test_prior_floor.py
@@ -1,0 +1,197 @@
+"""``prior_floor`` (stabilized forgetting re-injection) in the Laplace
+and R-VGA posterior updates."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+from scipy.sparse import csc_array
+from scipy.special import expit
+
+from bayesianbandits._gaussian import (
+    update_gaussian_posterior_laplace,
+    update_gaussian_posterior_rvga,
+)
+
+
+def _data(seed: int = 0, n: int = 30, p: int = 4):
+    rng = np.random.default_rng(seed)
+    X = rng.normal(size=(n, p))
+    y = rng.binomial(1, expit(X @ rng.normal(size=p))).astype(np.float64)
+    prior_mean = rng.normal(size=p)
+    A = rng.normal(size=(p, p))
+    prior_precision = A @ A.T + p * np.eye(p)
+    return X, y, prior_mean, prior_precision
+
+
+def _dense(a: Any) -> NDArray[np.float64]:
+    return np.asarray(a.toarray() if hasattr(a, "toarray") else a, dtype=np.float64)
+
+
+def _call(method: str, sparse: bool, X, y, prior_mean, prior_precision, **kw):
+    fn = (
+        update_gaussian_posterior_laplace
+        if method == "laplace"
+        else update_gaussian_posterior_rvga
+    )
+    if sparse:
+        X = csc_array(X)
+        prior_precision = csc_array(prior_precision)
+    post = fn(
+        X,
+        y,
+        prior_mean,
+        prior_precision,
+        link="logit",
+        sparse=sparse,
+        n_iter=10,
+        tol=1e-10,
+        **kw,
+    )
+    prec = _dense(post.precision)
+    return np.asarray(post.mean), np.triu(prec) + np.triu(prec, 1).T
+
+
+@pytest.mark.parametrize("method", ["laplace", "rvga"])
+@pytest.mark.parametrize("sparse", [False, True])
+class TestPriorFloor:
+    def test_zero_floor_is_a_no_op(self, method: str, sparse: bool) -> None:
+        X, y, m, P = _data()
+        a = _call(method, sparse, X, y, m, P, learning_rate=0.9)
+        b = _call(method, sparse, X, y, m, P, learning_rate=0.9, prior_floor=0.0)
+        np.testing.assert_allclose(a[0], b[0])
+        np.testing.assert_allclose(a[1], b[1])
+
+    def test_no_decay_ignores_floor(self, method: str, sparse: bool) -> None:
+        X, y, m, P = _data()
+        a = _call(method, sparse, X, y, m, P)
+        b = _call(method, sparse, X, y, m, P, prior_floor=5.0)
+        np.testing.assert_allclose(a[0], b[0])
+        np.testing.assert_allclose(a[1], b[1])
+
+    def test_equals_zero_centered_prior_shift(self, method: str, sparse: bool) -> None:
+        """Decay + floor == a single update whose prior is the product of
+        N(m, (γⁿP)⁻¹) and N(0, (sI)⁻¹) with s = (1 - γⁿ)·floor."""
+        X, y, m, P = _data()
+        lr, floor = 0.95, 2.0
+        n = X.shape[0]
+        g = lr**n
+        s = (1.0 - g) * floor
+
+        got = _call(method, sparse, X, y, m, P, learning_rate=lr, prior_floor=floor)
+
+        # Equivalent prior: precision γⁿP + sI, mean solving (γⁿP + sI) m' = γⁿP m.
+        P_eq = g * P + s * np.eye(P.shape[0])
+        m_eq = np.linalg.solve(P_eq, g * P @ m)
+        # Run with learning_rate=1 but the same per-row weights: the
+        # effective weights depend on learning_rate, so replicate them
+        # via sample_weight.
+        from bayesianbandits._estimators import compute_effective_weights
+
+        w = compute_effective_weights(n, None, lr)
+        want = _call(method, sparse, X, y, m_eq, P_eq, sample_weight=w)
+
+        np.testing.assert_allclose(got[0], want[0], atol=1e-8)
+        np.testing.assert_allclose(got[1], want[1], atol=1e-8)
+
+    def test_caller_prior_not_mutated(self, method: str, sparse: bool) -> None:
+        X, y, m, P = _data()
+        P_F = np.asfortranarray(P)
+        P_copy = P_F.copy()
+        _call(method, False, X, y, m, P_F, learning_rate=0.9, prior_floor=3.0)
+        np.testing.assert_array_equal(P_F, P_copy)
+
+
+@pytest.mark.parametrize("method", ["laplace", "rvga"])
+@pytest.mark.parametrize("sparse", [False, True])
+@pytest.mark.parametrize("lr", [1.0, 0.95])
+def test_prior_shift_is_a_zero_centered_precision_shift(
+    method: str, sparse: bool, lr: float
+) -> None:
+    """prior_shift adds γⁿ·shift to the decayed prior precision only:
+    equals an update from the product prior N(m, (γⁿP)⁻¹)·N(0, (γⁿs I)⁻¹).
+    With lr=1 the dense scaled prior aliases the caller's array, which
+    must come back untouched."""
+    X, y, m, P = _data()
+    n = X.shape[0]
+    g = lr**n
+    shift = 0.7
+    P_F = np.asfortranarray(P)
+    P_copy = P_F.copy()
+    got = _call(method, sparse, X, y, m, P_F, learning_rate=lr, prior_shift=shift)
+    np.testing.assert_array_equal(P_F, P_copy)
+
+    from bayesianbandits._estimators import compute_effective_weights
+
+    P_eq = g * P + g * shift * np.eye(P.shape[0])
+    m_eq = np.linalg.solve(P_eq, g * P @ m)
+    w = compute_effective_weights(n, None, lr)
+    want = _call(method, sparse, X, y, m_eq, P_eq, sample_weight=w)
+    np.testing.assert_allclose(got[0], want[0], atol=1e-8)
+    np.testing.assert_allclose(got[1], want[1], atol=1e-8)
+
+
+def test_rvga_sparse_chunked_shift_applies_once() -> None:
+    """Chunked R-VGA applies prior_shift on the first chunk only; later
+    chunks decay it with the rest of the prior."""
+    _, y, m, P = _data(n=40)
+    n = y.shape[0]
+    X = np.zeros((n, P.shape[0]))
+    lr, shift = 0.97, 0.7
+    one, chunked = (
+        update_gaussian_posterior_rvga(
+            csc_array(X),
+            y,
+            m,
+            csc_array(P),
+            link="logit",
+            sparse=True,
+            learning_rate=lr,
+            prior_shift=shift,
+            n_iter=3,
+            batch_size=bs,
+        )
+        for bs in (None, 7)
+    )
+    g = lr**n
+    want_prec = g * P + g * shift * np.eye(P.shape[0])
+    want_mean = np.linalg.solve(want_prec, g * P @ m)
+    for post in (one, chunked):
+        np.testing.assert_allclose(_dense(post.precision), want_prec, atol=1e-10)
+        np.testing.assert_allclose(_dense(post.mean), want_mean, atol=1e-10)
+
+
+def test_rvga_sparse_chunked_floor_composes() -> None:
+    """Minibatched R-VGA re-injects per chunk.  With no data signal
+    (all-zero X) the data Hessian vanishes and chunked must equal
+    one-shot exactly: precision γⁿP + (1 - γⁿ)·floor·I, and mean
+    solving that against γⁿ·P·m, because per-chunk re-injection
+    telescopes."""
+    _, y, m, P = _data(n=40)
+    n = y.shape[0]
+    X = np.zeros((n, P.shape[0]))
+    lr, floor = 0.97, 2.0
+    one, chunked = (
+        update_gaussian_posterior_rvga(
+            csc_array(X),
+            y,
+            m,
+            csc_array(P),
+            link="logit",
+            sparse=True,
+            learning_rate=lr,
+            prior_floor=floor,
+            n_iter=3,
+            batch_size=bs,
+        )
+        for bs in (None, 7)
+    )
+    g = lr**n
+    want_prec = g * P + (1.0 - g) * floor * np.eye(P.shape[0])
+    want_mean = np.linalg.solve(want_prec, g * P @ m)
+    for post in (one, chunked):
+        np.testing.assert_allclose(_dense(post.precision), want_prec, atol=1e-10)
+        np.testing.assert_allclose(_dense(post.mean), want_mean, atol=1e-10)


### PR DESCRIPTION
Stacked on #281. Prepares for `EmpiricalBayesGLM`, which applies stabilized forgetting and MacKay's alpha rescale through an approximator it does not own.

`update_posterior` (Laplace and R-VGA, dense and sparse) gains `prior_floor` and `prior_shift`: after decaying the prior precision by γⁿ, `(1 − γⁿ)·prior_floor + γⁿ·prior_shift` is added to its diagonal before the posterior is formed, so the shift rides the factorization the update does anyway instead of costing a second one. Precision only, never the prior's eta, so the shifted prior stays centered at zero.

Defaults are 0, so every existing caller is unchanged. `tests/test_prior_floor.py` checks both against an explicit zero-centered prior shift, chunk composition for sparse R-VGA, and that the caller's prior is never mutated. `_gaussian.py` at 100%.

`tests/`: 2669 passed, 26 skipped.