### PR TITLE
Add feature-wise forgetting, a sparsity-preserving directional rule

### DIFF
--- a/benchmarks/test_bench_forgetting.py
+++ b/benchmarks/test_bench_forgetting.py
@@ -1,4 +1,4 @@
-"""Benchmarks for forgetting rules: exponential, stabilized (KZ), and SIFt."""
+"""Benchmarks for forgetting rules: exponential, stabilized (KZ), SIFt, and feature-wise."""
 
 import numpy as np
 import pytest
@@ -7,6 +7,7 @@ from scipy.sparse import random as sparse_random
 
 from bayesianbandits._forgetting import (
     ExponentialForgetting,
+    FeatureWiseForgetting,
     SiftForgetting,
     StabilizedForgetting,
     filter_batch,
@@ -133,6 +134,7 @@ RULES = [
     pytest.param(ExponentialForgetting(), id="exponential"),
     pytest.param(StabilizedForgetting(alpha=1.0), id="stabilized"),
     pytest.param(SiftForgetting(eps=1e-12), id="sift"),
+    pytest.param(FeatureWiseForgetting(), id="feature-wise"),
 ]
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -101,6 +101,7 @@ Unreleased
   Not yet wired into the estimators. The math page documents what it gives
   up: it is a coordinate stretch rather than a Bayesian update and can
   over-tighten combinations with strongly correlated unobserved features
+  (#300)
 
 **Internal**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -89,6 +89,19 @@ Unreleased
   With per-arm learners, drawing one arm at a time is the correct joint
   law, so the remaining path needs no batching (#267)
 
+**New features**
+
+- ``FeatureWiseForgetting`` joins the forgetting rules in
+  ``_forgetting.py``: vector-type forgetting (Saelid & Foss 1983) with the
+  per-feature factors set from the batch support, ``Λ̄ = D Λ D`` with
+  ``D = diag(γ^{m_i/2})``. It forgets only the observed features, leaves
+  every unobserved feature's marginal and every correlation unchanged, and
+  preserves the sparsity pattern at exponential-forgetting cost, where the
+  SIFt correction is dense on the neighbourhood of the active features.
+  Not yet wired into the estimators. The math page documents what it gives
+  up: it is a coordinate stretch rather than a Bayesian update and can
+  over-tighten combinations with strongly correlated unobserved features
+
 **Internal**
 
 - ``NormalRegressor`` and ``BayesianGLM`` now share a single private base,

--- a/docs/math/forgetting.rst
+++ b/docs/math/forgetting.rst
@@ -1,9 +1,10 @@
 Forgetting Strategies
 =====================
 
-Three strategies for shrinking the posterior precision matrix before
-a recursive Bayesian update.  Each addresses a limitation of the
-previous one.  The update and sampling steps are unchanged;
+Four strategies for shrinking the posterior precision matrix before
+a recursive Bayesian update.  Each of the first three addresses a
+limitation of the previous one; the fourth trades exactness for the
+sparsity pattern.  The update and sampling steps are unchanged;
 see :doc:`normal` for those details and :doc:`/howto/decay` for
 practical tuning guidance.
 
@@ -37,6 +38,10 @@ Symbols
      - Number of features
    * - :math:`\varepsilon`
      - Eigenvalue threshold for batch filtering
+   * - :math:`m_i`
+     - Number of rows of the batch in which feature :math:`i` is nonzero
+   * - :math:`\mathbf{D}`
+     - Diagonal matrix of per-feature factors :math:`\gamma^{m_i/2}`
 
 
 The update loop
@@ -57,7 +62,7 @@ The subsequent update is standard:
    \boldsymbol{\mu}_n
    &= \boldsymbol{\Lambda}_n^{-1}\,\boldsymbol{\eta}_n
 
-The three strategies below differ only in the forgetting rule.
+The four strategies below differ only in the forgetting rule.
 
 
 Exponential forgetting
@@ -180,6 +185,100 @@ handles rank deficiency and is faster for the small Gram matrices
 that arise in practice.
 
 
+Feature-wise forgetting (vector-type)
+-------------------------------------
+
+.. math::
+
+   \bar{\boldsymbol{\Lambda}} = \mathbf{D}\,\boldsymbol{\Lambda}\,\mathbf{D},
+   \qquad
+   \mathbf{D} = \operatorname{diag}\bigl(\gamma^{m_i/2}\bigr)
+
+Each feature is forgotten by :math:`\gamma` once per row of the batch
+in which it appears, and features absent from the batch are not
+forgotten at all.  Entry :math:`(i, j)` of the precision is scaled by
+:math:`\gamma^{(m_i + m_j)/2}`, so the diagonal of an observed feature
+scales by :math:`\gamma^{m_i}` and its cross terms with unobserved
+features by :math:`\gamma^{m_i/2}`.  When every feature appears in
+every row this is exponential forgetting; when the batch is one-hot it
+touches one row and one column per active feature.
+
+Per-parameter forgetting factors applied as a congruence of the
+covariance,
+:math:`\bar{\mathbf{P}} = \boldsymbol{\Lambda}_f^{-1/2}\,\mathbf{P}\,\boldsymbol{\Lambda}_f^{-1/2}`,
+are the *vector variable forgetting factor* of [4]_ [5]_ and the
+*selective forgetting* of [6]_; the form above is equation (12) of
+[7]_ and of [8]_.  Those works fix the factors per parameter from prior
+knowledge of how fast each one drifts.  Setting them from the batch
+support, :math:`\gamma` on the active features and :math:`1`
+elsewhere, is what makes the rule directional: it is the oracle
+"multiple forgetting" baseline that [3]_ reports as comparable to
+SIFt, with the oracle read off the regressor.
+
+
+What it preserves
+~~~~~~~~~~~~~~~~~
+
+In covariance form the rule is
+:math:`\bar{\boldsymbol{\Sigma}} = \mathbf{D}^{-1}\boldsymbol{\Sigma}\mathbf{D}^{-1}`:
+the standard deviation of each observed coefficient is inflated by
+:math:`\gamma^{-m_i/2}` and nothing else moves.  Consequently
+
+- every correlation between coefficients is unchanged;
+- the marginal posterior of every unobserved feature is unchanged
+  (the Schur complement of the untouched block is invariant, which is
+  what fixes the exponent at one half);
+- the sparsity pattern of :math:`\boldsymbol{\Lambda}` is unchanged,
+  so a sparse factorization refactorizes numerically on the same
+  symbolic analysis;
+- positive definiteness is preserved, by congruence.
+
+The cost is one pass over the nonzeros of :math:`\boldsymbol{\Lambda}`,
+the same as exponential forgetting.
+
+
+What it gives up
+~~~~~~~~~~~~~~~~
+
+The rule is a coordinate stretch of the posterior about its mean, not
+a Bayesian update: it is neither conditioning nor a transition model.
+:math:`\boldsymbol{\Lambda} - \bar{\boldsymbol{\Lambda}}` is not
+positive semidefinite in general, so the rule is not *proper* in the
+sense of [9]_, which notes the same of the multiple-forgetting scheme
+of [8]_.  Concretely, stretching a tilted ellipse along one axis
+rotates its principal axes, so the combination of an observed feature
+with a correlated unobserved one that the posterior claims to know
+best moves to a new combination, and that combination can come out
+tighter than any data supported.  The rotation is in the same
+direction as the exact update; the overclaim is in its width, and it
+grows with the correlation.  Relative to a Kalman step inflating the
+observed coefficient by the same amount, the best-known combination is
+about 2% too tight at correlation :math:`0.8` and
+:math:`\gamma = 0.98`, 8% at :math:`0.95`, and 29% at :math:`0.99`.
+The next observation of that feature re-pins the combination from
+data.
+
+SIFt is the exact counterpart: it adds noise along the excited
+direction rather than stretching, which can never tighten any
+direction, and it pays for that with a correction that is dense on the
+neighbourhood of the active features.  In the special case where the
+observed feature is conditionally independent of every other
+(its row of :math:`\boldsymbol{\Lambda}` is diagonal) the two rules
+coincide.
+
+
+Choosing :math:`\gamma`
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The same :math:`\gamma` means different amounts of memory under
+different rules.  Per row, exponential forgetting removes
+:math:`p \log\gamma` of log-determinant from the precision,
+feature-wise removes :math:`k \log\gamma` where :math:`k` is the number
+of active features, and SIFt removes exactly :math:`\log\gamma`.  A
+SIFt factor of :math:`\gamma^k` is therefore a reasonable starting
+point for the memory of a feature-wise factor of :math:`\gamma`.
+
+
 Choosing a strategy
 -------------------
 
@@ -204,13 +303,26 @@ Choosing a strategy
        against collapse
    * - Directional (SIFt)
      - Preserves precision in unexcited directions; natural
-       eigenvalue floor
-     - Slightly more compute per step
-     - Sparse / high-dimensional features with heterogeneous
-       excitation
+       eigenvalue floor; exact
+     - Correction is dense on the neighbourhood of the excited
+       features, so a sparse precision fills in
+     - Dense or correlated continuous features
+   * - Feature-wise
+     - Forgets only observed features; preserves the sparsity
+       pattern; exponential cost
+     - A coordinate stretch, not a Bayesian update; can
+       over-tighten combinations with strongly correlated
+       unobserved features
+     - One-hot and hierarchical sparse designs
 
 Stabilized and directional forgetting address orthogonal problems
-(prior collapse vs. isotropic decay) and can be combined.
+(prior collapse vs. isotropic decay) and can be combined.  On one-hot
+hierarchies, feature-wise and SIFt reach the same predictive accuracy
+and calibration; feature-wise does so at the cost and pattern of
+exponential forgetting, while SIFt's precision becomes dense over
+every feature ever observed.  On dense low-rank regressors feature-wise
+reduces to exponential forgetting and only SIFt protects the unexcited
+directions.
 
 
 Adaptation from SIFt-RLS
@@ -340,3 +452,28 @@ References
 .. [3] Lai, B. & Bernstein, D. S. (2024). "SIFt-RLS: Subspace of
    Information Forgetting Recursive Least Squares."
    *arXiv:2404.10844*.
+
+.. [4] Saelid, S. & Foss, B. (1983). "Adaptive controllers with a vector
+   variable forgetting factor." *Proceedings of the 22nd IEEE Conference
+   on Decision and Control*, 1488--1494.
+
+.. [5] Saelid, S., Egeland, O. & Foss, B. (1985). "A solution to the
+   blow-up problem in adaptive controllers." *Modeling, Identification
+   and Control*, 6(1), 39--56.
+
+.. [6] Parkum, J. E., Poulsen, N. K. & Holst, J. (1992). "Recursive
+   forgetting algorithms." *International Journal of Control*, 55(1),
+   109--128.
+
+.. [7] Fraccaroli, F., Peruffo, A. & Zorzi, M. (2015). "A new recursive
+   least-squares method with multiple forgetting schemes."
+   *arXiv:1503.07338*.
+
+.. [8] Vahidi, A., Stefanopoulou, A. & Peng, H. (2005). "Recursive least
+   squares with forgetting for online estimation of vehicle mass and
+   road grade: theory and experiments." *Vehicle System Dynamics*,
+   43(1), 31--55.
+
+.. [9] Lai, B. & Bernstein, D. S. (2024). "Generalized forgetting
+   recursive least squares: stability and robustness guarantees."
+   *IEEE Transactions on Automatic Control*. *arXiv:2308.04259*.

--- a/src/bayesianbandits/_forgetting.py
+++ b/src/bayesianbandits/_forgetting.py
@@ -1,14 +1,18 @@
 """Forgetting rules for precision-based Bayesian recursive least squares.
 
-Three strategies for computing a "forgotten" precision matrix from the
-current precision, each addressing a limitation of the previous one:
+Four strategies for computing a "forgotten" precision matrix from the
+current precision:
 
 - :class:`ExponentialForgetting` -- scalar decay, simplest but subject to
   covariance windup under non-uniform excitation.
 - :class:`StabilizedForgetting` -- Kulhavy & Zarrop (1993) prior floor
   prevents collapse, but forgetting is isotropic.
 - :class:`SiftForgetting` -- directional forgetting via SIFt-RLS
-  (Lai & Bernstein 2024), forgets only in excited directions.
+  (Lai & Bernstein 2024), forgets only in excited directions; the
+  correction is dense on the neighbourhood of the excited features.
+- :class:`FeatureWiseForgetting` -- vector-type forgetting (Saelid & Foss
+  1983) with the factors chosen from the batch support; forgets only the
+  observed features and preserves the sparsity pattern.
 
 See ``docs/math/forgetting.rst`` for the full mathematical reference.
 
@@ -29,7 +33,7 @@ The caller then does::
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, NamedTuple, Union
+from typing import Any, NamedTuple, Union, cast
 
 import numpy as np
 from numpy.typing import NDArray
@@ -402,3 +406,87 @@ class SiftForgetting:
         else:
             R_bar = _sift_downdate_dense(precision, X_bar, lam)
         return R_bar, X_bar, y_bar
+
+
+def _active_counts(X: ArrayType) -> NDArray[np.intp]:
+    """Number of rows of ``X`` in which each feature is nonzero, shape ``(n,)``."""
+    if sparse.issparse(X):
+        X_csc = csc_array(X)
+        assert X_csc.shape is not None
+        n = X_csc.shape[1]
+        col = np.repeat(np.arange(n), np.diff(X_csc.indptr))
+        return np.bincount(col[X_csc.data != 0], minlength=n).astype(np.intp)
+    return np.count_nonzero(np.asarray(X), axis=0).astype(np.intp)
+
+
+@dataclass(frozen=True)
+class FeatureWiseForgetting:
+    """Vector-type forgetting with the factors chosen from the batch support.
+
+    ``R_bar = D R D`` with ``D = diag(lam ** (m_i / 2))``, where ``m_i``
+    is the number of rows of ``X`` in which feature ``i`` is nonzero.  A
+    feature present in every row of an ``n``-row batch decays by
+    ``lam ** n``, exactly as under :class:`ExponentialForgetting`; a
+    feature absent from the batch is untouched.
+
+    In covariance form this inflates the standard deviation of each
+    observed coefficient by ``lam ** (-m_i / 2)`` and leaves every
+    correlation and every unobserved coefficient's marginal unchanged.
+    Because it only scales rows and columns, the sparsity pattern of
+    ``R`` is preserved and the cost is one pass over its nonzeros.
+
+    Per-parameter factors of this form are the vector variable
+    forgetting factor of [1]_ [2]_ and the selective forgetting of [3]_;
+    the ``D R D`` form is equation (12) of [4]_ (and of [5]_, which calls
+    it ad hoc).  Choosing the factors from the batch support is what
+    makes the rule directional for sparse designs.  It is a coordinate
+    stretch rather than a Bayesian update: ``R - R_bar`` need not be
+    positive semidefinite [6]_, so a combination of an observed feature
+    with an unobserved one it is correlated with can come out tighter
+    than before, by an amount that grows with that correlation.  For
+    dense or strongly correlated regressors prefer :class:`SiftForgetting`.
+
+    References
+    ----------
+    .. [1] Saelid, S. & Foss, B. (1983). "Adaptive controllers with a
+       vector variable forgetting factor." *Proc. 22nd IEEE CDC*, 1488--1494.
+    .. [2] Saelid, S., Egeland, O. & Foss, B. (1985). "A solution to the
+       blow-up problem in adaptive controllers." *Modeling, Identification
+       and Control*, 6(1), 39--56.
+    .. [3] Parkum, J. E., Poulsen, N. K. & Holst, J. (1992). "Recursive
+       forgetting algorithms." *Int. J. Control*, 55(1), 109--128.
+    .. [4] Fraccaroli, F., Peruffo, A. & Zorzi, M. (2015). "A new recursive
+       least-squares method with multiple forgetting schemes."
+       *arXiv:1503.07338*.
+    .. [5] Vahidi, A., Stefanopoulou, A. & Peng, H. (2005). "Recursive least
+       squares with forgetting for online estimation of vehicle mass and
+       road grade: theory and experiments." *Vehicle System Dynamics*,
+       43(1), 31--55.
+    .. [6] Lai, B. & Bernstein, D. S. (2024). "Generalized forgetting
+       recursive least squares: stability and robustness guarantees."
+       *IEEE Trans. Automatic Control*. *arXiv:2308.04259*.
+    """
+
+    def __call__(
+        self,
+        precision: ArrayType,
+        X: ArrayType,
+        y: NDArray[Any],
+        lam: float,
+    ) -> ForgettingResult:
+        d = lam ** (_active_counts(X) / 2.0)
+        if sparse.issparse(precision):
+            R = csc_array(precision)
+            assert R.shape is not None
+            # D R D on the stored entries only: rows by d[i], columns by d[j].
+            data = R.data * d[R.indices]
+            data *= np.repeat(d, np.diff(R.indptr))
+            R_bar: ArrayType = csc_array(
+                (data, R.indices.copy(), R.indptr.copy()), shape=R.shape
+            )
+        else:
+            R_bar = (d[:, np.newaxis] * np.asarray(precision)) * d[np.newaxis, :]
+        # The batch is passed through untouched; a sparse X stays sparse, as
+        # in the sparse SIFt path.
+        X_eff = cast(NDArray[Any], X) if sparse.issparse(X) else np.asarray(X)
+        return R_bar, X_eff, y

--- a/tests/test_forgetting.py
+++ b/tests/test_forgetting.py
@@ -651,24 +651,6 @@ class TestFeatureWiseForgetting:
 
         assert_allclose(sparse.csc_array(sp).toarray(), np.asarray(dense), atol=1e-12)
 
-    def test_positive_definite(self):
-        rng = np.random.default_rng(3)
-        for _ in range(20):
-            R = _random_pd(8, rng)
-            X = _one_hot_rows(8, [list(rng.choice(8, 3, replace=False))])
-            R_bar, _, _ = FeatureWiseForgetting()(R, X, np.zeros(1), 0.7)
-            assert eigvalsh(np.asarray(R_bar))[0] > 0
-
-    def test_reduces_to_exponential_when_every_feature_is_active(self):
-        rng = np.random.default_rng(5)
-        R = _random_pd(5, rng)
-        X = rng.standard_normal((3, 5))  # dense: every feature in every row
-        lam = 0.9
-
-        R_bar, _, _ = FeatureWiseForgetting()(R, X, np.zeros(3), lam)
-
-        assert_allclose(np.asarray(R_bar), lam**3 * R, atol=1e-12)
-
     def test_matches_sift_when_forgotten_feature_is_uncorrelated(self):
         """With R[0, j] = 0 for j != 0 the stretch and the SIFt downdate coincide."""
         rng = np.random.default_rng(9)
@@ -687,8 +669,9 @@ class TestFeatureWiseForgetting:
 
     def test_unobserved_marginals_and_correlations_unchanged(self):
         """The Schur complement of the untouched block, hence the marginal
-        precision of the unobserved features, is unchanged; and in
-        covariance form every correlation is preserved."""
+        precision of the unobserved features, is unchanged; in covariance
+        form every correlation is preserved and each observed coefficient's
+        variance is inflated by exactly 1/lam."""
         rng = np.random.default_rng(11)
         R = _random_pd(7, rng)
         obs = [0, 2]
@@ -712,18 +695,8 @@ class TestFeatureWiseForgetting:
 
         assert_allclose(corr(R_bar), corr(R), atol=1e-12)
 
-    def test_observed_variance_inflates_by_lam(self):
-        rng = np.random.default_rng(13)
-        R = _random_pd(5, rng)
-        X = _one_hot_rows(5, [[2]])
-        lam = 0.75
-
-        R_bar, _, _ = FeatureWiseForgetting()(R, X, np.zeros(1), lam)
-
-        S, S_bar = np.linalg.inv(R), np.linalg.inv(np.asarray(R_bar))
-        assert_allclose(S_bar[2, 2], S[2, 2] / lam)
-        untouched = [0, 1, 3, 4]
-        assert_allclose(np.diag(S_bar)[untouched], np.diag(S)[untouched])
+        S, S_bar = np.linalg.inv(R), np.linalg.inv(R_bar)
+        assert_allclose(np.diag(S_bar)[obs], np.diag(S)[obs] / 0.5)
 
     def test_sparse_batch_counts_nonzero_values_only(self):
         """An explicitly stored zero in a sparse batch does not count as active."""

--- a/tests/test_forgetting.py
+++ b/tests/test_forgetting.py
@@ -1,4 +1,4 @@
-"""Tests for forgetting rules: exponential, stabilized (KZ), and SIFt."""
+"""Tests for forgetting rules: exponential, stabilized (KZ), SIFt, and feature-wise."""
 
 import numpy as np
 import pytest
@@ -8,6 +8,7 @@ from scipy.linalg import cho_factor, cho_solve, eigvalsh
 
 from bayesianbandits._forgetting import (
     ExponentialForgetting,
+    FeatureWiseForgetting,
     SiftForgetting,
     StabilizedForgetting,
     _filter_batch_sparse,
@@ -40,14 +41,16 @@ def _naive_sift_downdate(R, X_bar, lam):
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(params=["exponential", "stabilized", "sift"])
+@pytest.fixture(params=["exponential", "stabilized", "sift", "feature-wise"])
 def rule(request):
     if request.param == "exponential":
         return ExponentialForgetting()
     elif request.param == "stabilized":
         return StabilizedForgetting(alpha=1.0)
-    else:
+    elif request.param == "sift":
         return SiftForgetting(eps=1e-10)
+    else:
+        return FeatureWiseForgetting()
 
 
 # ---------------------------------------------------------------------------
@@ -590,3 +593,147 @@ class TestSiftForgetting:
         # R_bar >= lam * R (Corollary 1)
         diff = R_bar_full - lam * R_dense
         assert eigvalsh(diff)[0] >= -1e-10
+
+
+# ---------------------------------------------------------------------------
+# FeatureWiseForgetting tests
+# ---------------------------------------------------------------------------
+
+
+def _one_hot_rows(n, rows):
+    """A dense (len(rows), n) batch with ones at the given column sets."""
+    X = np.zeros((len(rows), n))
+    for r, cols in enumerate(rows):
+        X[r, cols] = 1.0
+    return X
+
+
+class TestFeatureWiseForgetting:
+    def test_formula(self):
+        """R_bar = D R D with D_ii = lam ** (m_i / 2), m_i the rows feature i is in."""
+        rng = np.random.default_rng(42)
+        R = _random_pd(6, rng)
+        X = _one_hot_rows(6, [[0, 1], [0, 2]])  # feature 0 in two rows, 1 and 2 in one
+        lam = 0.8
+
+        R_bar, X_eff, y_eff = FeatureWiseForgetting()(R, X, np.zeros(2), lam)
+
+        d = np.array([lam, np.sqrt(lam), np.sqrt(lam), 1.0, 1.0, 1.0])
+        assert_allclose(np.asarray(R_bar), np.diag(d) @ R @ np.diag(d), atol=1e-12)
+        assert_allclose(X_eff, X)
+        assert y_eff.shape == (2,)
+
+    def test_pattern_preserved(self):
+        """The sparse result has exactly the input's indices and indptr."""
+        rng = np.random.default_rng(1)
+        X_hist = np.where(
+            rng.random((50, 30)) < 0.05, rng.standard_normal((50, 30)), 0.0
+        )
+        R = sparse.csc_array(np.eye(30) + X_hist.T @ X_hist)
+        X = _one_hot_rows(30, [[3, 7, 11]])
+
+        R_bar, _, _ = FeatureWiseForgetting()(R, X, np.zeros(1), 0.9)
+
+        assert sparse.issparse(R_bar)
+        R_bar = sparse.csc_array(R_bar)
+        np.testing.assert_array_equal(R_bar.indptr, R.indptr)
+        np.testing.assert_array_equal(R_bar.indices, R.indices)
+
+    def test_dense_and_sparse_agree(self):
+        rng = np.random.default_rng(7)
+        R = _random_pd(8, rng)
+        X = _one_hot_rows(8, [[1, 4], [4, 6]])
+
+        dense, _, _ = FeatureWiseForgetting()(R, X, np.zeros(2), 0.85)
+        sp, _, _ = FeatureWiseForgetting()(
+            sparse.csc_array(R), sparse.csc_array(X), np.zeros(2), 0.85
+        )
+
+        assert_allclose(sparse.csc_array(sp).toarray(), np.asarray(dense), atol=1e-12)
+
+    def test_positive_definite(self):
+        rng = np.random.default_rng(3)
+        for _ in range(20):
+            R = _random_pd(8, rng)
+            X = _one_hot_rows(8, [list(rng.choice(8, 3, replace=False))])
+            R_bar, _, _ = FeatureWiseForgetting()(R, X, np.zeros(1), 0.7)
+            assert eigvalsh(np.asarray(R_bar))[0] > 0
+
+    def test_reduces_to_exponential_when_every_feature_is_active(self):
+        rng = np.random.default_rng(5)
+        R = _random_pd(5, rng)
+        X = rng.standard_normal((3, 5))  # dense: every feature in every row
+        lam = 0.9
+
+        R_bar, _, _ = FeatureWiseForgetting()(R, X, np.zeros(3), lam)
+
+        assert_allclose(np.asarray(R_bar), lam**3 * R, atol=1e-12)
+
+    def test_matches_sift_when_forgotten_feature_is_uncorrelated(self):
+        """With R[0, j] = 0 for j != 0 the stretch and the SIFt downdate coincide."""
+        rng = np.random.default_rng(9)
+        R = _random_pd(6, rng)
+        R[0, 1:] = 0.0
+        R[1:, 0] = 0.0
+        X = _one_hot_rows(6, [[0]])
+        lam = 0.6
+
+        fw, _, _ = FeatureWiseForgetting()(R, X, np.zeros(1), lam)
+        result = SiftForgetting(eps=1e-12)(R, X, np.zeros(1), lam)
+        assert result is not None
+        sift, _, _ = result
+
+        assert_allclose(np.asarray(fw), symmetrize(np.asarray(sift)), atol=1e-12)
+
+    def test_unobserved_marginals_and_correlations_unchanged(self):
+        """The Schur complement of the untouched block, hence the marginal
+        precision of the unobserved features, is unchanged; and in
+        covariance form every correlation is preserved."""
+        rng = np.random.default_rng(11)
+        R = _random_pd(7, rng)
+        obs = [0, 2]
+        rest = [1, 3, 4, 5, 6]
+        X = _one_hot_rows(7, [obs])
+
+        R_bar, _, _ = FeatureWiseForgetting()(R, X, np.zeros(1), 0.5)
+        R_bar = np.asarray(R_bar)
+
+        def marginal(M):
+            return M[np.ix_(rest, rest)] - M[np.ix_(rest, obs)] @ np.linalg.solve(
+                M[np.ix_(obs, obs)], M[np.ix_(obs, rest)]
+            )
+
+        assert_allclose(marginal(R_bar), marginal(R), atol=1e-12)
+
+        def corr(M):
+            S = np.linalg.inv(M)
+            sd = np.sqrt(np.diag(S))
+            return S / np.outer(sd, sd)
+
+        assert_allclose(corr(R_bar), corr(R), atol=1e-12)
+
+    def test_observed_variance_inflates_by_lam(self):
+        rng = np.random.default_rng(13)
+        R = _random_pd(5, rng)
+        X = _one_hot_rows(5, [[2]])
+        lam = 0.75
+
+        R_bar, _, _ = FeatureWiseForgetting()(R, X, np.zeros(1), lam)
+
+        S, S_bar = np.linalg.inv(R), np.linalg.inv(np.asarray(R_bar))
+        assert_allclose(S_bar[2, 2], S[2, 2] / lam)
+        untouched = [0, 1, 3, 4]
+        assert_allclose(np.diag(S_bar)[untouched], np.diag(S)[untouched])
+
+    def test_sparse_batch_counts_nonzero_values_only(self):
+        """An explicitly stored zero in a sparse batch does not count as active."""
+        rng = np.random.default_rng(17)
+        R = _random_pd(4, rng)
+        X = sparse.csc_array(
+            (np.array([1.0, 0.0]), (np.array([0, 0]), np.array([1, 3]))), shape=(1, 4)
+        )
+
+        R_bar, _, _ = FeatureWiseForgetting()(R, X, np.zeros(1), 0.5)
+
+        d = np.array([1.0, np.sqrt(0.5), 1.0, 1.0])
+        assert_allclose(np.asarray(R_bar), np.diag(d) @ R @ np.diag(d), atol=1e-12)


### PR DESCRIPTION
## Summary

- Adds `FeatureWiseForgetting` to `_forgetting.py`: vector-type forgetting (Saelid & Foss 1983; Parkum, Poulsen & Holst 1992; Fraccaroli, Peruffo & Zorzi 2015 eq. 12) with the per-feature factors chosen from the batch support, `Λ̄ = D Λ D`, `D = diag(γ^{m_i/2})`.
- Forgets only the observed features, leaves every unobserved feature's marginal and every correlation unchanged, preserves the sparsity pattern, and costs one pass over the nonzeros. Reduces to exponential when every feature is active and to SIFt when the forgotten feature is conditionally independent of the rest.
- Math page gets a section with the citations, what the rule preserves, what it gives up (it is a coordinate stretch, not a Bayesian update, and can over-tighten combinations with strongly correlated unobserved features, by an amount that grows with the correlation), and the γ-scaling note across rules.
- Nine tests, a benchmark entry, a changelog entry. Not yet wired into the estimators; that is PR 2 (#236).

## Why

SIFt's correction is dense on the one-hop neighbourhood of the active features. With any shared feature (an intercept, a hierarchy root) that neighbourhood is everything, so a sparse precision fills in to dense over every feature ever seen. On a 20k-feature root/arm/leaf hierarchy with an identical observation stream:

| step | features seen | SIFt nnz(R) | SIFt nnz(L) | feature-wise nnz(R) | feature-wise nnz(L) |
|---|---|---|---|---|---|
| 200 | 288 | 102,657 | 61,329 | 20,975 | 20,488 |
| 600 | 693 | 499,557 | 259,779 | 22,569 | 21,285 |

Feature-wise is pattern-identical to exponential at every step. On the same hierarchy with drifting coefficients, feature-wise and SIFt tie on predictive RMSE and 95% coverage (1.089/0.96 vs 1.086/0.95 with arms jumping; 1.109/0.97 vs 1.107/0.95 with coefficients moving on observation), both ahead of stabilized and exponential. On dense low-rank regressors feature-wise equals exponential to the digit and only SIFt avoids windup, which the docs say.

## Test plan

- [x] `uv run pytest tests/test_forgetting.py` (52 passed)
- [x] `uv run ruff format` / `ruff check` clean
- [x] pyright: identical message set to master on the touched files (25 pre-existing, none added)
- [x] `benchmarks/test_bench_forgetting.py -k feature-wise` runs
