### PR TITLE
Reject an empty iteration budget in the posterior approximators

### DIFF
--- a/src/bayesianbandits/_gaussian.py
+++ b/src/bayesianbandits/_gaussian.py
@@ -625,6 +625,9 @@ def update_gaussian_posterior_laplace(
         posterior.mean : MAP estimate
         posterior.precision : Hessian at MAP (approximate posterior precision)
     """
+    if n_iter < 1:
+        raise ValueError(f"n_iter must be at least 1, got {n_iter}")
+
     assert X.shape is not None, "X must be a 2D array"
     n_samples = X.shape[0]
 
@@ -738,10 +741,10 @@ class LaplaceApproximator(MemoryUsageMixin, PosteriorApproximator):
     Parameters
     ----------
     n_iter : int, default=5
-        Maximum number of Newton (IRLS) iterations per update.  When
-        the budget runs out before the step falls below ``tol``, the
-        returned posterior has ``converged=False`` and
-        :class:`BayesianGLM` raises a ``ConvergenceWarning``.
+        Maximum number of Newton (IRLS) iterations per update; must be
+        at least 1.  When the budget runs out before the step falls
+        below ``tol``, the returned posterior has ``converged=False``
+        and :class:`BayesianGLM` raises a ``ConvergenceWarning``.
 
         - ``1``: Single-step update from the current posterior. Fast
           and usually sufficient for online/streaming use where the
@@ -1187,6 +1190,9 @@ def update_gaussian_posterior_rvga(
     ----------
     Lambert, Bonnabel, Bach (2022). Statistics and Computing, 32, 10.
     """
+    if n_iter < 1:
+        raise ValueError(f"n_iter must be at least 1, got {n_iter}")
+
     assert X.shape is not None, "X must be a 2D array"
     n_samples = X.shape[0]
 
@@ -1267,7 +1273,7 @@ class RVGAApproximator(MemoryUsageMixin, PosteriorApproximator):
     Parameters
     ----------
     n_iter : int, default=5
-        Maximum iterations per update.
+        Maximum iterations per update; must be at least 1.
     tol : float, default=1e-4
         Convergence tolerance on coefficient change.
     n_gh_nodes : int, default=20

--- a/tests/test_bayesian_glm.py
+++ b/tests/test_bayesian_glm.py
@@ -6,7 +6,7 @@ import scipy.sparse as sp
 from numpy.testing import assert_allclose, assert_array_less
 from sklearn.datasets import make_classification, make_regression
 
-from bayesianbandits import BayesianGLM, LaplaceApproximator
+from bayesianbandits import BayesianGLM, LaplaceApproximator, RVGAApproximator
 
 
 # Fixtures and parametrization
@@ -666,3 +666,25 @@ def test_laplace_non_convergence_warns():
         BayesianGLM(
             link="log", alpha=2.0, approximator=LaplaceApproximator(n_iter=1)
         ).fit(X, y)
+
+
+@pytest.mark.parametrize("n_iter", [0, -1])
+@pytest.mark.parametrize("sparse", [False, True])
+@pytest.mark.parametrize(
+    "approximator", [LaplaceApproximator, RVGAApproximator], ids=["laplace", "rvga"]
+)
+def test_n_iter_below_one_is_rejected(approximator, sparse, n_iter):
+    """An empty iteration budget fell through the solver loop and read a
+    variable the loop assigns, so two of these four raised
+    UnboundLocalError and the other two returned the prior unchanged."""
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((20, 3))
+    y = (X[:, 0] > 0).astype(np.float64)
+
+    with pytest.raises(ValueError, match="n_iter must be at least 1"):
+        BayesianGLM(
+            link="logit",
+            alpha=1.0,
+            sparse=sparse,
+            approximator=approximator(n_iter=n_iter),
+        ).fit(sp.csc_array(X) if sparse else X, y)


### PR DESCRIPTION
Neither approximator validated `n_iter`, so a zero or negative budget ran the solver's `for iteration in range(n_iter)` zero times and then read a variable that only the loop body assigns. Two of the four approximator and density combinations raised `UnboundLocalError`:

```
LaplaceApproximator(n_iter=0), dense:   'cho'
RVGAApproximator(n_iter=0),   sparse:   'posterior_precision'
```

The other two were quieter and worse: they returned the prior as though it were a fitted posterior, so a typo in a constructor kwarg produced a model that trained on nothing and reported no error.

The guard goes in `update_gaussian_posterior_laplace` and `update_gaussian_posterior_rvga` rather than in the two dataclasses. Both approximators delegate there, so one check per function covers all four solver loops, it also covers the direct callers in the tests, and it keeps validation at fit time the way the estimators do it rather than in a constructor that sklearn's `clone` round-trips. It sits ahead of the `n_samples == 0` fast path, so an invalid budget is rejected whether or not there is data to fit.

The new test is parametrized over approximator, density, and `n_iter` in `{0, -1}`, pinning all four combinations including the two that failed silently.

Pyright reported these four sites as `reportPossiblyUnbound` and still does: the guard is in the caller, and pyright does not infer that `range(n_iter)` runs at least once from a bound established in another function. Clearing them would need dead initializers before each loop, which trades a real diagnostic for a cosmetic one.

Suite: `2936 passed, 26 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019R5wJiCKag6njFhiiZJ95n