### PR TITLE
Damp Laplace IRLS with step halving, report convergence

### DIFF
--- a/src/bayesianbandits/_eb_estimators.py
+++ b/src/bayesianbandits/_eb_estimators.py
@@ -1117,6 +1117,8 @@ class EmpiricalBayesGLM(_StabilizedPriorMixin, BayesianGLM):
             if self.alpha != fitted_alpha:
                 self._refit_warm(X_fit, y, sample_weight)
                 fitted_alpha = self.alpha
+            if not self._laplace_converged:
+                break  # the evidence at a non-mode would mis-tune alpha
             # After a fresh fit: Λ = prior_decay·α·I + H_data
             self._prior_scalar = prior_decay * self.alpha
             self._effective_n = effective_n
@@ -1206,6 +1208,8 @@ class EmpiricalBayesGLM(_StabilizedPriorMixin, BayesianGLM):
         self._eff_loglik *= prior_decay
 
     def _online_eb_step(self, old: tuple[float, ...]) -> None:
+        if not self._laplace_converged:
+            return
         self._eb_mackay_step()
         self._correct_precision(old[0])
 

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections import defaultdict
 from functools import cached_property, partial, wraps
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, TypeVar, Union, cast
@@ -16,6 +17,7 @@ from scipy.stats import (
     gamma,
 )
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin  # type: ignore
+from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils.validation import (
     NotFittedError,
     check_array,  # type: ignore
@@ -2722,6 +2724,13 @@ scipy.sparse.csc_array
         )
         self.coef_ = posterior.mean
         self.cov_inv_ = posterior.precision
+        self._laplace_converged = posterior.converged
+        if not posterior.converged:
+            warnings.warn(
+                "Posterior approximation did not converge within n_iter "
+                "iterations; increase n_iter or loosen tol.",
+                ConvergenceWarning,
+            )
         if posterior.factor is not None:
             if self.sparse:
                 self._precision_factor = posterior.factor

--- a/src/bayesianbandits/_gaussian.py
+++ b/src/bayesianbandits/_gaussian.py
@@ -6,7 +6,13 @@ import numpy as np
 from numpy.polynomial.hermite_e import hermegauss
 from numpy.typing import NDArray
 from scipy.linalg import cho_factor, cho_solve, solve_triangular
-from scipy.linalg.blas import dgemv, dsymv, dsyrk
+from scipy.linalg.blas import (
+    daxpy,  # type: ignore[attr-defined]
+    ddot,  # type: ignore[attr-defined]
+    dgemv,
+    dsymv,
+    dsyrk,
+)
 from scipy.sparse import csc_array, eye
 from scipy.sparse import issparse as sp_issparse
 from scipy.special import expit
@@ -39,6 +45,7 @@ class GaussianPosterior(NamedTuple):
     mean: ArrayType  # Posterior mean
     precision: ArrayType  # Posterior precision matrix
     factor: Optional[Any] = None  # Sparse factor (CHOLMOD/SuperLU), if available
+    converged: bool = True  # False when an iterative solver ran out of n_iter
 
 
 def compute_effective_weights(
@@ -174,6 +181,38 @@ def _stabilized_prior_sparse(
     return csc_array(prior_precision_scaled + shift * eye(n, format="csc"))
 
 
+# Step halving: glm2's accept test, sklearn's roundoff tolerance and cap.
+_LINE_SEARCH_MAX_HALVINGS = 21
+_LINE_SEARCH_EPS = 16.0 * np.finfo(np.float64).eps
+# OpenBLAS ddot is single-threaded below this; einsum above avoids the pool.
+_DOT_EINSUM_MIN = 8192
+
+
+def _einsum_dot(a: NDArray[Any], b: NDArray[Any]) -> float:
+    return float(np.einsum("i,i", a, b))
+
+
+def _dot(a: NDArray[Any], b: NDArray[Any]) -> float:
+    if a.shape[0] < _DOT_EINSUM_MIN:
+        return ddot(a, b)
+    return _einsum_dot(a, b)
+
+
+def _fortran_view(A: NDArray[Any]) -> Tuple[NDArray[Any], int]:
+    """``(F, trans)`` with ``F`` Fortran-contiguous and ``A = op(F)``, so
+    f2py BLAS wrappers take ``A`` without copying it on every call."""
+    if A.flags.f_contiguous:
+        return A, 0
+    if A.flags.c_contiguous:
+        return A.T, 1
+    return np.asfortranarray(A), 0
+
+
+def _symmetric_fortran(M: NDArray[Any]) -> NDArray[Any]:
+    """Fortran-contiguous alias of the symmetric ``M`` (``M.T`` if C-order)."""
+    return _fortran_view(M)[0]
+
+
 def _irls_dense(
     X: NDArray[np.float64],
     y: NDArray[np.float64],
@@ -188,69 +227,182 @@ def _irls_dense(
     tol: float,
     coef_init: Optional[NDArray[np.float64]] = None,
 ) -> GaussianPosterior:
-    """Dense IRLS loop with pre-allocated buffers and fused BLAS calls."""
+    """Dense damped-Newton IRLS with pre-allocated buffers and fused BLAS.
+
+    Each Newton step is halved until ``ℓ_w(θ) − ½θᵀPθ + θᵀb`` stops
+    decreasing.  Convergence is tested on the undamped step before the
+    line search and, on the last iteration, on the gradient at the new
+    point through the lagged factor; ``n_iter=1`` does not assess it.
+    """
     n_samples, n_features = X.shape
+    logit = link == "logit"
+    if not logit and link != "log":
+        raise ValueError(f"Unknown link function: {link}")
 
     no_decay = prior_decay == 1.0
     prior_precision_scaled = (
         prior_precision if no_decay else prior_decay * prior_precision
     )
-    prior_eta_scaled = dsymv(prior_decay, prior_precision, prior_mean)
+    prior_eta_scaled = dsymv(
+        prior_decay, _symmetric_fortran(prior_precision), prior_mean
+    )
 
-    # F-order copy of prior precision for dsyrk accumulation buffer
     prior_prec_F = _stabilized_prior_dense(
-        np.asfortranarray(prior_precision_scaled),
+        _symmetric_fortran(prior_precision_scaled),
         prior_precision,
         prior_decay,
         prior_floor,
     )
 
-    X_weighted = np.empty_like(X)
+    n2 = 2 * n_samples
+    dot_n = ddot if n2 < _DOT_EINSUM_MIN else _einsum_dot
+    dot_p = ddot if n_features < _DOT_EINSUM_MIN else _einsum_dot
+
+    XF, xt = _fortran_view(X)
+    X_weighted = np.empty_like(X, order="F" if xt == 0 else "C")
+    XwF, xwt = _fortran_view(X_weighted)  # dsyrk trans=1-xwt gives X_wᵀX_w
     W_sqrt_buf = np.empty(n_samples, dtype=np.float64)
     Wz_buf = np.empty(n_samples, dtype=np.float64)
     diff_buf = np.empty(n_features, dtype=np.float64)
     precision_buf = np.empty_like(prior_prec_F)
     eta_buf = np.empty_like(prior_eta_scaled)
+    # Packed [eta; mu] (log) or [eta; softplus] (logit) against [w∘y; −w].
+    em = np.empty(n2, dtype=np.float64)
+    em_try = np.empty(n2, dtype=np.float64)
+    eta, eta_try = em[:n_samples], em_try[:n_samples]
+    if logit:
+        mu = np.empty(n_samples, dtype=np.float64)
+        mu_try = np.empty(n_samples, dtype=np.float64)
+        dmu_buf = np.empty(n_samples, dtype=np.float64)
+    else:
+        mu, mu_try = em[n_samples:], em_try[n_samples:]
+        dmu_buf = mu  # unused
+    w = effective_weights
+    wy2 = np.empty(n2, dtype=np.float64)
+    np.multiply(w, y, out=wy2[:n_samples])
+    np.negative(w, out=wy2[n_samples:])
 
     coef = (prior_mean if coef_init is None else coef_init).copy()
-    coef_old = coef
+    dgemv(1.0, XF, coef, trans=xt, y=eta, overwrite_y=True)
+    if logit:
+        expit(eta, out=mu)
+        np.logaddexp(0.0, eta, out=em[n_samples:])
+    else:
+        np.minimum(eta, 700.0, out=mu)
+        np.exp(mu, out=mu)
+    f_old = dot_n(wy2, em)
+
+    # r = b − P·θ (None while zero), prior value ½θᵀ(r + b); P·m = b + shift·m.
+    shift = (1.0 - prior_decay) * prior_floor
+    r: Optional[NDArray[np.float64]] = None
+    if coef_init is not None:
+        r = prior_eta_scaled - dsymv(1.0, prior_prec_F, coef)
+    elif shift != 0.0:
+        r = np.multiply(coef, -shift, dtype=np.float64)
+    prior_val = 0.5 * dot_p(coef, prior_eta_scaled)
+    if r is not None:
+        prior_val += 0.5 * dot_p(coef, r)
+    f_old += prior_val
+
     posterior_precision = prior_prec_F
+    converged = n_iter == 1
+    last = n_iter - 1
 
     for iteration in range(n_iter):
-        if iteration > 0 and n_iter > 1:
-            coef_old = coef.copy()
-
-        eta = cast(NDArray[np.float64], X @ coef)
-        link_out = _eval_link(link, eta)
-        glm_weights = compute_glm_weights_and_working_response(
-            y, link_out.mu, link_out.d_mu_d_eta, eta, effective_weights
-        )
+        # W = w·μ' and W·z = w·(μ'·η + y − μ)
+        if logit:
+            np.multiply(mu, mu, out=dmu_buf)
+            d_mu_d_eta = np.subtract(mu, dmu_buf, out=dmu_buf)
+        else:
+            d_mu_d_eta = mu  # floored in place; mu is not read again
+        np.maximum(d_mu_d_eta, 1e-10, out=d_mu_d_eta)
+        np.multiply(d_mu_d_eta, eta, out=Wz_buf)
+        Wz_buf += y
+        Wz_buf -= mu
+        Wz_buf *= w
+        np.multiply(d_mu_d_eta, w, out=W_sqrt_buf)
 
         # Fused X^T W X + prior via dsyrk(beta=1, c=prior_copy)
-        np.sqrt(glm_weights.W, out=W_sqrt_buf)
+        np.sqrt(W_sqrt_buf, out=W_sqrt_buf)
         np.multiply(X, W_sqrt_buf[:, np.newaxis], out=X_weighted)
         np.copyto(precision_buf, prior_prec_F)
         posterior_precision = dsyrk(
-            1.0, X_weighted, trans=1, beta=1.0, c=precision_buf, overwrite_c=True
+            1.0, XwF, trans=1 - xwt, beta=1.0, c=precision_buf, overwrite_c=True
         )
 
         # Fused X^T @ (W*z) + prior_eta via dgemv(beta=1, y=prior_copy)
-        np.multiply(glm_weights.W, glm_weights.z, out=Wz_buf)
         np.copyto(eta_buf, prior_eta_scaled)
         posterior_eta = dgemv(
-            1.0, X, Wz_buf, trans=1, beta=1.0, y=eta_buf, overwrite_y=True
+            1.0, XF, Wz_buf, trans=1 - xt, beta=1.0, y=eta_buf, overwrite_y=True
         )
 
         cho = cho_factor(posterior_precision, lower=False, check_finite=False)
-        coef = cho_solve(cho, posterior_eta, check_finite=False)
+        coef_new = cho_solve(cho, posterior_eta, check_finite=False)
 
-        if iteration > 0 and n_iter > 1:
-            np.subtract(coef, coef_old, out=diff_buf)
-            np.abs(diff_buf, out=diff_buf)
-            if diff_buf.max() < tol:
+        np.subtract(coef_new, coef, out=diff_buf)
+        if n_iter > 1 and max(diff_buf.max(), -diff_buf.min()) < tol:
+            coef = coef_new
+            converged = True
+            break
+
+        # eta_buf is dead until the next iteration; Wz_buf until a halving.
+        P_delta = dsymv(1.0, prior_prec_F, diff_buf, y=eta_buf, overwrite_y=True)
+        quad = dot_p(diff_buf, P_delta)
+        lin = 0.0 if r is None else dot_p(diff_buf, r)
+        threshold = f_old - _LINE_SEARCH_EPS * abs(f_old)
+
+        t = 1.0
+        X_delta = None
+        dgemv(1.0, XF, coef_new, trans=xt, y=eta_try, overwrite_y=True)
+        for _ in range(_LINE_SEARCH_MAX_HALVINGS):
+            if logit:
+                expit(eta_try, out=mu_try)
+                np.logaddexp(0.0, eta_try, out=em_try[n_samples:])
+            else:
+                np.minimum(eta_try, 700.0, out=mu_try)
+                np.exp(mu_try, out=mu_try)
+            f_new = dot_n(wy2, em_try) + prior_val + t * (lin - 0.5 * t * quad)
+            if f_new >= threshold:
                 break
+            if X_delta is None:
+                X_delta = np.subtract(eta_try, eta, out=Wz_buf)
+            t *= 0.5
+            daxpy(X_delta, eta_try, a=-t)
+        else:
+            converged = False
+            break
 
-    return GaussianPosterior(coef, cast(NDArray[np.float64], posterior_precision), cho)
+        if t == 1.0:
+            coef = coef_new
+        else:
+            daxpy(diff_buf, coef, a=t)
+
+        if iteration == last:
+            if n_iter > 1:
+                # Next Newton step from the new gradient r − t·Pδ + Xᵀw(y − μ).
+                np.subtract(y, mu_try, out=Wz_buf)
+                Wz_buf *= w
+                P_delta *= -t
+                if r is not None:
+                    P_delta += r
+                grad = dgemv(
+                    1.0, XF, Wz_buf, trans=1 - xt, beta=1.0, y=eta_buf, overwrite_y=True
+                )
+                step = cho_solve(cho, grad, check_finite=False)
+                converged = bool(max(step.max(), -step.min()) < tol)
+            break
+
+        if r is None:
+            r = np.multiply(P_delta, -t, dtype=np.float64)
+        else:
+            daxpy(P_delta, r, a=-t)
+        prior_val += t * (lin - 0.5 * t * quad)
+        f_old = f_new
+        em, eta, mu, em_try, eta_try, mu_try = em_try, eta_try, mu_try, em, eta, mu
+
+    return GaussianPosterior(
+        coef, cast(NDArray[np.float64], posterior_precision), cho, converged
+    )
 
 
 def _irls_sparse(
@@ -268,7 +420,9 @@ def _irls_sparse(
     prior_factor: Optional[Any] = None,
     coef_init: Optional[NDArray[np.float64]] = None,
 ) -> GaussianPosterior:
-    """Sparse IRLS loop using CHOLMOD/SuperLU factorization.
+    """Sparse damped-Newton IRLS using CHOLMOD/SuperLU factorization.
+
+    Same step halving and convergence tests as :func:`_irls_dense`.
 
     ``prior_factor``, when given, seeds the posterior's factorization:
     ``refactorize`` reuses its symbolic analysis whenever the posterior
@@ -277,6 +431,12 @@ def _irls_sparse(
     the pattern grew.
     """
     from ._sparse_bayesian_linear_regression import create_sparse_factor
+
+    assert X.shape is not None
+    n_samples = X.shape[0]
+    logit = link == "logit"
+    if not logit and link != "log":
+        raise ValueError(f"Unknown link function: {link}")
 
     no_decay = prior_decay == 1.0
     prior_precision_scaled = (
@@ -291,19 +451,45 @@ def _irls_sparse(
         prior_precision_scaled, prior_decay, prior_floor
     )
 
+    w = effective_weights
+    wy = np.multiply(w, y, dtype=np.float64)
+    mu_try = np.empty(n_samples, dtype=np.float64)
+
+    def loglik(eta: NDArray[np.float64], mu: NDArray[np.float64]) -> float:
+        if logit:
+            expit(eta, out=mu)
+            return _dot(wy, eta) - _dot(w, np.logaddexp(0.0, eta))
+        np.minimum(eta, 700.0, out=mu)
+        np.exp(mu, out=mu)
+        return _dot(wy, eta) - _dot(w, mu)
+
     coef = (prior_mean if coef_init is None else coef_init).copy()
-    coef_old = coef
+    eta = np.asarray(X @ coef, dtype=np.float64)
+    mu = np.empty(n_samples, dtype=np.float64)
+    f_old = loglik(eta, mu)
+
+    shift = (1.0 - prior_decay) * prior_floor
+    r: Optional[NDArray[np.float64]] = None
+    if coef_init is not None:
+        r = np.asarray(
+            prior_eta_scaled - prior_precision_scaled @ coef, dtype=np.float64
+        )
+    elif shift != 0.0:
+        r = np.multiply(coef, -shift, dtype=np.float64)
+    prior_val = 0.5 * _dot(coef, prior_eta_scaled)
+    if r is not None:
+        prior_val += 0.5 * _dot(coef, r)
+    f_old += prior_val
+
     sparse_factor = prior_factor
     posterior_precision = prior_precision
+    converged = n_iter == 1
+    last = n_iter - 1
 
     for iteration in range(n_iter):
-        if iteration > 0 and n_iter > 1:
-            coef_old = coef.copy()
-
-        eta = cast(NDArray[np.float64], X @ coef)
-        link_out = _eval_link(link, eta)
+        d_mu_d_eta = cast(NDArray[np.float64], mu * (1.0 - mu) if logit else mu)
         glm_weights = compute_glm_weights_and_working_response(
-            y, link_out.mu, link_out.d_mu_d_eta, eta, effective_weights
+            y, mu, d_mu_d_eta, eta, w
         )
 
         # X^T W X via element-wise row scaling (avoids diags construction)
@@ -318,14 +504,53 @@ def _irls_sparse(
             sparse_factor = create_sparse_factor(posterior_precision)
         else:
             sparse_factor = sparse_factor.refactorize(posterior_precision)
-        coef = sparse_factor.solve(posterior_eta)
+        coef_new = sparse_factor.solve(posterior_eta)
 
-        if iteration > 0 and n_iter > 1:
-            coef_change = np.max(np.abs(coef - coef_old))
-            if coef_change < tol:
+        delta = coef_new - coef
+        if n_iter > 1 and max(delta.max(), -delta.min()) < tol:
+            coef = coef_new
+            converged = True
+            break
+
+        P_delta = np.asarray(prior_precision_scaled @ delta, dtype=np.float64)
+        quad = _dot(delta, P_delta)
+        lin = 0.0 if r is None else _dot(delta, r)
+        threshold = f_old - _LINE_SEARCH_EPS * abs(f_old)
+
+        t = 1.0
+        X_delta = None
+        eta_try = np.asarray(X @ coef_new, dtype=np.float64)
+        for _ in range(_LINE_SEARCH_MAX_HALVINGS):
+            f_new = loglik(eta_try, mu_try) + prior_val + t * (lin - 0.5 * t * quad)
+            if f_new >= threshold:
                 break
+            if X_delta is None:
+                X_delta = eta_try - eta
+            t *= 0.5
+            daxpy(X_delta, eta_try, a=-t)
+        else:
+            converged = False
+            break
 
-    return GaussianPosterior(coef, posterior_precision, sparse_factor)
+        if t == 1.0:
+            coef = coef_new
+        else:
+            daxpy(delta, coef, a=t)
+        if r is None:
+            r = np.multiply(P_delta, -t, dtype=np.float64)
+        else:
+            daxpy(P_delta, r, a=-t)
+        prior_val += t * (lin - 0.5 * t * quad)
+        f_old = f_new
+        eta, mu, mu_try = eta_try, mu_try, mu
+
+        if iteration == last and n_iter > 1:
+            # Next Newton step from the new gradient through the lagged factor.
+            grad = r + X.T @ (w * (y - mu))
+            step = sparse_factor.solve(grad)
+            converged = bool(max(step.max(), -step.min()) < tol)
+
+    return GaussianPosterior(coef, posterior_precision, sparse_factor, converged)
 
 
 def update_gaussian_posterior_laplace(
@@ -506,12 +731,17 @@ class LaplaceApproximator(MemoryUsageMixin, PosteriorApproximator):
         (\\alpha I + X^T W X)^{-1}\\bigr)
 
     where :math:`W` is the diagonal matrix of IRLS weights (Fisher
-    information).
+    information).  Each Newton step is halved until the penalized
+    log-likelihood stops decreasing, so the iteration cannot diverge
+    (cf. R's ``glm2``).
 
     Parameters
     ----------
     n_iter : int, default=5
-        Maximum number of Newton (IRLS) iterations per update.
+        Maximum number of Newton (IRLS) iterations per update.  When
+        the budget runs out before the step falls below ``tol``, the
+        returned posterior has ``converged=False`` and
+        :class:`BayesianGLM` raises a ``ConvergenceWarning``.
 
         - ``1``: Single-step update from the current posterior. Fast
           and usually sufficient for online/streaming use where the
@@ -520,10 +750,11 @@ class LaplaceApproximator(MemoryUsageMixin, PosteriorApproximator):
         - ``>10``: Use for batch fitting when full convergence is
           needed (pair with a tight ``tol``).
     tol : float, default=1e-4
-        Convergence tolerance on the coefficient change. Iteration
+        Convergence tolerance on the undamped Newton step. Iteration
         stops when
         :math:`\\|w_{\\text{new}} - w_{\\text{old}}\\|_\\infty < \\text{tol}`.
-        Only effective when ``n_iter > 1``.
+        Only effective when ``n_iter > 1``; a single-step update does
+        not assess convergence.
 
     See Also
     --------

--- a/tests/test_bayesian_glm.py
+++ b/tests/test_bayesian_glm.py
@@ -170,6 +170,7 @@ def test_bayesian_glm_fit_log(count_data, sparse: bool) -> None:
 
 
 @pytest.mark.parametrize("sparse", [True, False])
+@pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")
 def test_bayesian_glm_partial_fit_basic(binary_data, sparse: bool) -> None:
     """Test basic partial_fit functionality."""
     X, y = binary_data
@@ -201,6 +202,7 @@ def test_bayesian_glm_partial_fit_basic(binary_data, sparse: bool) -> None:
 
 
 @pytest.mark.parametrize("sparse", [True, False])
+@pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")
 def test_bayesian_glm_streaming_convergence(binary_data, sparse: bool) -> None:
     """Test that streaming updates eventually produce a good model."""
     X, y = binary_data
@@ -542,6 +544,7 @@ def test_bayesian_glm_sample_invalid_link() -> None:
 
 
 @pytest.mark.parametrize("n_samples,n_features", [(50, 2), (100, 5), (200, 10)])
+@pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")
 def test_bayesian_glm_scaling(n_samples, n_features) -> None:
     """Test model works with different data sizes."""
     rng = np.random.RandomState(42)  # Fixed seed
@@ -600,6 +603,7 @@ class RecordingApproximator(LaplaceApproximator):
 
 
 @pytest.mark.parametrize("sparse", [True, False])
+@pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")
 def test_bayesian_glm_threads_prior_factor(binary_data, sparse: bool) -> None:
     """Sparse partial_fit passes the cached precision factor through."""
     X, y = binary_data
@@ -622,6 +626,7 @@ def test_bayesian_glm_threads_prior_factor(binary_data, sparse: bool) -> None:
         assert approximator.received_factors[1] is None
 
 
+@pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")
 def test_bayesian_glm_refit_does_not_pass_stale_factor(binary_data) -> None:
     """Refitting resets the prior, so the old posterior's factor must not
     be handed to the approximator as if it factored the fresh prior."""
@@ -636,3 +641,28 @@ def test_bayesian_glm_refit_does_not_pass_stale_factor(binary_data) -> None:
 
     clf.fit(X, y)
     assert approximator.received_factors == [None, None]
+
+
+def test_laplace_non_convergence_warns():
+    import warnings
+
+    from sklearn.exceptions import ConvergenceWarning
+
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((300, 8))
+    y = rng.poisson(np.exp(X @ rng.normal(scale=0.7, size=8))).astype(np.float64)
+
+    with pytest.warns(ConvergenceWarning):
+        BayesianGLM(
+            link="log", alpha=2.0, approximator=LaplaceApproximator(n_iter=2)
+        ).fit(X, y)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ConvergenceWarning)
+        BayesianGLM(
+            link="log", alpha=2.0, approximator=LaplaceApproximator(n_iter=100)
+        ).fit(X, y)
+        # Single-step mode never claims convergence, so it never warns.
+        BayesianGLM(
+            link="log", alpha=2.0, approximator=LaplaceApproximator(n_iter=1)
+        ).fit(X, y)

--- a/tests/test_eb_glm.py
+++ b/tests/test_eb_glm.py
@@ -101,8 +101,10 @@ class TestEBGLM:
         ).fit(_X(X, sparse), y)
         # Both IRLS runs stop within tol=1e-6 of the mode; the EB one is
         # warm-started from the previous iteration, the plain one from 0.
+        # Each precision is built at its run's last pre-convergence
+        # iterate, so they agree only to O(tol · scale).
         np.testing.assert_allclose(eb.coef_, plain.coef_, atol=1e-5)
-        np.testing.assert_allclose(_dense_prec(eb), _dense_prec(plain), atol=1e-5)
+        np.testing.assert_allclose(_dense_prec(eb), _dense_prec(plain), atol=1e-4)
 
     def test_log_evidence_matches_hand_formula(self, link, sparse):
         """fit's log_evidence_ is the Laplace evidence at the alpha used for
@@ -428,3 +430,26 @@ class TestEffectiveN:
         assert model._effective_n == pytest.approx(
             np.sum(w * 0.9 ** np.arange(3, -1, -1))
         )
+
+
+@pytest.mark.parametrize("sparse", [True, False])
+def test_alpha_untouched_when_laplace_does_not_converge(sparse):
+    from sklearn.exceptions import ConvergenceWarning
+
+    X, y = _simulate("log")
+    # tol=0 can never be met, so every Laplace update reports non-convergence.
+    model = EmpiricalBayesGLM(
+        link="log",
+        alpha=1.0,
+        sparse=sparse,
+        approximator=LaplaceApproximator(n_iter=2, tol=0.0),
+    )
+    with pytest.warns(ConvergenceWarning):
+        model.fit(_X(X, sparse), y)
+    assert model.alpha == 1.0
+    assert not model.eb_converged_
+    assert model.n_eb_iterations_ == 0
+
+    with pytest.warns(ConvergenceWarning):
+        model.partial_fit(_X(X[:20], sparse), y[:20])
+    assert model.alpha == 1.0

--- a/tests/test_gaussian_posterior_laplace.py
+++ b/tests/test_gaussian_posterior_laplace.py
@@ -367,3 +367,76 @@ def test_first_newton_step_exact():
     expected_mean = np.linalg.solve(H, g)
 
     assert_allclose(posterior.mean, expected_mean, rtol=1e-10)
+
+
+def _poisson_overshoot_data(n=300, p=8, seed=0):
+    """Issue #284: undamped IRLS from zero overshoots on this data and
+    stops with a log-likelihood of about -2e8 against -475 at the mode."""
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n, p))
+    w = rng.normal(scale=0.7, size=p)
+    y = rng.poisson(np.exp(X @ w)).astype(np.float64)
+    sample_weight = rng.uniform(0.5, 1.5, size=n)
+    return X, y, sample_weight
+
+
+def _poisson_loglik(X, y, coef):
+    eta = X @ np.asarray(coef)
+    return float(np.sum(y * eta - np.exp(eta)))
+
+
+def _fit_overshoot(X, y, sample_weight, n_iter, sparse=False):
+    from scipy.sparse import csc_array
+
+    p = X.shape[1]
+    P = np.asarray(2.0 * np.eye(p), dtype=np.float64)
+    posterior = update_gaussian_posterior_laplace(
+        csc_array(X) if sparse else X,
+        y,
+        np.zeros(p),
+        csc_array(P) if sparse else P,
+        link="log",
+        sample_weight=sample_weight,
+        learning_rate=0.98,
+        sparse=sparse,
+        n_iter=n_iter,
+        tol=1e-6,
+    )
+    return np.asarray(posterior.mean), posterior.converged
+
+
+@pytest.mark.parametrize("sparse", [False, True])
+def test_irls_step_halving_reaches_mode_from_cold_start(sparse):
+    X, y, sample_weight = _poisson_overshoot_data()
+    short, short_conv = _fit_overshoot(X, y, sample_weight, 25, sparse)
+    long, long_conv = _fit_overshoot(X, y, sample_weight, 200, sparse)
+
+    assert short_conv and long_conv
+    assert_allclose(short, long, atol=1e-5)
+    assert_allclose(_poisson_loglik(X, y, short), _poisson_loglik(X, y, long))
+
+
+def test_irls_reports_non_convergence():
+    X, y, sample_weight = _poisson_overshoot_data()
+
+    two, converged = _fit_overshoot(X, y, sample_weight, 2)
+    assert not converged
+    assert np.isfinite(two).all()
+
+    # A single-step update does not assess convergence.
+    _, converged = _fit_overshoot(X, y, sample_weight, 1)
+    assert converged
+
+
+def test_irls_overshoot_stays_finite():
+    """Wide Poisson features with a weak prior: the undamped first step
+    used to leave non-finite coefficients."""
+    rng = np.random.default_rng(1)
+    X = np.asarray(rng.standard_normal((50, 3)) * 6.0, dtype=np.float64)
+    y = rng.poisson(np.exp(np.clip(X @ np.array([0.5, -0.3, 0.2]), -10, 10)))
+    P = np.asarray(1e-3 * np.eye(3), dtype=np.float64)
+    posterior = update_gaussian_posterior_laplace(
+        X, y.astype(np.float64), np.zeros(3), P, link="log", n_iter=25
+    )
+    assert np.isfinite(np.asarray(posterior.mean)).all()
+    assert posterior.converged

--- a/tests/test_gaussian_posterior_laplace.py
+++ b/tests/test_gaussian_posterior_laplace.py
@@ -440,3 +440,75 @@ def test_irls_overshoot_stays_finite():
     )
     assert np.isfinite(np.asarray(posterior.mean)).all()
     assert posterior.converged
+
+
+@pytest.mark.parametrize("sparse", [False, True])
+def test_irls_unknown_link_raises(sparse):
+    from scipy.sparse import csc_array
+
+    X, y, sample_weight = _poisson_overshoot_data(n=20, p=3)
+    P = np.asarray(np.eye(3), dtype=np.float64)
+    with pytest.raises(ValueError, match="Unknown link"):
+        update_gaussian_posterior_laplace(
+            csc_array(X) if sparse else X,
+            y,
+            np.zeros(3),
+            csc_array(P) if sparse else P,
+            link="probit",  # type: ignore[arg-type]
+            sparse=sparse,
+        )
+
+
+def test_dot_dispatches_on_length():
+    from bayesianbandits._gaussian import _DOT_EINSUM_MIN, _dot
+
+    short = np.ones(8)
+    long = np.ones(_DOT_EINSUM_MIN)
+    assert _dot(short, short) == 8.0
+    assert _dot(long, long) == float(_DOT_EINSUM_MIN)
+
+
+def test_irls_accepts_noncontiguous_X():
+    X_full, y_full, sample_weight_full = _poisson_overshoot_data(n=200, p=4)
+    X, y, sample_weight = X_full[::2], y_full[::2], sample_weight_full[::2]
+    assert not X.flags.c_contiguous and not X.flags.f_contiguous
+    P = np.asarray(2.0 * np.eye(4), dtype=np.float64)
+    strided = update_gaussian_posterior_laplace(
+        X, y, np.zeros(4), P, link="log", sample_weight=sample_weight, n_iter=50
+    )
+    contiguous = update_gaussian_posterior_laplace(
+        np.ascontiguousarray(X),
+        y,
+        np.zeros(4),
+        P,
+        link="log",
+        sample_weight=sample_weight,
+        n_iter=50,
+    )
+    assert_allclose(np.asarray(strided.mean), np.asarray(contiguous.mean))
+    assert_allclose(np.asarray(strided.precision), np.asarray(contiguous.precision))
+
+
+@pytest.mark.parametrize("sparse", [False, True])
+def test_irls_exhausted_line_search_keeps_start(sparse, monkeypatch):
+    """With no halvings allowed, a rejected full step leaves the start
+    point untouched and reports non-convergence."""
+    from scipy.sparse import csc_array
+
+    from bayesianbandits import _gaussian
+
+    monkeypatch.setattr(_gaussian, "_LINE_SEARCH_MAX_HALVINGS", 0)
+    X, y, sample_weight = _poisson_overshoot_data()
+    P = np.asarray(2.0 * np.eye(8), dtype=np.float64)
+    posterior = update_gaussian_posterior_laplace(
+        csc_array(X) if sparse else X,
+        y,
+        np.zeros(8),
+        csc_array(P) if sparse else P,
+        link="log",
+        sample_weight=sample_weight,
+        sparse=sparse,
+        n_iter=5,
+    )
+    assert not posterior.converged
+    assert_allclose(np.asarray(posterior.mean), np.zeros(8))

--- a/tests/test_howto_reward_functions.py
+++ b/tests/test_howto_reward_functions.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pandas as pd
+import pytest
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import OneHotEncoder, StandardScaler
 
@@ -58,6 +59,7 @@ def test_binary_outcome_profit_reward():
     np.testing.assert_allclose(actual, expected)
 
 
+@pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")
 def test_binary_outcome_contextual_agent():
     """ContextualAgent with BayesianGLM arms: pull selects, update gets raw 0/1."""
     arms = [

--- a/tests/test_mathematical_correctness.py
+++ b/tests/test_mathematical_correctness.py
@@ -425,7 +425,11 @@ class TestBayesianGLMMath:
         X^T W X = 1 + 4 = 5
         Lambda = 1 + 5 = 6
         X^T (W*z) = 1*2 + 2*6 = 14
-        coef_ = 14/6 = 7/3
+        Newton step = 14/6 = 7/3
+
+        The full step drops the penalized log-likelihood from -2 to
+        about -79, so the line search halves it once: coef_ = 7/6
+        (objective about +5.6).  Lambda is built at w=0 either way.
         """
         X = np.array([[1.0], [2.0]])
         y = np.array([3.0, 7.0])
@@ -441,7 +445,7 @@ class TestBayesianGLMMath:
         )
         glm.fit(X, y)
 
-        assert_allclose(glm.coef_[0], 7.0 / 3, atol=1e-10)
+        assert_allclose(glm.coef_[0], 7.0 / 6, atol=1e-10)
         assert_allclose(cov_inv_dense(glm)[0, 0], 6.0, atol=1e-10)
 
     def test_posterior_predictive_logit_bounded(self, sparse):


### PR DESCRIPTION
Fixes #284.

Step halving on the penalized log-likelihood is R's `glm2` (halve until the deviance decreases); the accept tolerance (`16·eps·|f|`) and 21-halving cap are sklearn's `NewtonCholeskySolver`; the final-iteration convergence check (gradient at the new point through the lagged Hessian) is sklearn's post-step check. The `converged` flag plus `ConvergenceWarning` is what R and sklearn do; statsmodels flags silently. `EmpiricalBayesGLM` skips the MacKay step on a non-converged mode.