### PR TITLE
Regularize the MacKay alpha update with a Gamma hyperprior

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,16 @@ Unreleased
 
 **Breaking changes**
 
+- ``EmpiricalBayesNormalRegressor`` and ``EmpiricalBayesGLM`` regularize
+  the MacKay update of ``alpha`` with a Gamma hyperprior at the
+  constructor's ``alpha``, weighted by the new ``alpha_prior_strength``
+  (default ``0.2`` pseudo-observations): ``(γ + k) / (‖θ‖² + k/α₀)``. Plain
+  MacKay ran ``alpha`` to the guardrail on arms with near-zero coefficients
+  and locked them there. Learned alphas change under the default and are
+  bounded by ``(γ + k)·α₀/k``; ``0.0`` restores the previous update, and
+  ``log_evidence_`` includes the log hyperprior when the strength is
+  positive (#286)
+
 - ``PolicyProtocol`` gains a ``consumes: DrawKind`` attribute, naming the
   weakest draws a policy can correctly consume over a totally ordered
   lattice::

--- a/src/bayesianbandits/_eb_estimators.py
+++ b/src/bayesianbandits/_eb_estimators.py
@@ -339,6 +339,12 @@ class EmpiricalBayesNormalRegressor(_StabilizedPriorMixin, NormalRegressor):
         Initial noise precision. The likelihood is
         :math:`y \\mid x, w \\sim \\mathcal{N}(x^T w, \\beta^{-1})`.
         Updated automatically during fitting.
+    alpha_prior_strength : float, default=0.2
+        Pseudo-observations :math:`k` of a Gamma hyperprior on ``alpha``
+        at the constructor's :math:`\\alpha_0`: the MacKay update becomes
+        :math:`(\\gamma + k) / (\\|m\\|^2 + k / \\alpha_0)`, finite at
+        zero mean but bounded by :math:`(\\gamma + k)\\,\\alpha_0 / k`.
+        ``0.0`` is plain MacKay.
     n_eb_iter : int, default=10
         Maximum number of empirical Bayes iterations during ``fit``.
         Each iteration re-fits the posterior and runs one MacKay update.
@@ -375,7 +381,8 @@ class EmpiricalBayesNormalRegressor(_StabilizedPriorMixin, NormalRegressor):
         Log marginal likelihood at the most recent MacKay step --
         the last iteration of ``fit``, then refreshed by every
         ``partial_fit`` -- or ``-inf`` if ``n_eb_iter=0``. Under
-        forgetting this is the evidence of the *decayed* data.
+        forgetting this is the evidence of the *decayed* data, and with
+        ``alpha_prior_strength > 0`` it includes the log hyperprior.
     n_eb_iterations_ : int
         Number of EB iterations performed during the last ``fit``.
     eb_converged_ : bool
@@ -474,6 +481,7 @@ class EmpiricalBayesNormalRegressor(_StabilizedPriorMixin, NormalRegressor):
         alpha: float = 1.0,
         beta: float = 1.0,
         *,
+        alpha_prior_strength: float = 0.2,
         n_eb_iter: int = 10,
         eb_tol: float = 1e-4,
         learning_rate: float = 1.0,
@@ -488,6 +496,7 @@ class EmpiricalBayesNormalRegressor(_StabilizedPriorMixin, NormalRegressor):
             sparse=sparse,
             random_state=random_state,
         )
+        self.alpha_prior_strength = alpha_prior_strength
         self.n_eb_iter = n_eb_iter
         self.eb_tol = eb_tol
         self.trace_method = trace_method
@@ -544,6 +553,8 @@ class EmpiricalBayesNormalRegressor(_StabilizedPriorMixin, NormalRegressor):
             self._eff_XTy,
             factor=self._precision_factor,
             trace_method=self.trace_method,
+            alpha_prior_strength=self.alpha_prior_strength,
+            alpha_prior_mode=self._alpha0,
         )
         self.alpha = update.alpha
         self.beta = update.beta
@@ -652,6 +663,8 @@ class EmpiricalBayesNormalRegressor(_StabilizedPriorMixin, NormalRegressor):
                     eff_XTy,
                     factor=self._precision_factor,
                     trace_method=self.trace_method,
+                    alpha_prior_strength=self.alpha_prior_strength,
+                    alpha_prior_mode=self._alpha0,
                 )
                 self.alpha = update.alpha
                 self.beta = update.beta
@@ -930,7 +943,9 @@ class EmpiricalBayesGLM(_StabilizedPriorMixin, BayesianGLM):
     update of ``alpha``, applied to the Laplace approximation: with
     :math:`\\gamma = p - s\\,\\operatorname{tr}(\\Lambda^{-1})` (``s`` the
     prior's contribution to the diagonal of :math:`\\Lambda`),
-    :math:`\alpha_{\text{new}} = \\gamma / \\|\theta_{\text{MAP}}\\|^2`.
+    :math:`\\alpha_{\\text{new}} = (\\gamma + k) /
+    (\\|\\theta_{\\text{MAP}}\\|^2 + k / \\alpha_0)`, :math:`k` the
+    ``alpha_prior_strength`` at the constructor's :math:`\\alpha_0`.
 
     ``fit`` alternates IRLS and MacKay steps until the Laplace log
     evidence converges. ``partial_fit`` takes one MacKay step on the
@@ -951,6 +966,9 @@ class EmpiricalBayesGLM(_StabilizedPriorMixin, BayesianGLM):
         Initial prior precision. Updated automatically during fitting.
     link : {'logit', 'log'}, default='logit'
         Link function; see :class:`BayesianGLM`.
+    alpha_prior_strength : float, default=0.2
+        Pseudo-observations of the Gamma hyperprior on ``alpha``; see
+        :class:`EmpiricalBayesNormalRegressor`.
     n_eb_iter : int, default=10
         Maximum number of EB iterations during ``fit``; 0 disables
         tuning there.
@@ -982,6 +1000,7 @@ class EmpiricalBayesGLM(_StabilizedPriorMixin, BayesianGLM):
         ``-inf`` if ``n_eb_iter=0``. Exact after ``fit``; under
         ``partial_fit`` the log-likelihood term is a decayed running
         sum of each batch's log-likelihood at the mode right after it.
+        Includes the log hyperprior when ``alpha_prior_strength > 0``.
     n_eb_iterations_ : int
         Number of EB iterations performed during the last ``fit``.
     eb_converged_ : bool
@@ -1010,6 +1029,7 @@ class EmpiricalBayesGLM(_StabilizedPriorMixin, BayesianGLM):
         alpha: float = 1.0,
         *,
         link: LinkFunction = "logit",
+        alpha_prior_strength: float = 0.2,
         n_eb_iter: int = 10,
         eb_tol: float = 1e-4,
         learning_rate: float = 1.0,
@@ -1026,6 +1046,7 @@ class EmpiricalBayesGLM(_StabilizedPriorMixin, BayesianGLM):
             sparse=sparse,
             random_state=random_state,
         )
+        self.alpha_prior_strength = alpha_prior_strength
         self.n_eb_iter = n_eb_iter
         self.eb_tol = eb_tol
         self.trace_method = trace_method
@@ -1056,6 +1077,8 @@ class EmpiricalBayesGLM(_StabilizedPriorMixin, BayesianGLM):
             self._eff_loglik,
             factor=self._precision_factor,
             trace_method=self.trace_method,
+            alpha_prior_strength=self.alpha_prior_strength,
+            alpha_prior_mode=self._alpha0,
         )
         self.alpha = update.alpha
         self.log_evidence_ = update.log_evidence

--- a/src/bayesianbandits/_empirical_bayes.py
+++ b/src/bayesianbandits/_empirical_bayes.py
@@ -151,6 +151,21 @@ def accumulate_sufficient_stats(
     )
 
 
+def _alpha_fixed_point(
+    gamma: float, norm_sq: float, alpha: float, k: float, alpha0: float
+) -> float:
+    """MacKay's alpha under ``k`` pseudo-observations at ``alpha0``; ``k = 0`` is plain."""
+    if k < 0:
+        raise ValueError(f"alpha_prior_strength must be >= 0, got {k}")
+    denom = norm_sq + k / alpha0
+    return (gamma + k) / denom if denom > 0 else alpha
+
+
+def _alpha_hyperprior_log(alpha: float, k: float, alpha0: float) -> float:
+    """``log Gamma(alpha | 1 + k/2, k/(2 alpha0))`` up to its normalizer."""
+    return 0.5 * k * math.log(alpha) - 0.5 * k * alpha / alpha0
+
+
 def mackay_update_normal_online(
     mu_n: NDArray[np.float64],
     precision: Union[NDArray[np.float64], csc_array],
@@ -162,6 +177,8 @@ def mackay_update_normal_online(
     eff_XTy: NDArray[np.float64],
     factor: PrecisionFactor,
     trace_method: str = "auto",
+    alpha_prior_strength: float = 0.0,
+    alpha_prior_mode: float = 1.0,
 ) -> MacKayUpdate:
     """MacKay update using accumulated sufficient statistics for beta.
 
@@ -186,6 +203,8 @@ def mackay_update_normal_online(
     eff_XTy : decayed Xᵀy
     factor : pre-computed factorization
     trace_method : method for computing tr(Λ⁻¹)
+    alpha_prior_strength, alpha_prior_mode : Gamma hyperprior on alpha,
+        ``k`` pseudo-observations at the mode; ``0`` is plain MacKay
 
     Returns
     -------
@@ -211,8 +230,8 @@ def mackay_update_normal_online(
     _EPS = 1e-8
     gamma = float(np.clip(p - prior_scalar * tr_inv, _EPS, min(effective_n, p)))
 
-    # Alpha update.
-    alpha_new = gamma / mu_norm_sq if mu_norm_sq > 0 else alpha
+    k, alpha0 = alpha_prior_strength, alpha_prior_mode
+    alpha_new = _alpha_fixed_point(gamma, mu_norm_sq, alpha, k, alpha0)
 
     # Beta update from sufficient statistics.
     # XᵀX_decayed = (Λ − prior_scalar·I) / β
@@ -248,6 +267,7 @@ def mackay_update_normal_online(
         - 0.5 * ld
         - 0.5 * (beta * rss + alpha * mu_norm_sq)
         - 0.5 * effective_n * _LOG_2PI
+        + _alpha_hyperprior_log(alpha, k, alpha0)
     )
 
     return MacKayUpdate(alpha_new, beta_new, log_ev, rejected)
@@ -307,6 +327,8 @@ def mackay_update_glm(
     log_lik: float,
     factor: PrecisionFactor,
     trace_method: str = "auto",
+    alpha_prior_strength: float = 0.0,
+    alpha_prior_mode: float = 1.0,
 ) -> MacKayGLMUpdate:
     """MacKay update of the prior precision for a Laplace GLM posterior.
 
@@ -338,6 +360,8 @@ def mackay_update_glm(
     log_lik : log-likelihood at ``theta``
     factor : pre-computed factorization of ``precision``
     trace_method : method for computing tr(Lambda^-1)
+    alpha_prior_strength, alpha_prior_mode : see
+        :func:`mackay_update_normal_online`
     """
     p = cast(tuple[int, int], precision.shape)[0]
     theta_norm_sq = _dot(theta, theta)
@@ -347,7 +371,8 @@ def mackay_update_glm(
     # Floor just above the cancellation noise of p - s.tr(Lambda^-1); a larger
     # one would inflate alpha_new past the ceiling when the prior dominates.
     gamma = float(np.clip(p - prior_scalar * tr_inv, p * 1e-13, min(effective_n, p)))
-    alpha_new = gamma / theta_norm_sq if theta_norm_sq > 0 else alpha
+    k, alpha0 = alpha_prior_strength, alpha_prior_mode
+    alpha_new = _alpha_fixed_point(gamma, theta_norm_sq, alpha, k, alpha0)
 
     if isinstance(precision, csc_array):
         diag = np.asarray(precision.diagonal(), dtype=np.float64)
@@ -364,7 +389,11 @@ def mackay_update_glm(
         alpha_new = alpha
 
     log_ev = float(
-        log_lik + 0.5 * p * math.log(alpha) - 0.5 * alpha * theta_norm_sq - 0.5 * ld
+        log_lik
+        + 0.5 * p * math.log(alpha)
+        - 0.5 * alpha * theta_norm_sq
+        - 0.5 * ld
+        + _alpha_hyperprior_log(alpha, k, alpha0)
     )
 
     return MacKayGLMUpdate(alpha_new, log_ev, rejected)

--- a/tests/test_eb_estimators.py
+++ b/tests/test_eb_estimators.py
@@ -73,8 +73,14 @@ class TestEBNormalRegressor:
         X, y = regression_data
         evidences = []
 
+        # re-anchored each round, so only plain MacKay is one objective
         model = EmpiricalBayesNormalRegressor(
-            alpha=1.0, beta=1.0, n_eb_iter=1, eb_tol=0.0, sparse=sparse
+            alpha=1.0,
+            beta=1.0,
+            n_eb_iter=1,
+            eb_tol=0.0,
+            sparse=sparse,
+            alpha_prior_strength=0.0,
         )
         for _ in range(10):
             model.fit(X, y)
@@ -86,6 +92,7 @@ class TestEBNormalRegressor:
                 n_eb_iter=1,
                 eb_tol=0.0,
                 sparse=sparse,
+                alpha_prior_strength=0.0,
             )
 
         for i in range(1, len(evidences)):
@@ -145,23 +152,25 @@ class TestEBNormalRegressor:
 
     def test_get_set_params(self, sparse):
         model = EmpiricalBayesNormalRegressor(
-            alpha=2.0, beta=3.0, n_eb_iter=5, sparse=sparse
+            alpha=2.0, beta=3.0, n_eb_iter=5, sparse=sparse, alpha_prior_strength=0.25
         )
         params = model.get_params()
         assert params["alpha"] == 2.0
         assert params["beta"] == 3.0
         assert params["n_eb_iter"] == 5
+        assert params["alpha_prior_strength"] == 0.25
 
         model.set_params(alpha=10.0)
         assert model.alpha == 10.0
 
     def test_clone(self, sparse):
         model = EmpiricalBayesNormalRegressor(
-            alpha=2.0, beta=3.0, n_eb_iter=7, sparse=sparse
+            alpha=2.0, beta=3.0, n_eb_iter=7, sparse=sparse, alpha_prior_strength=0.25
         )
         cloned = clone(model)
         assert cloned.get_params() == model.get_params()
         assert cloned is not model
+        assert cloned.alpha_prior_strength == 0.25
 
     def test_pickle_roundtrip(self, regression_data, sparse):
         X, y = regression_data
@@ -239,6 +248,41 @@ class TestEBNormalRegressor:
         assert model.alpha != 3.0 and model._alpha0 == 3.0
         model.fit(X, y)
         assert model._alpha0 == 3.0
+
+    def test_hyperprior_bounds_alpha_on_pure_noise(self, sparse):
+        """Pure noise: plain alpha runs off (no ceiling here), regularized stays bounded."""
+        rng = np.random.default_rng(3)
+        n, p = 300, 5
+        X = np.eye(p)[rng.integers(0, p, size=n)]
+        y = rng.standard_normal(n) * 10.0
+        y -= X @ (X.T @ y / X.sum(axis=0))  # centered: the noise carries no signal
+        alpha0 = 1.0
+        k = EmpiricalBayesNormalRegressor().alpha_prior_strength
+        bound = (p + k) * alpha0 / k * (1 + 1e-9)
+
+        plain = EmpiricalBayesNormalRegressor(
+            sparse=sparse, n_eb_iter=50, alpha_prior_strength=0.0
+        ).fit(X, y)
+        assert plain.alpha > 1e100
+
+        model = EmpiricalBayesNormalRegressor(sparse=sparse, n_eb_iter=50).fit(X, y)
+        assert model.alpha <= bound
+        assert model.eb_updates_rejected_ == 0
+
+        plain = EmpiricalBayesNormalRegressor(sparse=sparse, alpha_prior_strength=0.0)
+        online = EmpiricalBayesNormalRegressor(sparse=sparse)
+        for start in range(0, n, 10):
+            plain.partial_fit(X[start : start + 10], y[start : start + 10])
+            online.partial_fit(X[start : start + 10], y[start : start + 10])
+            assert online.alpha <= bound
+        assert plain.alpha > 1e10
+        assert online.eb_updates_rejected_ == 0
+
+    def test_negative_prior_strength_raises(self, regression_data, sparse):
+        X, y = regression_data
+        model = EmpiricalBayesNormalRegressor(sparse=sparse, alpha_prior_strength=-1.0)
+        with pytest.raises(ValueError, match="alpha_prior_strength"):
+            model.fit(X, y)
 
     def test_decay(self, regression_data, sparse):
         """decay() scales _prior_scalar and sufficient stats."""

--- a/tests/test_eb_glm.py
+++ b/tests/test_eb_glm.py
@@ -74,8 +74,14 @@ class TestEBGLM:
         evidences = []
         alpha = 50.0
         for _ in range(10):
+            # re-anchored each round, so only plain MacKay is one objective
             model = EmpiricalBayesGLM(
-                alpha=alpha, link=link, n_eb_iter=1, eb_tol=0.0, sparse=sparse
+                alpha=alpha,
+                link=link,
+                n_eb_iter=1,
+                eb_tol=0.0,
+                sparse=sparse,
+                alpha_prior_strength=0.0,
             )
             model.fit(_X(X, sparse), y)
             evidences.append(model.log_evidence_)
@@ -123,19 +129,30 @@ class TestEBGLM:
         theta = plain.coef_
         P = _dense_prec(plain)
         p = X.shape[1]
+        k = model.alpha_prior_strength
         expected = (
             glm_log_likelihood(X, y, theta, link)
             + 0.5 * p * np.log(alpha0)
             - 0.5 * alpha0 * theta @ theta
             - 0.5 * np.linalg.slogdet(P)[1]
+            + 0.5 * k * np.log(alpha0)
+            - 0.5 * k  # alpha / alpha0 at the anchor
         )
         np.testing.assert_allclose(model.log_evidence_, expected, rtol=1e-8)
 
-    def test_converged_alpha_is_the_mackay_fixed_point(self, link, sparse):
-        """At convergence alpha = gamma / ||theta||^2 with gamma and theta
-        taken from an independent plain GLM fit at that alpha."""
+    @pytest.mark.parametrize("k", [0.0, 0.5])
+    def test_converged_alpha_is_the_mackay_fixed_point(self, link, sparse, k):
+        """At convergence alpha = (gamma + k) / (||theta||^2 + k/alpha0) with
+        gamma and theta taken from an independent plain GLM fit at that
+        alpha."""
         X, y = _simulate(link)
-        eb = EmpiricalBayesGLM(link=link, sparse=sparse, n_eb_iter=100, eb_tol=1e-10)
+        eb = EmpiricalBayesGLM(
+            link=link,
+            sparse=sparse,
+            n_eb_iter=100,
+            eb_tol=1e-10,
+            alpha_prior_strength=k,
+        )
         eb.fit(_X(X, sparse), y)
         plain = BayesianGLM(
             alpha=eb.alpha,
@@ -145,18 +162,27 @@ class TestEBGLM:
         ).fit(_X(X, sparse), y)
         theta = plain.coef_
         gamma = X.shape[1] - eb.alpha * np.trace(np.linalg.inv(_dense_prec(plain)))
-        np.testing.assert_allclose(eb.alpha, gamma / (theta @ theta), rtol=1e-5)
+        np.testing.assert_allclose(
+            eb.alpha, (gamma + k) / (theta @ theta + k / eb._alpha0), rtol=1e-5
+        )
 
     def test_partial_fit_tracks_full_fit(self, link, sparse):
         """Chunked partial_fit from a far-off alpha lands near the full
         fit's fixed point. The slack is sequential Laplace: even at fixed
         alpha the chunked posterior is 2-4% off the batch one."""
         X, y = _simulate(link, n=4000, p=10, seed=7)
-        full = EmpiricalBayesGLM(alpha=1e3, link=link, sparse=sparse, n_eb_iter=50)
+        # the two starts would anchor differently; compare plain MacKay
+        full = EmpiricalBayesGLM(
+            alpha=1e3, link=link, sparse=sparse, n_eb_iter=50, alpha_prior_strength=0.0
+        )
         full.fit(_X(X, sparse), y)
         for alpha0 in (1e3, 1e-2):
             online = EmpiricalBayesGLM(
-                alpha=alpha0, link=link, sparse=sparse, n_eb_iter=1
+                alpha=alpha0,
+                link=link,
+                sparse=sparse,
+                n_eb_iter=1,
+                alpha_prior_strength=0.0,
             )
             for start in range(0, 4000, 50):
                 online.partial_fit(
@@ -167,9 +193,41 @@ class TestEBGLM:
 
     def test_recovers_true_alpha(self, link, sparse):
         X, y = _simulate(link, n=4000, p=40, seed=3, alpha_true=4.0)
-        model = EmpiricalBayesGLM(alpha=0.1, link=link, sparse=sparse, n_eb_iter=50)
+        # alpha0 is 40x too small, so the hyperprior's bound would bind
+        model = EmpiricalBayesGLM(
+            alpha=0.1, link=link, sparse=sparse, n_eb_iter=50, alpha_prior_strength=0.0
+        )
         model.fit(_X(X, sparse), y)
         assert 0.4 < model.alpha / 4.0 < 2.5
+
+    def test_hyperprior_keeps_alpha_off_the_guardrail(self, link, sparse):
+        """Near-zero coefficients: plain alpha hits the ceiling, regularized stays bounded."""
+        X, y = _simulate(link, n=30, p=5, seed=5, alpha_true=1e4)
+        p, alpha0 = 5, 1.0
+        k = EmpiricalBayesGLM().alpha_prior_strength
+        bound = (p + k) * alpha0 / k * (1 + 1e-9)
+
+        plain = EmpiricalBayesGLM(
+            link=link, sparse=sparse, n_eb_iter=50, alpha_prior_strength=0.0
+        ).fit(_X(X, sparse), y)
+        assert plain.alpha > 100
+
+        model = EmpiricalBayesGLM(link=link, sparse=sparse, n_eb_iter=50)
+        model.fit(_X(X, sparse), y)
+        assert model.alpha <= bound
+        assert model.eb_converged_ and model.eb_updates_rejected_ == 0
+
+        online = EmpiricalBayesGLM(link=link, sparse=sparse)
+        for start in range(0, 30, 5):
+            online.partial_fit(_X(X[start : start + 5], sparse), y[start : start + 5])
+            assert online.alpha <= bound
+        assert online.eb_updates_rejected_ == 0
+
+    def test_negative_prior_strength_raises(self, link, sparse):
+        X, y = _simulate(link)
+        model = EmpiricalBayesGLM(link=link, sparse=sparse, alpha_prior_strength=-1.0)
+        with pytest.raises(ValueError, match="alpha_prior_strength"):
+            model.fit(_X(X, sparse), y)
 
     def test_n_eb_iter_zero(self, link, sparse):
         X, y = _simulate(link)
@@ -306,14 +364,21 @@ class TestEBGLM:
 
     def test_get_set_params_and_clone(self, link, sparse):
         model = EmpiricalBayesGLM(
-            alpha=2.0, link=link, n_eb_iter=3, eb_tol=1e-2, sparse=sparse
+            alpha=2.0,
+            link=link,
+            n_eb_iter=3,
+            eb_tol=1e-2,
+            sparse=sparse,
+            alpha_prior_strength=0.25,
         )
         params = model.get_params()
         assert params["n_eb_iter"] == 3 and params["eb_tol"] == 1e-2
         assert params["link"] == link
+        assert params["alpha_prior_strength"] == 0.25
         model.set_params(n_eb_iter=7)
         cloned = cast(EmpiricalBayesGLM, clone(model))
         assert cloned.n_eb_iter == 7
+        assert cloned.alpha_prior_strength == 0.25
 
     def test_pickle_roundtrip(self, link, sparse):
         X, y = _simulate(link)

--- a/tests/test_empirical_bayes.py
+++ b/tests/test_empirical_bayes.py
@@ -14,10 +14,13 @@ from scipy.sparse import csc_array
 from scipy.special import expit, gammaln
 
 from bayesianbandits._empirical_bayes import (
+    MacKayGLMUpdate,
+    MacKayUpdate,
     _diagonal_trace_approx,
     _dirichlet_multinomial_log_evidence,
     _factorization_stats,
     accumulate_sufficient_stats,
+    mackay_update_glm,
     mackay_update_normal_online,
     minka_update_dirichlet_multinomial,
     negbin_update_gamma_poisson,
@@ -505,6 +508,134 @@ class TestLogEvidenceFromUpdates:
         )
         expected = _log_evidence_normal_hand(X, y, mu_n, precision, alpha, beta)
         np.testing.assert_allclose(result.log_evidence, expected, atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# 10b. Gamma hyperprior on alpha
+# ---------------------------------------------------------------------------
+
+
+def _normal_objective(alpha, beta, X, y, k, alpha0):
+    """The Normal update at alpha, for checking its fixed point against its evidence."""
+    mu_n, precision = _compute_posterior_normal(X, y, alpha, beta)
+    return mackay_update_normal_online(
+        mu_n,
+        precision,
+        alpha,
+        beta,
+        prior_scalar=alpha,
+        effective_n=float(X.shape[0]),
+        eff_yTy=float(y @ y),
+        eff_XTy=np.asarray(X.T @ y, dtype=np.float64),
+        factor=_make_dense_factor(precision),
+        alpha_prior_strength=k,
+        alpha_prior_mode=alpha0,
+    )
+
+
+def _glm_objective(alpha, H, t, k, alpha0):
+    """The GLM update on a quadratic log-likelihood, where the Laplace evidence is exact."""
+    precision = alpha * np.eye(H.shape[0]) + H
+    theta = np.linalg.solve(precision, H @ t)
+    log_lik = -0.5 * float((theta - t) @ H @ (theta - t))
+    return mackay_update_glm(
+        theta,
+        precision,
+        alpha,
+        prior_scalar=alpha,
+        effective_n=1e9,
+        log_lik=log_lik,
+        factor=_make_dense_factor(precision),
+        alpha_prior_strength=k,
+        alpha_prior_mode=alpha0,
+    )
+
+
+class TestAlphaHyperprior:
+    def _normal_data(self):
+        rng = np.random.default_rng(11)
+        X = rng.standard_normal((30, 4))
+        y = X @ rng.standard_normal(4) + rng.standard_normal(30) * 0.5
+        return X.astype(np.float64), y.astype(np.float64)
+
+    def _glm_data(self):
+        rng = np.random.default_rng(12)
+        A = rng.standard_normal((6, 4))
+        return (A.T @ A).astype(np.float64), rng.standard_normal(4).astype(np.float64)
+
+    def test_zero_mean_is_bounded_not_infinite(self) -> None:
+        """At theta = 0 plain MacKay falls back; k > 0 gives (gamma + k) alpha0 / k."""
+        p, alpha, beta, k, alpha0 = 3, 2.0, 1.0, 0.5, 4.0
+        precision = np.asarray((alpha + beta) * np.eye(p), dtype=np.float64)
+        gamma = p - alpha * p / (alpha + beta)
+        zeros = np.zeros(p)
+        factor = _make_dense_factor(precision)
+
+        def normal(k: float) -> MacKayUpdate:
+            return mackay_update_normal_online(
+                zeros,
+                precision,
+                alpha,
+                beta,
+                prior_scalar=alpha,
+                effective_n=10.0,
+                eff_yTy=1.0,
+                eff_XTy=zeros,
+                factor=factor,
+                alpha_prior_strength=k,
+                alpha_prior_mode=alpha0,
+            )
+
+        def glm(k: float) -> MacKayGLMUpdate:
+            return mackay_update_glm(
+                zeros,
+                precision,
+                alpha,
+                prior_scalar=alpha,
+                effective_n=10.0,
+                log_lik=0.0,
+                factor=factor,
+                alpha_prior_strength=k,
+                alpha_prior_mode=alpha0,
+            )
+
+        assert normal(0.0).alpha == alpha
+        assert glm(0.0).alpha == alpha
+        for reg in (normal(k), glm(k)):
+            np.testing.assert_allclose(reg.alpha, (gamma + k) * alpha0 / k)
+            assert not reg.rejected
+
+    @pytest.mark.parametrize("k", [0.0, 0.5, 3.0])
+    def test_normal_fixed_point_is_stationary(self, k) -> None:
+        """The iteration's fixed point is a local maximum of the reported evidence."""
+        X, y = self._normal_data()
+        alpha, beta, alpha0 = 1.0, 1.0, 0.3
+        for _ in range(500):
+            upd = _normal_objective(alpha, beta, X, y, k, alpha0)
+            alpha, beta = upd.alpha, upd.beta
+
+        def obj(a):
+            return _normal_objective(a, beta, X, y, k, alpha0).log_evidence
+
+        assert obj(alpha) >= obj(alpha * (1 + 1e-3))
+        assert obj(alpha) >= obj(alpha * (1 - 1e-3))
+        h = 1e-5 * alpha
+        assert abs(obj(alpha + h) - obj(alpha - h)) / (2 * h) < 1e-4
+
+    @pytest.mark.parametrize("k", [0.0, 0.5, 3.0])
+    def test_glm_fixed_point_is_stationary(self, k) -> None:
+        H, t = self._glm_data()
+        alpha, alpha0 = 1.0, 0.3
+        for _ in range(500):
+            alpha = _glm_objective(alpha, H, t, k, alpha0).alpha
+
+        def obj(a):
+            return _glm_objective(a, H, t, k, alpha0).log_evidence
+
+        assert obj(alpha) >= obj(alpha * (1 + 1e-3))
+        assert obj(alpha) >= obj(alpha * (1 - 1e-3))
+        h = 1e-5 * alpha
+        assert abs(obj(alpha + h) - obj(alpha - h)) / (2 * h) < 1e-4
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #286. Stacked on #287; merge that first.

`alpha_new = (γ + k) / (‖θ‖² + k/α₀)`, with `α₀` the constructor's alpha and `k = alpha_prior_strength` pseudo-observations (shape `1 + k/2`, rate `k/(2α₀)`), in both `mackay_update_normal_online` and `mackay_update_glm`; `log_evidence_` carries the log hyperprior so the update is its stationary point. Tipping 2001 App. A and sklearn's `BayesianRidge` have the same form (sklearn's `lambda_1 = lambda_2 = 1e-6` is the `k → 0` limit); Chung et al. 2013 / blme is the precedent for a shape above 1 keeping the mode off the boundary. `0.0` is the previous update, and the tests that probe the raw fixed point pass it explicitly.

Two corrections to the issue text. The bound on the learned alpha is `(γ + k)·α₀/k` with `γ ≤ min(n_eff, p)`, not `p·α₀/k`: alpha cannot be learned more than about `γ/k` times larger than `α₀`, and under `learning_rate < 1` that is permanent since `n_eff` is capped. And the plain Normal path does not just reach `2e201`, it overflows to `inf`.

The default is `0.2` rather than the issue's `1.0`, from a Thompson-sampling sweep (K=5, T=3000, 20 reps, 5 dense + Zipf one-hot contexts, constructor `alpha=1`):

| scenario | fixed | oracle | k=0 | k=0.1 | **k=0.2** | k=0.5 | k=1 |
|---|---|---|---|---|---|---|---|
| dense Normal, α_true 100, lr .99 | 578 | 535 | 638 (inf) | 469 | 478 | 487 | 504 |
| GLM 200 one-hot, α_true 25, lr 1 | 237 | 183 | 195 (max 7e11) | 176 | 178 | 188 | 193 |
| GLM 200 one-hot, lr .99 | 313 | 280 | 298 | 244 | 242 | 243 | 249 |
| Normal 0.1-scale rewards, lr 1 | 394 | 49 | 51 | 54 | 55 | 61 | 65 |
| Normal 0.1-scale rewards, lr .99 | 561 | 95 | 74 | 79 | 80 | 89 | 100 |

Where the data are informative and `α₀` is 100x too small (the Normal rows), plain MacKay learns alpha ≈ 100 exactly and `k = 0.5` costs 20% regret to the bound; `k = 0.2` gives most of that back while still holding the explosion cases (pure-noise one-hot Normal at ~4 where plain reaches 1e191; near-zero-coefficient GLM at ~12 where plain reaches 1e11). `0.2` is also BoTorch's historic `GammaPrior(1.1, 0.05)` noise prior in this parametrization. A log-normal prior on `log α` (BoTorch's current choice, symmetric so no wall above `α₀`) was prototyped on the same seeds: at `σ = 2` it ties `k = 0.2` within 1 to 2 se in both directions and reaches the same alpha envelope on the noise cases, so the closed form stays.

Separate follow-up: on the Normal path `beta = (n_eff − γ)/rss` has the mirror failure while `n < p` (rss ≈ 0 from interpolation), reaching 1e4 to 2e11 by row 5 to 8 and recovering by row 20; the `beta/alpha` guardrail does not catch it since alpha stays small. Same fix, one parameter over.