### PR TITLE
Stop the shared bases from re-documenting the estimators' attributes

### DIFF
--- a/src/bayesianbandits/_eb_estimators.py
+++ b/src/bayesianbandits/_eb_estimators.py
@@ -9,7 +9,7 @@ rate estimation.
 from __future__ import annotations
 
 import math
-from typing import Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import numpy as np
 from numpy.typing import NDArray
@@ -63,9 +63,14 @@ class _StabilizedPriorMixin(_BayesianLinearModel):
     _factor_hint: Any
     _prior_scalar: float
     _effective_n: float
-    eb_updates_rejected_: int
-    n_eb_iterations_: int
-    eb_converged_: bool
+
+    if TYPE_CHECKING:
+        # Declared for the checker only, as in _BayesianLinearModel: an
+        # annotation outside this block duplicates each estimator's own
+        # ``Attributes`` entry on its docs page.
+        eb_updates_rejected_: int
+        n_eb_iterations_: int
+        eb_converged_: bool
 
     # ---- hooks -----------------------------------------------------------
 

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -1227,18 +1227,18 @@ class _BayesianLinearModel(MemoryUsageMixin, BaseEstimator):
     subclass supplies those two; everything a caller touches lives here.
     """
 
-    # ``Any`` where the concrete classes assign a wider set of array types
-    # than one annotation covers; a narrower declaration here would only
-    # make their own assignments type errors.
-    coef_: Any
-    cov_inv_: Any
-    n_features_: int
-
     if TYPE_CHECKING:
+        # Assigned here, but declared for the checker only: an annotation
+        # outside this block renders as an undocumented attribute on every
+        # estimator page, duplicating the subclass's own ``Attributes``
+        # entry. ``Any`` where the concrete classes assign a wider set of
+        # array types than one annotation covers.
+        coef_: Any
+        cov_inv_: Any
+        n_features_: int
+
         # Read here, owned elsewhere: the concrete ``__init__`` sets the
-        # hyperparameters and ``_initialize_prior`` the generator. Declared
-        # for the checker only, since a class-level annotation would also
-        # render them as undocumented attributes on every estimator page.
+        # hyperparameters and ``_initialize_prior`` the generator.
         alpha: float
         learning_rate: float
         sparse: bool


### PR DESCRIPTION
#292 added `:inherited-members:` to the autosummary class template so a method defined on `_BayesianLinearModel` would still appear on each estimator's page. It also picked up the base's class-level attribute annotations, and every one of those is already documented in the concrete class's own numpydoc `Attributes` section, so Sphinx described each of them twice on the same page:

```
docs build at 46e2c48:  build succeeded.
docs build at 30a782f:  build succeeded, 15 warnings.
```

All 15 were "duplicate object description": `coef_`, `cov_inv_` and `n_features_` from `_BayesianLinearModel` on `NormalRegressor`, `NormalInverseGammaRegressor` and `BayesianGLM`, plus `eb_updates_rejected_`, `n_eb_iterations_` and `eb_converged_` from `_StabilizedPriorMixin` on `EmpiricalBayesNormalRegressor` and `EmpiricalBayesGLM`. The estimators that document the same names without inheriting either base (`DirichletClassifier`, `GammaRegressor`, and the two non-linear EB estimators) were never affected.

#292 had already found this failure mode and fixed it for the hyperparameters, which it put in a `TYPE_CHECKING` block precisely because "a class-level annotation would also render them as undocumented attributes on every estimator page". The remaining six annotations get the same treatment. They are read by nothing at runtime: these are not dataclasses, sklearn reads `__init__` rather than `__annotations__` for `get_params`, and nothing in the package calls `get_type_hints`.

The surviving entry on each page is the numpydoc one, which carries the type and the prose; the bare inherited annotation was the duplicate. Every attribute now resolves to exactly one anchor, and the inherited methods #292 wanted (`sample_marginal`, `sample_reward_space`, `decay`, `memory_usage`) still render on all three pages.

Docs build back to zero warnings, pyright unchanged at 16 pre-existing errors across the two files, suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019R5wJiCKag6njFhiiZJ95n