### PR TITLE
Reuse the shared solver fixture instead of redefining it three times

### DIFF
--- a/tests/test_eb_estimators.py
+++ b/tests/test_eb_estimators.py
@@ -15,24 +15,12 @@ from bayesianbandits import (
     EmpiricalBayesNormalRegressor,
 )
 from bayesianbandits._estimators import NormalRegressor
-from bayesianbandits._sparse_bayesian_linear_regression import SparseSolver
-
-suitespare_envvar_params = [
-    SparseSolver.SUPERLU,
-    SparseSolver.CHOLMOD,
-]
 
 
-@pytest.fixture(
-    params=suitespare_envvar_params,
-    autouse=True,
-)
-def suitesparse_envvar(request):
-    """Allows running test suite with and without CHOLMOD."""
-    with mock.patch(
-        "bayesianbandits._sparse_bayesian_linear_regression.solver", request.param
-    ):
-        yield
+@pytest.fixture(autouse=True)
+def suitesparse_envvar(sparse_solver):
+    """Run every test in this module against both sparse backends."""
+    yield
 
 
 @pytest.fixture

--- a/tests/test_eb_glm.py
+++ b/tests/test_eb_glm.py
@@ -17,18 +17,12 @@ from bayesianbandits import (
     RVGAApproximator,
 )
 from bayesianbandits._empirical_bayes import glm_log_likelihood
-from bayesianbandits._sparse_bayesian_linear_regression import SparseSolver
 
 
-@pytest.fixture(
-    params=[SparseSolver.SUPERLU, SparseSolver.CHOLMOD],
-    autouse=True,
-)
-def suitesparse_envvar(request):
-    with mock.patch(
-        "bayesianbandits._sparse_bayesian_linear_regression.solver", request.param
-    ):
-        yield
+@pytest.fixture(autouse=True)
+def suitesparse_envvar(sparse_solver):
+    """Run every test in this module against both sparse backends."""
+    yield
 
 
 def _simulate(link, n=200, p=5, seed=0, alpha_true=2.0):

--- a/tests/test_normal_estimators.py
+++ b/tests/test_normal_estimators.py
@@ -1,5 +1,4 @@
 from typing import Literal
-from unittest import mock
 
 import numpy as np
 import pytest
@@ -12,24 +11,12 @@ from bayesianbandits import (
     NormalInverseGammaRegressor,
     NormalRegressor,
 )
-from bayesianbandits._sparse_bayesian_linear_regression import SparseSolver
-
-suitespare_envvar_params = [
-    SparseSolver.SUPERLU,
-    SparseSolver.CHOLMOD,
-]
 
 
-@pytest.fixture(
-    params=suitespare_envvar_params,
-    autouse=True,
-)
-def suitesparse_envvar(request):
-    """Allows running test suite with and without CHOLMOD."""
-    with mock.patch(
-        "bayesianbandits._sparse_bayesian_linear_regression.solver", request.param
-    ):
-        yield
+@pytest.fixture(autouse=True)
+def suitesparse_envvar(sparse_solver):
+    """Run every test in this module against both sparse backends."""
+    yield
 
 
 @pytest.fixture


### PR DESCRIPTION
`conftest.py` has defined `sparse_solver` since the backends were first parameterized, and its docstring spells out the intended usage:

```python
@pytest.fixture(autouse=True)
def suitesparse_envvar(sparse_solver):
    yield
```

Five modules follow it. Three did not: `test_normal_estimators.py` and `test_eb_estimators.py` each carried their own 18-line copy of the params list, the `mock.patch` and the fixture, byte-identical to one another down to the `suitespare_envvar_params` typo, and `test_eb_glm.py` carried a third, shorter variant of the same thing.

Nothing about the copies differed from conftest's version: the same two `SparseSolver` members in the same order, patching the same global. The collected test IDs across the three modules are unchanged, **1382 before and 1382 after**, so the parameterization, its order and every test name are the same.

Dropping them leaves `SparseSolver` unused in all three modules and `mock` unused in `test_normal_estimators.py`; those imports go too.

Suite: `2920 passed, 26 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019R5wJiCKag6njFhiiZJ95n