### PR TITLE
Drop the delegation boilerplate in the agent and policy layers

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,20 @@ Unreleased
 
 **Breaking changes**
 
+- ``NonContextualAgentPipeline`` is removed, and ``AgentPipeline`` is now
+  a class rather than a factory dispatching between it and
+  ``ContextualAgentPipeline``. A pipeline's steps transform the context on
+  its way to the agent; a non-contextual ``Agent`` has no context, so the
+  steps never ran. The class validated its ``steps``, stored them, and
+  exposed them through ``named_steps``, ``__len__``, and ``__getitem__``
+  without ever applying them. ``AgentPipeline`` now raises ``TypeError``
+  on an ``Agent``, pointing at ``LearnerPipeline`` for preprocessing the
+  arms' features. Code wrapping a plain ``Agent`` should drop the wrapper
+  and use the agent, which has the same ``pull``/``update``/``decay``
+  interface. ``ContextualAgentPipeline`` remains as an alias for
+  ``AgentPipeline``, so the two are now one class under two names, but
+  ``repr`` reports ``AgentPipeline`` (#291)
+
 - ``EmpiricalBayesNormalRegressor`` and ``EmpiricalBayesGLM`` regularize
   the MacKay update of ``alpha`` with a Gamma hyperprior at the
   constructor's ``alpha``, weighted by the new ``alpha_prior_strength``
@@ -76,6 +90,13 @@ Unreleased
   law, so the remaining path needs no batching (#267)
 
 **New features**
+
+- ``PolicyDefaultUpdate`` implements ``__call__``, so a policy subclassing
+  it now needs only ``samples_needed`` and ``select``: draw the samples
+  the policy asked for, then let it choose. All five shipped policies had
+  carried a byte-identical copy of that two-line body under its own pair
+  of ``@overload`` stubs. The base also declares ``samples_needed`` and
+  ``select``, naming the contract it calls into (#291)
 
 - ``EmpiricalBayesGLM``: ``BayesianGLM`` with MacKay evidence-framework
   tuning of the prior precision ``alpha``, applied to the Laplace

--- a/src/bayesianbandits/pipelines/__init__.py
+++ b/src/bayesianbandits/pipelines/__init__.py
@@ -2,7 +2,7 @@
 
 This module provides two types of pipelines:
 
-1. **AgentPipeline**: Wraps Agent/ContextualAgent with preprocessing steps.
+1. **AgentPipeline**: Wraps a ContextualAgent with preprocessing steps.
    Use this when you want to apply sklearn preprocessing to raw input data
    before it reaches the agent.
 
@@ -14,13 +14,11 @@ This module provides two types of pipelines:
 from ._agent import (
     AgentPipeline,
     ContextualAgentPipeline,
-    NonContextualAgentPipeline,
 )
 from ._learner import LearnerPipeline
 
 __all__ = [
     "AgentPipeline",
     "ContextualAgentPipeline",
-    "NonContextualAgentPipeline",
     "LearnerPipeline",
 ]

--- a/src/bayesianbandits/pipelines/_agent.py
+++ b/src/bayesianbandits/pipelines/_agent.py
@@ -1,8 +1,8 @@
 """Agent-wrapping pipeline implementation for Bayesian bandits.
 
 This module implements agent-wrapping pipelines that apply preprocessing steps
-before delegating to wrapped Agent/ContextualAgent instances. This enables
-efficient preprocessing at the agent level rather than per-arm.
+before delegating to a wrapped ContextualAgent. This enables efficient
+preprocessing at the agent level rather than per-arm.
 """
 
 from typing import Any, Dict, Generic, List, Optional, Tuple, Union, overload
@@ -55,7 +55,7 @@ def _transform_data(X: Any, steps: List[Tuple[str, Any]]) -> Any:
     return result
 
 
-class ContextualAgentPipeline(MemoryUsageMixin, Generic[ContextType, TokenType]):
+class AgentPipeline(MemoryUsageMixin, Generic[ContextType, TokenType]):
     """Pipeline that wraps a ContextualAgent.
 
     Transforms input data through preprocessing steps before delegating
@@ -84,7 +84,7 @@ class ContextualAgentPipeline(MemoryUsageMixin, Generic[ContextType, TokenType])
     >>> # Pipeline can accept dict input and transform to sparse
     >>> vectorizer = DictVectorizer(sparse=True)
     >>> _ = vectorizer.fit([{'user': 'A', 'item': 1}, {'user': 'B', 'item': 2}])
-    >>> pipeline = ContextualAgentPipeline(
+    >>> pipeline = AgentPipeline(
     ...     steps=[('vectorize', vectorizer)],
     ...     final_agent=agent
     ... )
@@ -100,6 +100,13 @@ class ContextualAgentPipeline(MemoryUsageMixin, Generic[ContextType, TokenType])
         steps: List[Tuple[str, Any]],
         final_agent: ContextualAgent[ContextType, TokenType],
     ) -> None:
+        if isinstance(final_agent, Agent):
+            raise TypeError(
+                "AgentPipeline wraps a contextual agent, whose context the "
+                "steps transform. A non-contextual Agent has no context to "
+                "transform, so the steps would never run. Preprocess the "
+                "arms' features with a LearnerPipeline instead."
+            )
         _validate_steps(steps)
         self.steps = steps
         self._agent = final_agent
@@ -238,7 +245,7 @@ class ContextualAgentPipeline(MemoryUsageMixin, Generic[ContextType, TokenType])
             f"('{name}', {transformer.__class__.__name__})"
             for name, transformer in self.steps
         ]
-        return f"ContextualAgentPipeline(steps=[{', '.join(steps_repr)}], final_agent={self._agent!r})"
+        return f"AgentPipeline(steps=[{', '.join(steps_repr)}], final_agent={self._agent!r})"
 
     def __len__(self) -> int:
         """Number of steps in the pipeline."""
@@ -251,237 +258,6 @@ class ContextualAgentPipeline(MemoryUsageMixin, Generic[ContextType, TokenType])
         return self.steps[ind]
 
 
-class NonContextualAgentPipeline(MemoryUsageMixin, Generic[TokenType]):
-    """Pipeline that wraps an Agent.
-
-    For non-contextual agents, preprocessing steps are not applied since
-    there's no context to transform. This class exists primarily for
-    API consistency and to support future extensions.
-
-    Parameters
-    ----------
-    steps : List[Tuple[str, Any]]
-        List of (name, transformer) tuples. For non-contextual agents,
-        these are typically unused but kept for API consistency.
-    final_agent : Agent[TokenType]
-        The Agent to wrap and delegate to.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from bayesianbandits import Arm, NormalRegressor, Agent, ThompsonSampling
-    >>>
-    >>> # Create arms and agent
-    >>> arms = [Arm(i, learner=NormalRegressor(alpha=1.0, beta=1.0)) for i in range(3)]
-    >>> agent = Agent(arms, ThompsonSampling())
-    >>>
-    >>> # Create pipeline (steps are unused for non-contextual)
-    >>> pipeline = NonContextualAgentPipeline(
-    ...     steps=[],  # No preprocessing needed
-    ...     final_agent=agent
-    ... )
-    >>>
-    >>> # Use like a normal Agent
-    >>> recommendations = pipeline.pull()
-    >>> pipeline.update(np.array([1.0]))
-    """
-
-    def __init__(
-        self, steps: List[Tuple[str, Any]], final_agent: Agent[TokenType]
-    ) -> None:
-        (
-            _validate_steps(steps) if steps else None
-        )  # Allow empty steps for non-contextual
-        self.steps = steps
-        self._agent = final_agent
-
-    @property
-    def named_steps(self) -> Dict[str, Any]:
-        """Access pipeline steps by name."""
-        return dict(self.steps)
-
-    @overload
-    def pull(self) -> List[TokenType]: ...
-
-    @overload
-    def pull(self, *, top_k: int) -> List[List[TokenType]]: ...
-
-    def pull(
-        self, *, top_k: Optional[int] = None
-    ) -> Union[List[TokenType], List[List[TokenType]]]:
-        """Choose arm(s) and pull.
-
-        Parameters
-        ----------
-        top_k : int, optional
-            Number of arms to select. If None (default), selects single
-            best arm.
-
-        Returns
-        -------
-        List[TokenType] or List[List[TokenType]]
-            If top_k is None: List containing single action token
-            If top_k is int: List containing list of action tokens
-        """
-        if top_k is None:
-            return self._agent.pull()
-        else:
-            return self._agent.pull(top_k=top_k)
-
-    def update(
-        self,
-        y: NDArray[np.float64],
-        sample_weight: Optional[NDArray[np.float64]] = None,
-    ) -> None:
-        """Update the wrapped agent with observed reward(s).
-
-        Parameters
-        ----------
-        y : NDArray[np.float64]
-            Reward(s) to use for updating the arm.
-        sample_weight : Optional[NDArray[np.float64]], default=None
-            Sample weights to use for updating the arm.
-        """
-        self._agent.update(y, sample_weight=sample_weight)
-
-    def decay(self, decay_rate: Optional[float] = None) -> None:
-        """Decay all arms of the wrapped agent.
-
-        Parameters
-        ----------
-        decay_rate : Optional[float], default=None
-            Decay rate to use for decaying the arms.
-        """
-        self._agent.decay(decay_rate=decay_rate)
-
-    # Delegation methods
-    def add_arm(self, arm: Arm[NDArray[np.float64], TokenType]) -> None:
-        """Add an arm to the wrapped agent."""
-        self._agent.add_arm(arm)
-
-    def remove_arm(self, token: TokenType) -> None:
-        """Remove an arm from the wrapped agent."""
-        self._agent.remove_arm(token)
-
-    def arm(self, token: TokenType) -> Arm[NDArray[np.float64], TokenType]:
-        """Get an arm by its action token."""
-        return self._agent.arm(token)
-
-    def select_for_update(self, token: TokenType) -> Self:
-        """Set the arm to update and return self for chaining."""
-        self._agent.select_for_update(token)
-        return self
-
-    @property
-    def arms(self) -> List[Arm[NDArray[np.float64], TokenType]]:
-        """Get the arms from the wrapped agent."""
-        return self._agent.arms
-
-    @property
-    def arm_to_update(self) -> Arm[NDArray[np.float64], TokenType]:
-        """Get the arm to update from the wrapped agent."""
-        return self._agent.arm_to_update
-
-    @property
-    def policy(self) -> PolicyProtocol[NDArray[np.float64], TokenType]:
-        """Get the policy from the wrapped agent."""
-        return self._agent.policy
-
-    @policy.setter
-    def policy(self, value: PolicyProtocol[NDArray[np.float64], TokenType]) -> None:
-        """Set the policy on the wrapped agent."""
-        self._agent.policy = value
-
-    @property
-    def rng(self) -> np.random.Generator:
-        """Get the random generator from the wrapped agent."""
-        return self._agent.rng
-
-    @rng.setter
-    def rng(self, value: Union[int, None, np.random.Generator]) -> None:
-        """Set the random generator on the wrapped agent."""
-        self._agent.rng = value
-
-    def __repr__(self) -> str:
-        """String representation."""
-        steps_repr = [
-            f"('{name}', {transformer.__class__.__name__})"
-            for name, transformer in self.steps
-        ]
-        return f"NonContextualAgentPipeline(steps=[{', '.join(steps_repr)}], final_agent={self._agent!r})"
-
-    def __len__(self) -> int:
-        """Number of steps in the pipeline."""
-        return len(self.steps)
-
-    def __getitem__(self, ind: Union[int, str]) -> Any:
-        """Get a step by index or name."""
-        if isinstance(ind, str):
-            return self.named_steps[ind]
-        return self.steps[ind]
-
-
-# Factory function with overloads
-@overload
-def AgentPipeline(
-    steps: List[Tuple[str, Any]], final_agent: ContextualAgent[ContextType, TokenType]
-) -> ContextualAgentPipeline[ContextType, TokenType]: ...
-
-
-@overload
-def AgentPipeline(
-    steps: List[Tuple[str, Any]], final_agent: Agent[TokenType]
-) -> NonContextualAgentPipeline[TokenType]: ...
-
-
-def AgentPipeline(
-    steps: List[Tuple[str, Any]],
-    final_agent: Union[ContextualAgent[ContextType, TokenType], Agent[TokenType]],
-) -> Union[
-    ContextualAgentPipeline[ContextType, TokenType],
-    NonContextualAgentPipeline[TokenType],
-]:
-    """Create a Pipeline that wraps an Agent or ContextualAgent.
-
-    This factory function provides a clean API for creating pipelines
-    while maintaining complete static typing based on the agent type.
-    The pipeline can accept any input type and transform it to what the agent expects.
-
-    The resulting Pipeline will have the same interface as the wrapped agent,
-    allowing you to call `pull`, `update`, and other methods directly on it.
-
-    Parameters
-    ----------
-    steps : List[Tuple[str, Any]]
-        List of (name, transformer) tuples for preprocessing steps.
-        All transformers must be either stateless or pre-fitted.
-        The output of the transformation chain must match the agent's expected input type.
-    final_agent : Agent[TokenType] or ContextualAgent[ContextType, TokenType]
-        The agent to wrap. The pipeline type is determined by the agent type.
-
-    Returns
-    -------
-    ContextualAgentPipeline or NonContextualAgentPipeline
-        The appropriate pipeline type based on the final_agent type.
-
-    Examples
-    --------
-    >>> from sklearn.feature_extraction import DictVectorizer
-    >>> from bayesianbandits import Arm, NormalRegressor, ContextualAgent, ThompsonSampling
-    >>>
-    >>> # Pipeline accepting dict input, outputting sparse arrays for agent
-    >>> arms = [Arm(i, learner=NormalRegressor(alpha=1.0, beta=1.0, sparse=True)) for i in range(3)]
-    >>> agent = ContextualAgent(arms, ThompsonSampling())
-    >>> vectorizer = DictVectorizer()
-    >>> _ = vectorizer.fit([{'user': 'A'}, {'user': 'B'}])
-    >>>
-    >>> pipeline = AgentPipeline(
-    ...     steps=[('vectorize', vectorizer)],
-    ...     final_agent=agent
-    ... )
-    >>> # Can accept dict input: [{'user': 'A', 'item': 1}]
-    >>> # Transforms to sparse matrix for agent
-    """
-    if isinstance(final_agent, Agent):
-        return NonContextualAgentPipeline(steps, final_agent)
-    return ContextualAgentPipeline(steps, final_agent)
+#: Kept for backward compatibility. One pipeline class serves every
+#: agent that has a context for its steps to transform.
+ContextualAgentPipeline = AgentPipeline

--- a/src/bayesianbandits/policies/_base.py
+++ b/src/bayesianbandits/policies/_base.py
@@ -6,6 +6,8 @@ from typing import (
     Generic,
     List,
     Optional,
+    Union,
+    overload,
 )
 
 import numpy as np
@@ -20,6 +22,11 @@ class PolicyDefaultUpdate(Generic[ContextType, TokenType]):
     #: serve every policy. Subclasses declare a weaker requirement to
     #: get cheaper draws (see :class:`~bayesianbandits.DrawKind`).
     consumes: DrawKind = DrawKind.JOINT
+
+    @property
+    def samples_needed(self) -> int:
+        """Number of samples per arm per context needed for decision making."""
+        raise NotImplementedError
 
     def _draw_samples(
         self,
@@ -58,6 +65,67 @@ class PolicyDefaultUpdate(Generic[ContextType, TokenType]):
                 for arm in arms
             ]
         )
+
+    @overload
+    def select(
+        self,
+        samples: NDArray[np.float64],  # Shape: (n_arms, n_contexts, samples_needed)
+        arms: List[Arm[ContextType, TokenType]],
+        rng: np.random.Generator,
+        top_k: None = None,
+    ) -> List[Arm[ContextType, TokenType]]: ...
+
+    @overload
+    def select(
+        self,
+        samples: NDArray[np.float64],  # Shape: (n_arms, n_contexts, samples_needed)
+        arms: List[Arm[ContextType, TokenType]],
+        rng: np.random.Generator,
+        top_k: int,
+    ) -> List[List[Arm[ContextType, TokenType]]]: ...
+
+    def select(
+        self,
+        samples: NDArray[np.float64],  # Shape: (n_arms, n_contexts, samples_needed)
+        arms: List[Arm[ContextType, TokenType]],
+        rng: np.random.Generator,
+        top_k: Optional[int] = None,
+    ) -> Union[
+        List[Arm[ContextType, TokenType]], List[List[Arm[ContextType, TokenType]]]
+    ]:
+        """Select arms based on pre-generated samples."""
+        raise NotImplementedError
+
+    @overload
+    def __call__(
+        self,
+        arms: List[Arm[ContextType, TokenType]],
+        X: ContextType,
+        rng: np.random.Generator,
+        top_k: None = None,
+    ) -> List[Arm[ContextType, TokenType]]: ...
+
+    @overload
+    def __call__(
+        self,
+        arms: List[Arm[ContextType, TokenType]],
+        X: ContextType,
+        rng: np.random.Generator,
+        top_k: int,
+    ) -> List[List[Arm[ContextType, TokenType]]]: ...
+
+    def __call__(
+        self,
+        arms: List[Arm[ContextType, TokenType]],
+        X: ContextType,
+        rng: np.random.Generator,
+        top_k: Optional[int] = None,
+    ) -> Union[
+        List[Arm[ContextType, TokenType]], List[List[Arm[ContextType, TokenType]]]
+    ]:
+        """Draw the samples the policy asked for, then let it choose."""
+        samples = self._draw_samples(arms, X, self.samples_needed)
+        return self.select(samples, arms, rng, top_k)
 
     def update(
         self,

--- a/src/bayesianbandits/policies/_epsilon_greedy.py
+++ b/src/bayesianbandits/policies/_epsilon_greedy.py
@@ -182,34 +182,3 @@ class EpsilonGreedy(PolicyDefaultUpdate[ContextType, TokenType]):
                 ]
                 for i in range(values.shape[1])
             ]
-
-    @overload
-    def __call__(
-        self,
-        arms: List[Arm[ContextType, TokenType]],
-        X: ContextType,
-        rng: np.random.Generator,
-        top_k: None = None,
-    ) -> List[Arm[ContextType, TokenType]]: ...
-
-    @overload
-    def __call__(
-        self,
-        arms: List[Arm[ContextType, TokenType]],
-        X: ContextType,
-        rng: np.random.Generator,
-        top_k: int,
-    ) -> List[List[Arm[ContextType, TokenType]]]: ...
-
-    def __call__(
-        self,
-        arms: List[Arm[ContextType, TokenType]],
-        X: ContextType,
-        rng: np.random.Generator,
-        top_k: Optional[int] = None,
-    ) -> Union[
-        List[Arm[ContextType, TokenType]], List[List[Arm[ContextType, TokenType]]]
-    ]:
-        """Choose arm(s) using epsilon-greedy."""
-        samples = self._draw_samples(arms, X, self.samples_needed)
-        return self.select(samples, arms, rng, top_k)

--- a/src/bayesianbandits/policies/_exp3a.py
+++ b/src/bayesianbandits/policies/_exp3a.py
@@ -307,56 +307,6 @@ class EXP3A(PolicyDefaultUpdate[ContextType, TokenType]):
                 results.append([arms[idx] for idx in indices])
             return results
 
-    @overload
-    def __call__(
-        self,
-        arms: List[Arm[ContextType, TokenType]],
-        X: ContextType,
-        rng: np.random.Generator,
-        top_k: None = None,
-    ) -> List[Arm[ContextType, TokenType]]: ...
-
-    @overload
-    def __call__(
-        self,
-        arms: List[Arm[ContextType, TokenType]],
-        X: ContextType,
-        rng: np.random.Generator,
-        top_k: int,
-    ) -> List[List[Arm[ContextType, TokenType]]]: ...
-
-    def __call__(
-        self,
-        arms: List[Arm[ContextType, TokenType]],
-        X: ContextType,
-        rng: np.random.Generator,
-        top_k: Optional[int] = None,
-    ) -> Union[
-        List[Arm[ContextType, TokenType]], List[List[Arm[ContextType, TokenType]]]
-    ]:
-        """
-        Select arms according to exponential weights with optional exploration.
-
-        Parameters
-        ----------
-        arms : List[Arm]
-            Available arms to choose from
-        X : ContextType
-            Context (any iterable)
-        rng : np.random.Generator
-            Random number generator for sampling
-        top_k : int, optional
-            Number of arms to select per context. If None, selects single arm.
-
-        Returns
-        -------
-        List[Arm] or List[List[Arm]]
-            Selected arms, one per context if top_k is None,
-            or k arms per context if top_k is specified.
-        """
-        samples = self._draw_samples(arms, X, self.samples_needed)
-        return self.select(samples, arms, rng, top_k)
-
     def update(
         self,
         arm: Arm[ContextType, TokenType],

--- a/src/bayesianbandits/policies/_information_directed_sampling.py
+++ b/src/bayesianbandits/policies/_information_directed_sampling.py
@@ -471,34 +471,3 @@ class InformationDirectedSampling(PolicyDefaultUpdate[ContextType, TokenType]):
             [arms[choices[slot, ctx]] for slot in range(n_slots)]
             for ctx in range(n_contexts)
         ]
-
-    @overload
-    def __call__(
-        self,
-        arms: List[Arm[ContextType, TokenType]],
-        X: ContextType,
-        rng: np.random.Generator,
-        top_k: None = None,
-    ) -> List[Arm[ContextType, TokenType]]: ...
-
-    @overload
-    def __call__(
-        self,
-        arms: List[Arm[ContextType, TokenType]],
-        X: ContextType,
-        rng: np.random.Generator,
-        top_k: int,
-    ) -> List[List[Arm[ContextType, TokenType]]]: ...
-
-    def __call__(
-        self,
-        arms: List[Arm[ContextType, TokenType]],
-        X: ContextType,
-        rng: np.random.Generator,
-        top_k: Optional[int] = None,
-    ) -> Union[
-        List[Arm[ContextType, TokenType]], List[List[Arm[ContextType, TokenType]]]
-    ]:
-        """Choose arm(s) using information-directed sampling."""
-        samples = self._draw_samples(arms, X, self.samples_needed)
-        return self.select(samples, arms, rng, top_k)

--- a/src/bayesianbandits/policies/_thompson_sampling.py
+++ b/src/bayesianbandits/policies/_thompson_sampling.py
@@ -150,34 +150,3 @@ class ThompsonSampling(PolicyDefaultUpdate[ContextType, TokenType]):
                 ]
                 for i in range(values.shape[1])
             ]
-
-    @overload
-    def __call__(
-        self,
-        arms: List[Arm[ContextType, TokenType]],
-        X: ContextType,
-        rng: np.random.Generator,
-        top_k: None = None,
-    ) -> List[Arm[ContextType, TokenType]]: ...
-
-    @overload
-    def __call__(
-        self,
-        arms: List[Arm[ContextType, TokenType]],
-        X: ContextType,
-        rng: np.random.Generator,
-        top_k: int,
-    ) -> List[List[Arm[ContextType, TokenType]]]: ...
-
-    def __call__(
-        self,
-        arms: List[Arm[ContextType, TokenType]],
-        X: ContextType,
-        rng: np.random.Generator,
-        top_k: Optional[int] = None,
-    ) -> Union[
-        List[Arm[ContextType, TokenType]], List[List[Arm[ContextType, TokenType]]]
-    ]:
-        """Choose arm(s) using Thompson sampling."""
-        samples = self._draw_samples(arms, X, self.samples_needed)
-        return self.select(samples, arms, rng, top_k)

--- a/src/bayesianbandits/policies/_upper_confidence_bound.py
+++ b/src/bayesianbandits/policies/_upper_confidence_bound.py
@@ -169,34 +169,3 @@ class UpperConfidenceBound(PolicyDefaultUpdate[ContextType, TokenType]):
                 ]
                 for i in range(ucb_values.shape[1])
             ]
-
-    @overload
-    def __call__(
-        self,
-        arms: List[Arm[ContextType, TokenType]],
-        X: ContextType,
-        rng: np.random.Generator,
-        top_k: None = None,
-    ) -> List[Arm[ContextType, TokenType]]: ...
-
-    @overload
-    def __call__(
-        self,
-        arms: List[Arm[ContextType, TokenType]],
-        X: ContextType,
-        rng: np.random.Generator,
-        top_k: int,
-    ) -> List[List[Arm[ContextType, TokenType]]]: ...
-
-    def __call__(
-        self,
-        arms: List[Arm[ContextType, TokenType]],
-        X: ContextType,
-        rng: np.random.Generator,
-        top_k: Optional[int] = None,
-    ) -> Union[
-        List[Arm[ContextType, TokenType]], List[List[Arm[ContextType, TokenType]]]
-    ]:
-        """Choose arm(s) using upper confidence bound."""
-        samples = self._draw_samples(arms, X, self.samples_needed)
-        return self.select(samples, arms, rng, top_k)

--- a/tests/test_agent_pipeline.py
+++ b/tests/test_agent_pipeline.py
@@ -1,4 +1,4 @@
-"""Tests for agent-wrapping AgentPipeline implementation."""
+"""Tests for the agent-wrapping AgentPipeline."""
 
 from __future__ import annotations
 
@@ -20,7 +20,6 @@ from bayesianbandits import (
 from bayesianbandits.pipelines import (
     AgentPipeline,
     ContextualAgentPipeline,
-    NonContextualAgentPipeline,
 )
 from bayesianbandits.pipelines._agent import (
     _transform_data,
@@ -112,8 +111,8 @@ class TestTransformData:
         assert "FunctionTransformer" in str(exc_info.value)
 
 
-class TestContextualAgentPipeline:
-    """Test ContextualAgentPipeline class."""
+class TestAgentPipeline:
+    """Test AgentPipeline class."""
 
     def test_basic_construction(self):
         """Test basic contextual pipeline construction."""
@@ -121,7 +120,7 @@ class TestContextualAgentPipeline:
         agent = ContextualAgent(arms, ThompsonSampling())
         steps = [("double", FunctionTransformer(lambda x: x * 2))]
 
-        pipeline = ContextualAgentPipeline(steps, agent)
+        pipeline = AgentPipeline(steps, agent)
 
         assert len(pipeline) == 1
         assert pipeline.named_steps["double"] is not None
@@ -133,7 +132,7 @@ class TestContextualAgentPipeline:
         agent = ContextualAgent(arms, ThompsonSampling())
 
         with pytest.raises(ValueError, match="Pipeline steps cannot be empty"):
-            ContextualAgentPipeline([], agent)
+            AgentPipeline([], agent)
 
     def test_pull_without_top_k(self):
         """Test pull method without top_k."""
@@ -141,7 +140,7 @@ class TestContextualAgentPipeline:
         agent = ContextualAgent(arms, ThompsonSampling(), random_seed=42)
         steps = [("identity", FunctionTransformer())]
 
-        pipeline = ContextualAgentPipeline(steps, agent)
+        pipeline = AgentPipeline(steps, agent)
 
         X = np.array([[1.0, 2.0], [3.0, 4.0]])
         actions = pipeline.pull(X)
@@ -155,7 +154,7 @@ class TestContextualAgentPipeline:
         agent = ContextualAgent(arms, ThompsonSampling(), random_seed=42)
         steps = [("identity", FunctionTransformer())]
 
-        pipeline = ContextualAgentPipeline(steps, agent)
+        pipeline = AgentPipeline(steps, agent)
 
         X = np.array([[1.0, 2.0], [3.0, 4.0]])
         action_lists = pipeline.pull(X, top_k=3)
@@ -169,7 +168,7 @@ class TestContextualAgentPipeline:
         agent = ContextualAgent(arms, ThompsonSampling(), random_seed=42)
         steps = [("scale", FunctionTransformer(lambda x: x / 10))]
 
-        pipeline = ContextualAgentPipeline(steps, agent)
+        pipeline = AgentPipeline(steps, agent)
 
         X = np.array([[10.0, 20.0]])
         y = np.array([1.0])
@@ -190,7 +189,7 @@ class TestContextualAgentPipeline:
         agent = ContextualAgent(arms, ThompsonSampling(), random_seed=42)
         steps = [("identity", FunctionTransformer())]
 
-        pipeline = ContextualAgentPipeline(steps, agent)
+        pipeline = AgentPipeline(steps, agent)
 
         X = np.array([[1.0], [2.0]])
         y = np.array([1.0, 2.0])
@@ -208,7 +207,7 @@ class TestContextualAgentPipeline:
         agent = ContextualAgent(arms, ThompsonSampling())
         steps = [("identity", FunctionTransformer())]
 
-        pipeline = ContextualAgentPipeline(steps, agent)
+        pipeline = AgentPipeline(steps, agent)
 
         X = np.array([[1.0]])
 
@@ -221,7 +220,7 @@ class TestContextualAgentPipeline:
         agent = ContextualAgent(arms, ThompsonSampling())
         steps = [("double", FunctionTransformer(lambda x: x * 2))]
 
-        pipeline = ContextualAgentPipeline(steps, agent)
+        pipeline = AgentPipeline(steps, agent)
 
         X = np.array([[1], [2]])
         result = pipeline.transform(X)
@@ -234,7 +233,7 @@ class TestContextualAgentPipeline:
         agent = ContextualAgent(arms, ThompsonSampling(), random_seed=42)
         steps = [("identity", FunctionTransformer())]
 
-        pipeline = ContextualAgentPipeline(steps, agent)
+        pipeline = AgentPipeline(steps, agent)
 
         # Test property access
         assert pipeline.arms is agent.arms
@@ -266,7 +265,7 @@ class TestContextualAgentPipeline:
         transform2 = StandardScaler()
         steps = [("double", transform1), ("scale", transform2)]
 
-        pipeline = ContextualAgentPipeline(steps, agent)
+        pipeline = AgentPipeline(steps, agent)
 
         # Test string indexing
         assert pipeline["double"] is transform1
@@ -289,201 +288,38 @@ class TestContextualAgentPipeline:
         agent = ContextualAgent(arms, ThompsonSampling())
         steps = [("transform", FunctionTransformer())]
 
-        pipeline = ContextualAgentPipeline(steps, agent)
+        pipeline = AgentPipeline(steps, agent)
         repr_str = repr(pipeline)
 
-        assert "ContextualAgentPipeline" in repr_str
+        assert "AgentPipeline" in repr_str
         assert "FunctionTransformer" in repr_str
 
 
-class TestNonContextualAgentPipeline:
-    """Test NonContextualAgentPipeline class."""
+class TestAgentPipelineName:
+    """Test the AgentPipeline public name."""
 
-    def test_basic_construction(self):
-        """Test basic non-contextual pipeline construction."""
+    def test_contextual_alias(self):
+        """One pipeline class, not a factory dispatching between two."""
+        assert ContextualAgentPipeline is AgentPipeline
+
+    def test_wraps_contextual_agent(self):
         arms = make_arms(range(3))
-        agent = Agent(arms, ThompsonSampling())
-        steps = [("identity", FunctionTransformer())]
-
-        pipeline = NonContextualAgentPipeline(steps, agent)
-
-        assert len(pipeline) == 1
-        assert pipeline._agent is agent
-
-    def test_empty_steps_allowed(self):
-        """Test empty steps are allowed for non-contextual."""
-        arms = make_arms(range(3))
-        agent = Agent(arms, ThompsonSampling())
-
-        # Should not raise
-        pipeline = NonContextualAgentPipeline([], agent)
-        assert len(pipeline) == 0
-
-    def test_pull_without_top_k(self):
-        """Test pull method without top_k."""
-        arms = make_arms(range(3))
-        agent = Agent(arms, ThompsonSampling(), random_seed=42)
-        steps = []
-
-        pipeline = NonContextualAgentPipeline(steps, agent)
-
-        actions = pipeline.pull()
-
-        assert len(actions) == 1
-        assert isinstance(actions[0], int)
-
-    def test_pull_with_top_k(self):
-        """Test pull method with top_k."""
-        arms = make_arms(range(5))
-        agent = Agent(arms, ThompsonSampling(), random_seed=42)
-        steps = []
-
-        pipeline = NonContextualAgentPipeline(steps, agent)
-
-        action_lists = pipeline.pull(top_k=3)
-
-        assert len(action_lists) == 1
-        assert len(action_lists[0]) == 3
-
-    def test_update(self):
-        """Test update method."""
-        arms = make_arms(range(3))
-        agent = Agent(arms, ThompsonSampling(), random_seed=42)
-        steps = []
-
-        pipeline = NonContextualAgentPipeline(steps, agent)
-
-        y = np.array([1.0, 2.0])
-
-        # Pull to set arm_to_update
-        pipeline.pull()
-
-        # Should not raise
-        pipeline.update(y)
-
-    def test_update_with_sample_weight(self):
-        """Test update method with sample weights."""
-        arms = make_arms(range(3))
-        agent = Agent(arms, ThompsonSampling(), random_seed=42)
-        steps = []
-
-        pipeline = NonContextualAgentPipeline(steps, agent)
-
-        y = np.array([1.0, 2.0])
-        sample_weight = np.array([1.0, 0.1])
-
-        # Pull to set arm_to_update
-        pipeline.pull()
-
-        # Should not raise
-        pipeline.update(y, sample_weight=sample_weight)
-
-    def test_decay(self):
-        """Test decay method."""
-        arms = make_arms(range(3))
-        agent = Agent(arms, ThompsonSampling())
-        steps = []
-
-        pipeline = NonContextualAgentPipeline(steps, agent)
-
-        # Should not raise
-        pipeline.decay(decay_rate=0.5)
-
-    def test_delegation_methods(self):
-        """Test that agent methods are properly delegated."""
-        arms = make_arms(range(3))
-        agent = Agent(arms, ThompsonSampling(), random_seed=42)
-        steps = []
-
-        pipeline = NonContextualAgentPipeline(steps, agent)
-
-        # Test property access
-        assert pipeline.arms is agent.arms
-        assert pipeline.policy is agent.policy
-        assert pipeline.rng is agent.rng
-
-        # Test arm access
-        assert pipeline.arm(0) is agent.arm(0)
-
-        # Test select_for_update
-        result = pipeline.select_for_update(1)
-        assert result is pipeline
-        assert pipeline.arm_to_update is agent.arm_to_update
-
-    def test_repr(self):
-        """Test string representation."""
-        arms = make_arms(range(3))
-        agent = Agent(arms, ThompsonSampling())
-        steps = []
-
-        pipeline = NonContextualAgentPipeline(steps, agent)
-        repr_str = repr(pipeline)
-
-        assert "NonContextualAgentPipeline" in repr_str
-
-
-class TestAgentPipelineFactory:
-    """Test AgentPipeline factory function."""
-
-    def test_contextual_agent_dispatch(self):
-        """Test factory dispatches to ContextualAgentPipeline for ContextualAgent."""
-        arms = make_arms(range(3))
-        agent = ContextualAgent(arms, ThompsonSampling())
-        steps = [("identity", FunctionTransformer())]
-
-        pipeline = AgentPipeline(steps, agent)
-
-        assert isinstance(pipeline, ContextualAgentPipeline)
-        assert pipeline._agent is agent
-
-    def test_agent_dispatch(self):
-        """Test factory dispatches to NonContextualAgentPipeline for Agent."""
-        arms = make_arms(range(3))
-        agent = Agent(arms, ThompsonSampling())
-        steps = [("identity", FunctionTransformer())]
-
-        pipeline = AgentPipeline(steps, agent)
-
-        assert isinstance(pipeline, NonContextualAgentPipeline)
-        assert pipeline._agent is agent
-
-    def test_factory_preserves_functionality(self):
-        """Test factory-created pipelines work correctly."""
-        # Test contextual
-        arms = make_arms(range(3))
-        contextual_agent = ContextualAgent(arms, ThompsonSampling(), random_seed=42)
+        agent = ContextualAgent(arms, ThompsonSampling(), random_seed=42)
         steps = [("scale", FunctionTransformer(lambda x: x / 10))]
 
-        contextual_pipeline = AgentPipeline(steps, contextual_agent)
+        pipeline = AgentPipeline(steps, agent)
 
-        X = np.array([[10.0, 20.0]])
-        actions = contextual_pipeline.pull(X)
+        assert pipeline._agent is agent
+        actions = pipeline.pull(np.array([[10.0, 20.0]]))
         assert len(actions) == 1
 
-        # Test non-contextual
+    def test_rejects_non_contextual_agent(self):
+        """A non-contextual Agent has no context for the steps to transform."""
         arms = make_arms(range(3))
-        agent = Agent(arms, ThompsonSampling(), random_seed=42)
-
-        noncontextual_pipeline = AgentPipeline([], agent)
-
-        actions = noncontextual_pipeline.pull()
-        assert len(actions) == 1
-
-    def test_factory_isinstance_check(self):
-        """Test factory function's isinstance logic for dispatch."""
-        arms = make_arms(range(3))
-
-        # Test that Agent gets NonContextualAgentPipeline
         agent = Agent(arms, ThompsonSampling())
-        pipeline = AgentPipeline([("identity", FunctionTransformer())], agent)
-        assert isinstance(pipeline, NonContextualAgentPipeline)
 
-        # Test that ContextualAgent gets ContextualAgentPipeline
-        contextual_agent = ContextualAgent(arms, ThompsonSampling())
-        contextual_pipeline = AgentPipeline(
-            [("identity", FunctionTransformer())], contextual_agent
-        )
-        assert isinstance(contextual_pipeline, ContextualAgentPipeline)
+        with pytest.raises(TypeError, match="no context to transform"):
+            AgentPipeline([("identity", FunctionTransformer())], agent)  # type: ignore[arg-type]
 
 
 class TestTransformationFlow:
@@ -500,7 +336,7 @@ class TestTransformationFlow:
             ("square", FunctionTransformer(lambda x: x**2)),
         ]
 
-        pipeline = ContextualAgentPipeline(steps, agent)
+        pipeline = AgentPipeline(steps, agent)
 
         X = np.array([[1.0], [2.0]])
         # Transform: x -> 2x -> 2x+1 -> (2x+1)^2
@@ -526,7 +362,7 @@ class TestTransformationFlow:
         agent = ContextualAgent(arms, ThompsonSampling(), random_seed=42)
 
         steps = [("scale", scaler)]
-        pipeline = ContextualAgentPipeline(steps, agent)
+        pipeline = AgentPipeline(steps, agent)
 
         X = np.array([[2.0, 3.0], [4.0, 5.0]])
 
@@ -554,7 +390,7 @@ class TestTransformationFlow:
         agent = ContextualAgent(arms, ThompsonSampling(), random_seed=42)
 
         steps = [("vectorize", vectorizer)]
-        pipeline = ContextualAgentPipeline(steps, agent)
+        pipeline = AgentPipeline(steps, agent)
 
         X = [{"user": "A", "item": "X"}, {"user": "B", "item": "Y"}]
 
@@ -606,20 +442,17 @@ class TestIntegrationScenarios:
             assert hasattr(arm.learner, "coef_")
 
     def test_ab_testing_scenario(self):
-        """Test A/B testing scenario with preprocessing."""
+        """Test A/B testing scenario. No context, so no pipeline."""
         # Create treatment arms
         arms = make_arms(["control", "treatment"])
         agent = Agent(arms, EpsilonGreedy(epsilon=0.1), random_seed=42)
-
-        # No preprocessing needed for A/B test
-        pipeline = AgentPipeline([], agent)
 
         # Run A/B test
         n_experiments = 100
         rewards = []
 
         for _ in range(n_experiments):
-            assignment = pipeline.pull()[0]
+            assignment = agent.pull()[0]
 
             # Simulate reward based on assignment
             if assignment == "treatment":
@@ -628,7 +461,7 @@ class TestIntegrationScenarios:
                 reward = np.random.normal(0.10, 0.1)  # Baseline
 
             rewards.append(reward)
-            pipeline.update(np.array([reward]))
+            agent.update(np.array([reward]))
 
         # Check that we collected data
         assert len(rewards) == n_experiments
@@ -661,7 +494,7 @@ class TestIntegrationScenarios:
             ("normalize", FunctionTransformer(normalize_features)),
         ]
 
-        pipeline = ContextualAgentPipeline(steps, agent)
+        pipeline = AgentPipeline(steps, agent)
 
         # Test with raw features
         X = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
@@ -691,7 +524,7 @@ class TestErrorHandling:
         agent = ContextualAgent(arms, ThompsonSampling())
 
         steps = [("fail", FunctionTransformer(failing_transform))]
-        pipeline = ContextualAgentPipeline(steps, agent)
+        pipeline = AgentPipeline(steps, agent)
 
         X = np.array([[1.0]])
 
@@ -704,7 +537,7 @@ class TestErrorHandling:
         agent = ContextualAgent(arms, ThompsonSampling())
 
         steps = [("scaler", StandardScaler())]  # Not fitted!
-        pipeline = ContextualAgentPipeline(steps, agent)
+        pipeline = AgentPipeline(steps, agent)
 
         X = np.array([[1.0], [2.0]])
 
@@ -729,7 +562,7 @@ class TestErrorHandling:
 
         # The factory function should handle invalid agent types
         # In practice, this would be a type error at development time
-        # Since isinstance check won't match, it will try to create ContextualAgentPipeline
+        # Since isinstance check won't match, it will try to create AgentPipeline
         # which will fail on first attribute access
         pipeline = AgentPipeline(steps, mock_agent)  # type: ignore
         # The error will happen when trying to use the agent
@@ -744,28 +577,18 @@ class TestCoverage:
         """Test policy setter on contextual pipeline."""
         arms = make_arms(range(3))
         agent = ContextualAgent(arms, ThompsonSampling())
-        pipeline = ContextualAgentPipeline([("identity", FunctionTransformer())], agent)
+        pipeline = AgentPipeline([("identity", FunctionTransformer())], agent)
 
         new_policy = EpsilonGreedy(epsilon=0.2)
         pipeline.policy = new_policy
         assert pipeline.policy is new_policy
         assert agent.policy is new_policy
 
-    def test_noncontextual_pipeline_policy_setter(self):
-        """Test policy setter on non-contextual pipeline."""
-        arms = make_arms(range(3))
-        agent = Agent(arms, ThompsonSampling())
-        pipeline = NonContextualAgentPipeline([], agent)
-
-        new_policy = EpsilonGreedy(epsilon=0.2)
-        pipeline.policy = new_policy
-        assert pipeline.policy is new_policy
-
     def test_contextual_pipeline_with_sample_weights(self):
         """Test contextual pipeline update with sample weights."""
         arms = make_arms(range(3))
         agent = ContextualAgent(arms, ThompsonSampling(), random_seed=42)
-        pipeline = ContextualAgentPipeline([("identity", FunctionTransformer())], agent)
+        pipeline = AgentPipeline([("identity", FunctionTransformer())], agent)
 
         X = np.array([[1.0], [2.0], [3.0]])
         y = np.array([1.0, 2.0, 3.0])
@@ -778,50 +601,32 @@ class TestCoverage:
         """Test contextual pipeline decay with explicit rate."""
         arms = make_arms(range(3))
         agent = ContextualAgent(arms, ThompsonSampling())
-        pipeline = ContextualAgentPipeline([("identity", FunctionTransformer())], agent)
+        pipeline = AgentPipeline([("identity", FunctionTransformer())], agent)
 
         X = np.array([[1.0]])
         pipeline.decay(X, decay_rate=0.7)
-
-    def test_noncontextual_pipeline_decay_with_rate(self):
-        """Test non-contextual pipeline decay with explicit rate."""
-        arms = make_arms(range(3))
-        agent = Agent(arms, ThompsonSampling())
-        pipeline = NonContextualAgentPipeline([], agent)
-
-        pipeline.decay(decay_rate=0.7)
 
     def test_pipeline_len_and_getitem_edge_cases(self):
         """Test pipeline length and indexing edge cases."""
         arms = make_arms(range(3))
         agent = ContextualAgent(arms, ThompsonSampling())
 
-        # Empty pipeline (though not allowed by validation)
-        # We'll test NonContextualAgentPipeline which allows empty steps
-        arms2 = make_arms(range(3))
-        agent2 = Agent(arms2, ThompsonSampling())
-        empty_pipeline = NonContextualAgentPipeline([], agent2)
-
-        assert len(empty_pipeline) == 0
-        assert empty_pipeline.named_steps == {}
-
         # Test negative indexing
         steps = [("a", FunctionTransformer()), ("b", FunctionTransformer())]
-        pipeline = ContextualAgentPipeline(steps, agent)
+        pipeline = AgentPipeline(steps, agent)
 
+        assert len(pipeline) == 2
         assert pipeline[-1] == steps[-1]
         assert pipeline[-2] == steps[-2]
 
     def test_uncovered_functionality(self):
         """Test functionality to improve code coverage."""
         arms = make_arms(range(3))
-
-        # Test NonContextualAgentPipeline with non-empty steps (edge case)
-        agent = Agent(arms, ThompsonSampling(), random_seed=42)
+        agent = ContextualAgent(arms, ThompsonSampling(), random_seed=42)
         steps = [("identity", FunctionTransformer())]
-        pipeline = NonContextualAgentPipeline(steps, agent)
+        pipeline = AgentPipeline(steps, agent)
 
-        # Test all delegation methods on NonContextualAgentPipeline
+        # Test all delegation methods
         assert len(pipeline.arms) == 3
         assert pipeline.arm(0) is not None
         pipeline.select_for_update(1)
@@ -832,7 +637,7 @@ class TestCoverage:
         pipeline.add_arm(new_arm)
         pipeline.remove_arm(99)
 
-        # Test indexing on NonContextualAgentPipeline
+        # Test indexing
         assert pipeline["identity"] is not None
         assert pipeline[0] == ("identity", steps[0][1])
 

--- a/tests/test_rng_reseed.py
+++ b/tests/test_rng_reseed.py
@@ -12,8 +12,7 @@ from bayesianbandits import (
 from bayesianbandits.api import LipschitzContextualAgent
 from bayesianbandits.featurizers._arm_column import ArmColumnFeaturizer
 from bayesianbandits.pipelines._agent import (
-    ContextualAgentPipeline,
-    NonContextualAgentPipeline,
+    AgentPipeline,
 )
 
 
@@ -109,16 +108,9 @@ class TestLipschitzContextualAgentRngSetter:
 class TestPipelineRngSetter:
     def test_contextual_pipeline_rng_setter_delegates(self):
         agent = _make_contextual_agent(seed=0)
-        pipeline = ContextualAgentPipeline(
+        pipeline = AgentPipeline(
             steps=[("noop", _NoopTransformer())], final_agent=agent
         )
-        pipeline.rng = 42
-        assert isinstance(pipeline.rng, np.random.Generator)
-        assert pipeline.rng is agent.rng
-
-    def test_noncontextual_pipeline_rng_setter_delegates(self):
-        agent = _make_agent(seed=0)
-        pipeline = NonContextualAgentPipeline(steps=[], final_agent=agent)
         pipeline.rng = 42
         assert isinstance(pipeline.rng, np.random.Generator)
         assert pipeline.rng is agent.rng


### PR DESCRIPTION
Two independent cleanups from an audit of the API layer. No behavior change beyond the removed class, and no numerics touched. Net -514 lines.

## Hoist the policy `__call__` into `PolicyDefaultUpdate`

Every policy carried the same two-line `__call__`: draw `samples_needed` samples, hand them to `select`. #261 hoisted the sampling those two lines call into the base and left the two lines themselves in all five subclasses, each under its own pair of `@overload` stubs, so 28 lines repeated five times to say one thing.

The base now implements `__call__` and declares the two members it calls into, `samples_needed` and `select`. A custom policy subclassing `PolicyDefaultUpdate` now needs only those two.

The removed bodies were byte-identical to the one kept, so the only thing that moves is where the MRO finds it.

## Delete the pipeline that wrapped a contextless agent

`AgentPipeline`'s steps transform the context on its way to the agent. A non-contextual `Agent` has no context, so `NonContextualAgentPipeline` never had anything to apply its steps to, and its docstring said so:

> preprocessing steps are not applied since there's no context to transform. This class exists primarily for API consistency and to support future extensions.

It still validated the steps, stored them, and exposed them through `named_steps`, `__len__` and `__getitem__`, then forwarded twelve members to an `Agent` that forwards them again to the `ContextualAgent` inside it. Reading `pipeline.arm_to_update` was three property hops to reach a list index.

With one product class left, the `AgentPipeline` factory and its two overloads have nothing to dispatch on, so `AgentPipeline` is now the class itself. It is the name `docs/api.rst` and every howto use, so it takes the class and `ContextualAgentPipeline` becomes the alias. `repr` and the generated autosummary page now say what callers typed.

**Breaking:** `NonContextualAgentPipeline` is gone, and passing a plain `Agent` to `AgentPipeline` raises `TypeError` pointing at `LearnerPipeline`, rather than constructing a pipeline whose steps would silently never run. Callers wrapping a plain `Agent` should drop the wrapper: the agent has the same `pull`/`update`/`decay` interface.

## Checks

- `pytest tests`: 2920 passed, 26 skipped
- `ruff format` / `ruff check`: clean
- `pyright`: 297 errors, against a 298 baseline on master (all pre-existing scipy/sklearn stub noise)