### PR TITLE
Keep the constructor alpha on the EB estimators as _alpha0

### DIFF
--- a/src/bayesianbandits/_eb_estimators.py
+++ b/src/bayesianbandits/_eb_estimators.py
@@ -491,6 +491,7 @@ class EmpiricalBayesNormalRegressor(_StabilizedPriorMixin, NormalRegressor):
         self.n_eb_iter = n_eb_iter
         self.eb_tol = eb_tol
         self.trace_method = trace_method
+        self._alpha0 = alpha  # EB overwrites alpha; keep the prior
 
     @property
     def coef_(self) -> NDArray[np.float64]:
@@ -1028,6 +1029,7 @@ class EmpiricalBayesGLM(_StabilizedPriorMixin, BayesianGLM):
         self.n_eb_iter = n_eb_iter
         self.eb_tol = eb_tol
         self.trace_method = trace_method
+        self._alpha0 = alpha  # EB overwrites alpha; keep the prior
 
     def _initialize_prior(self, X: Union[NDArray[Any], csc_array]) -> None:
         super()._initialize_prior(X)

--- a/tests/test_eb_estimators.py
+++ b/tests/test_eb_estimators.py
@@ -233,6 +233,13 @@ class TestEBNormalRegressor:
         assert np.isfinite(model.alpha)
         assert np.isfinite(model.beta)
 
+    def test_alpha0_keeps_the_constructor_alpha(self, regression_data, sparse):
+        X, y = regression_data
+        model = EmpiricalBayesNormalRegressor(alpha=3.0, sparse=sparse).fit(X, y)
+        assert model.alpha != 3.0 and model._alpha0 == 3.0
+        model.fit(X, y)
+        assert model._alpha0 == 3.0
+
     def test_decay(self, regression_data, sparse):
         """decay() scales _prior_scalar and sufficient stats."""
         X, y = regression_data

--- a/tests/test_eb_glm.py
+++ b/tests/test_eb_glm.py
@@ -226,6 +226,14 @@ class TestEBGLM:
         batch.fit(_X(X, sparse), y)
         assert 0.8 < model.alpha / batch.alpha < 1.25
 
+    def test_alpha0_keeps_the_constructor_alpha(self, link, sparse):
+        X, y = _simulate(link)
+        model = EmpiricalBayesGLM(alpha=3.0, link=link, sparse=sparse)
+        model.fit(_X(X, sparse), y)
+        assert model.alpha != 3.0 and model._alpha0 == 3.0
+        model.fit(_X(X, sparse), y)
+        assert model._alpha0 == 3.0
+
     def test_sample_before_partial_fit(self, link, sparse):
         X, y = _simulate(link)
         model = EmpiricalBayesGLM(link=link, sparse=sparse)


### PR DESCRIPTION
Groundwork for #286.

The EB estimators overwrite `alpha` with the learned value, so after the first fit there is no record of the prior the user asked for. The hyperprior in #286 anchors there, so both constructors keep it as `_alpha0`. No behavior change.