### PR TITLE
Make the forgetting rules public and decay by ticks

### DIFF
--- a/benchmarks/test_bench_forgetting.py
+++ b/benchmarks/test_bench_forgetting.py
@@ -131,39 +131,39 @@ def test_filter_batch_sparse_1m(benchmark, forgetting_sparse_1m):
 # ---------------------------------------------------------------------------
 
 RULES = [
-    pytest.param(ExponentialForgetting(), id="exponential"),
-    pytest.param(StabilizedForgetting(alpha=1.0), id="stabilized"),
-    pytest.param(SiftForgetting(eps=1e-12), id="sift"),
-    pytest.param(FeatureWiseForgetting(), id="feature-wise"),
+    pytest.param(ExponentialForgetting(LAM), id="exponential"),
+    pytest.param(StabilizedForgetting(LAM, alpha=1.0), id="stabilized"),
+    pytest.param(SiftForgetting(LAM, eps=1e-12), id="sift"),
+    pytest.param(FeatureWiseForgetting(LAM), id="feature-wise"),
 ]
 
 
 @pytest.mark.parametrize("rule", RULES)
 def test_rule_dense_100(benchmark, rule, forgetting_dense_100):
     R, X, y = forgetting_dense_100
-    benchmark(rule, R, X, y, LAM)
+    benchmark(rule.update, R, X, y, alpha=1.0)
 
 
 @pytest.mark.parametrize("rule", RULES)
 def test_rule_dense_1k(benchmark, rule, forgetting_dense_1k):
     R, X, y = forgetting_dense_1k
-    benchmark(rule, R, X, y, LAM)
+    benchmark(rule.update, R, X, y, alpha=1.0)
 
 
 @pytest.mark.parametrize("rule", RULES)
 def test_rule_sparse_1k(benchmark, rule, forgetting_sparse_1k):
     R, X, y = forgetting_sparse_1k
-    benchmark(rule, R, X, y, LAM)
+    benchmark(rule.update, R, X, y, alpha=1.0)
 
 
 @pytest.mark.parametrize("rule", RULES)
 def test_rule_sparse_100k(benchmark, rule, forgetting_sparse_100k):
     R, X, y = forgetting_sparse_100k
-    benchmark(rule, R, X, y, LAM)
+    benchmark(rule.update, R, X, y, alpha=1.0)
 
 
 @pytest.mark.slow
 @pytest.mark.parametrize("rule", RULES)
 def test_rule_sparse_1m(benchmark, rule, forgetting_sparse_1m):
     R, X, y = forgetting_sparse_1m
-    benchmark(rule, R, X, y, LAM)
+    benchmark(rule.update, R, X, y, alpha=1.0)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -68,12 +68,10 @@ Estimators
 ----------
 
 These estimators are the underlying models for the arms in a bandit. They
-should be passed to the ``learner`` argument of the ``bandit`` decorator. Each
-of these Bayesian estimators can be converted to a recursive estimator by
-passing a ``learning_rate`` argument to the constructor that is less than 1.
-Each of them implement a ``decay`` method that uses the ``learning_rate`` to
-increase the variance of the prior. This is a type of state-space model that
-is useful for restless bandits.
+should be passed to the ``learner`` argument of an ``Arm``. Each of them
+implements a ``decay`` method that forgets: the clock ticked, and the
+posterior widens by a forgetting rule so the model can follow rewards that
+change with time (a restless bandit).
 
 .. autosummary::
    :toctree: generated/
@@ -84,14 +82,30 @@ is useful for restless bandits.
    bayesianbandits.NormalRegressor
    bayesianbandits.NormalInverseGammaRegressor
 
+Forgetting Rules
+----------------
+
+A forgetting rule says how a posterior widens and carries its own rate.
+The uniform rules are what ``decay`` applies on a schedule; the
+directional rules forget only along what a batch excited. See
+:doc:`math/forgetting` for the equations.
+
+.. autosummary::
+   :toctree: generated/
+
+   bayesianbandits.ExponentialForgetting
+   bayesianbandits.StabilizedForgetting
+   bayesianbandits.FeatureWiseForgetting
+   bayesianbandits.SiftForgetting
+
 Empirical Bayes Estimators
 --------------------------
 
 These estimators automatically tune their hyperparameters via evidence
 maximization (MacKay's update rules). They are drop-in replacements for their
 base estimators and are especially useful when hyperparameters are unknown or
-when the environment may be non-stationary (pair with ``learning_rate < 1``
-for decay as a defensive default).
+when the environment may be non-stationary (their ``decay`` defaults to
+stabilized forgetting, which never forgets the prior).
 
 .. autosummary::
    :toctree: generated/

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,6 +32,19 @@ Unreleased
 
 **Breaking changes**
 
+- ``decay`` has one signature everywhere,
+  ``decay(forgetting=None, *, decay_rate=None, steps=1)``, and the
+  ``Learner`` protocol requires it. ``decay_rate`` is keyword-only on the
+  agents and pipelines, where it used to be positional, and
+  ``Agent.decay(0.9)`` is a ``TypeError`` that says to pass
+  ``decay_rate=``. A learner of your own with the old
+  ``decay(X, *, decay_rate=None)`` signature no longer works inside an
+  ``Arm``: arms call ``decay(forgetting, decay_rate=..., steps=...)``.
+  Internally, the estimators' private ``_apply_decay`` hook is replaced
+  by ``_apply_tick(rule, steps)``, the EB ``_reinject_prior`` helper is
+  gone, and the rule objects in ``_forgetting.py`` are built with a
+  ``rate`` and applied through ``update``/``tick`` rather than called.
+
 - ``NonContextualAgentPipeline`` is removed, and ``AgentPipeline`` is now
   a class rather than a factory dispatching between it and
   ``ContextualAgentPipeline``. A pipeline's steps transform the context on

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,32 @@ Changelog
 Unreleased
 ----------
 
+**Deprecations**
+
+- ``decay()`` no longer takes a context array. It was only ever read for
+  its row count (the grouped conjugate models also read the groups in
+  it), and it invited passing the last batch to a method that is meant
+  to be called on a clock. Pass ``steps=`` for the number of ticks
+  instead; an array still works for now, with a ``FutureWarning``, and
+  keeps its old meaning. ``decay()`` with neither a rule nor
+  ``decay_rate`` still falls back to ``learning_rate``, also with a
+  ``FutureWarning``: a nightly job should not inherit a per-observation
+  number.
+
+**New features**
+
+- The forgetting rules are public, ``ExponentialForgetting``,
+  ``StabilizedForgetting``, ``FeatureWiseForgetting`` and
+  ``SiftForgetting``, and each carries its own ``rate``. The uniform two
+  have a ``tick`` for the clock, and every rule has an ``update`` for a
+  batch. ``decay(rule, steps=)`` accepts a uniform rule on every
+  estimator, arm, agent and pipeline, so stabilized forgetting (Kulhavy &
+  Zarrop) is available to the plain estimators, with the floor at their
+  ``alpha``; the empirical Bayes estimators default to it, as before.
+  ``decay_rate=`` is shorthand for the estimator's default rule at that
+  rate. Passing a directional rule to ``decay`` is a ``TypeError``
+  pointing at where it belongs: the learner's update, coming next.
+
 **Breaking changes**
 
 - ``NonContextualAgentPipeline`` is removed, and ``AgentPipeline`` is now

--- a/docs/generated/bayesianbandits.ExponentialForgetting.rst
+++ b/docs/generated/bayesianbandits.ExponentialForgetting.rst
@@ -1,0 +1,12 @@
+﻿bayesianbandits.ExponentialForgetting
+=====================================
+
+.. currentmodule:: bayesianbandits
+
+.. autoclass:: ExponentialForgetting
+   :members:
+   :inherited-members: BaseEstimator, RegressorMixin, ClassifierMixin, IntEnum, Enum
+   :special-members: __init__
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: set_fit_request, set_partial_fit_request, set_score_request, set_predict_request, get_metadata_routing

--- a/docs/generated/bayesianbandits.FeatureWiseForgetting.rst
+++ b/docs/generated/bayesianbandits.FeatureWiseForgetting.rst
@@ -1,0 +1,12 @@
+﻿bayesianbandits.FeatureWiseForgetting
+=====================================
+
+.. currentmodule:: bayesianbandits
+
+.. autoclass:: FeatureWiseForgetting
+   :members:
+   :inherited-members: BaseEstimator, RegressorMixin, ClassifierMixin, IntEnum, Enum
+   :special-members: __init__
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: set_fit_request, set_partial_fit_request, set_score_request, set_predict_request, get_metadata_routing

--- a/docs/generated/bayesianbandits.SiftForgetting.rst
+++ b/docs/generated/bayesianbandits.SiftForgetting.rst
@@ -1,0 +1,12 @@
+﻿bayesianbandits.SiftForgetting
+==============================
+
+.. currentmodule:: bayesianbandits
+
+.. autoclass:: SiftForgetting
+   :members:
+   :inherited-members: BaseEstimator, RegressorMixin, ClassifierMixin, IntEnum, Enum
+   :special-members: __init__
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: set_fit_request, set_partial_fit_request, set_score_request, set_predict_request, get_metadata_routing

--- a/docs/generated/bayesianbandits.StabilizedForgetting.rst
+++ b/docs/generated/bayesianbandits.StabilizedForgetting.rst
@@ -1,0 +1,12 @@
+﻿bayesianbandits.StabilizedForgetting
+====================================
+
+.. currentmodule:: bayesianbandits
+
+.. autoclass:: StabilizedForgetting
+   :members:
+   :inherited-members: BaseEstimator, RegressorMixin, ClassifierMixin, IntEnum, Enum
+   :special-members: __init__
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: set_fit_request, set_partial_fit_request, set_score_request, set_predict_request, get_metadata_routing

--- a/docs/howto/decay.rst
+++ b/docs/howto/decay.rst
@@ -62,21 +62,24 @@ the timescale of change in your environment:
    agent.update(X, y=np.array([1.0]))  # purchase signal
 
    # Once per day (e.g. nightly cron): decay all arms
-   agent.decay(np.array([[0.0, 0.0]]), decay_rate=0.95)
+   agent.decay(decay_rate=0.95)
 
-Pass a 1-row array -- ``decay()`` uses ``X.shape[0]`` as the
-exponent, so a 100-row array would apply ``0.95^100`` instead of
-``0.95`` [1]_.
+One call is one tick. If the job missed a few days, pass
+``steps=3`` and the rate is raised to that power. Per-observation
+decay via ``learning_rate < 1`` is usually too aggressive for the
+same reason: most real systems make many decisions per natural time
+period (thousands of recommendations per day), and forgetting once
+per observation in that setting tracks traffic, not time.
 
-.. [1] ``decay()`` raises ``gamma`` to the power of ``X.shape[0]``,
-   so a 1-row array gives one decay step (``gamma^1``). This
-   exponent exists so that ``partial_fit`` on a batch of 10
-   observations gives the same posterior as fitting them one at a
-   time with decay between each. In practice, per-observation decay
-   via ``learning_rate < 1`` is often too aggressive: most real
-   systems make many decisions per natural time period (thousands of
-   recommendations per day), and decaying once per observation in
-   that setting forgets too fast.
+``decay_rate=0.95`` is shorthand for passing the learner's default
+rule, :class:`~bayesianbandits.ExponentialForgetting`, at that rate.
+The rule can be passed explicitly, and the rule carries its rate:
+
+.. code-block:: python
+
+   from bayesianbandits import StabilizedForgetting
+
+   agent.decay(StabilizedForgetting(0.95), steps=1)
 
 
 Choose a decay rate
@@ -115,25 +118,24 @@ Aggressive decay can cause problems:
   along with the data. After enough decay steps, the model is
   effectively unregularized.
 
-:class:`~bayesianbandits.EmpiricalBayesNormalRegressor` (and
-:class:`~bayesianbandits.EmpiricalBayesGLM` for binary or count
-outcomes) mitigates the second problem with stabilized forgetting:
-after each decay step, it re-injects ``(1 - gamma^n) * alpha`` onto
-the precision diagonal so the prior contribution converges to
-``alpha`` instead of zero. If you need decay and want a safety net
-against prior collapse, use EB:
+:class:`~bayesianbandits.StabilizedForgetting` fixes both. After
+scaling by ``gamma``, it adds ``(1 - gamma) * alpha`` back onto the
+precision diagonal, so the prior contribution converges to ``alpha``
+instead of zero and no direction can wind up past the prior. Any
+estimator accepts it in ``decay``:
 
 .. code-block:: python
 
-   from bayesianbandits import EmpiricalBayesNormalRegressor
+   from bayesianbandits import StabilizedForgetting
 
-   learner = EmpiricalBayesNormalRegressor(
-       alpha=1.0,
-       beta=1.0,
-       learning_rate=1.0,  # still decouple from partial_fit
-   )
+   agent.decay(StabilizedForgetting(0.95))
 
-Then call ``decay()`` on a schedule as above.
+The empirical Bayes estimators
+(:class:`~bayesianbandits.EmpiricalBayesNormalRegressor`,
+:class:`~bayesianbandits.EmpiricalBayesGLM`) use it by default, with
+the floor at their tuned ``alpha``, so for them ``decay_rate=0.95`` is
+already stabilized. For the other estimators the default is plain
+exponential forgetting, for compatibility; pass the rule to opt in.
 
 See the :doc:`delayed reward example </notebooks/delayed-reward>` for
 a full simulation that tunes the decay rate with optuna and shows how

--- a/docs/howto/delayed-rewards.rst
+++ b/docs/howto/delayed-rewards.rst
@@ -101,7 +101,7 @@ model further than you might expect.
    # ... store decisions ...
 
    # Nightly: decay + update with yesterday's rewards
-   agent.decay(np.array([[0.0, 0.0]]), decay_rate=0.99)
+   agent.decay(decay_rate=0.99)
    for token, X_row, reward in yesterdays_rewards:
        agent.select_for_update(token).update(
            np.atleast_2d(X_row), np.atleast_1d(reward)

--- a/src/bayesianbandits/__init__.py
+++ b/src/bayesianbandits/__init__.py
@@ -68,12 +68,10 @@ Estimators
 ==========
 
 These estimators are the underlying models for the arms in a bandit. They
-should be passed to the `learner` argument of the `bandit` decorator. Each
-of these Bayesian estimators can be converted to a recursive estimator by
-passing a `learning_rate` argument to the constructor that is less than 1.
-Each of them implement a `decay` method that uses the `learning_rate` to
-increase the variance of the prior. This is a type of state-space model that
-is useful for restless bandits.
+should be passed to the `learner` argument of an `Arm`. Each of them
+implements a `decay` method that forgets: the clock ticked, and the
+posterior widens by a forgetting rule so the model can follow rewards
+that change with time (a restless bandit).
 
 .. autosummary::
 
@@ -83,14 +81,28 @@ is useful for restless bandits.
     NormalRegressor
     NormalInverseGammaRegressor
 
+Forgetting Rules
+================
+
+A forgetting rule says how a posterior widens and carries its own rate.
+The uniform rules are what `decay` applies on a schedule; the directional
+rules forget only along what a batch excited.
+
+.. autosummary::
+
+    ExponentialForgetting
+    StabilizedForgetting
+    FeatureWiseForgetting
+    SiftForgetting
+
 Empirical Bayes Estimators
 ==========================
 
 These estimators automatically tune their hyperparameters via evidence
 maximization (MacKay's update rules). They are drop-in replacements for their
 base estimators and are especially useful when hyperparameters are unknown or
-when the environment may be non-stationary (pair with ``learning_rate < 1``
-for decay as a defensive default).
+when the environment may be non-stationary (their ``decay`` defaults to
+stabilized forgetting, which never forgets the prior).
 
 .. autosummary::
 
@@ -141,6 +153,12 @@ from ._estimators import (
     NormalInverseGammaRegressor,
     NormalRegressor,
 )
+from ._forgetting import (
+    ExponentialForgetting,
+    FeatureWiseForgetting,
+    SiftForgetting,
+    StabilizedForgetting,
+)
 from ._gaussian import LaplaceApproximator, RVGAApproximator
 from ._memory import MemoryUsage, memory_usage
 from .api import (
@@ -184,4 +202,8 @@ __all__ = [
     "EXP3A",
     "AgentPipeline",
     "LearnerPipeline",
+    "ExponentialForgetting",
+    "StabilizedForgetting",
+    "FeatureWiseForgetting",
+    "SiftForgetting",
 ]

--- a/src/bayesianbandits/_arm.py
+++ b/src/bayesianbandits/_arm.py
@@ -126,7 +126,13 @@ class Learner(Protocol[X_contra]):
         y: NDArray[np.float64],
         sample_weight: Optional[NDArray[np.float64]] = None,
     ) -> Self: ...
-    def decay(self, X: X_contra, *, decay_rate: Optional[float] = None) -> None: ...
+    def decay(
+        self,
+        forgetting: Any = None,
+        *,
+        steps: float = 1,
+        decay_rate: Optional[float] = None,
+    ) -> None: ...
     def predict(self, X: X_contra) -> NDArray[np.float64]: ...
     @property
     def random_state(self) -> Union[np.random.Generator, int, None]: ...
@@ -542,24 +548,31 @@ class Arm(MemoryUsageMixin, Generic[ContextType, TokenType]):
         self.learner.partial_fit(X, y, sample_weight)
 
     @requires_learner
-    def decay(self, X: ContextType, *, decay_rate: Optional[float] = None) -> None:
-        """Increase posterior uncertainty for non-stationary environments.
+    def decay(
+        self,
+        forgetting: Any = None,
+        *,
+        steps: float = 1,
+        decay_rate: Optional[float] = None,
+    ) -> None:
+        """Forget: the clock ticked ``steps`` times with no new observations.
 
-        Shrinks the learner's posterior precision, allowing the model
-        to forget old observations and adapt to changing reward
-        distributions (restless bandit setting).
+        Widens the learner's posterior so the arm can follow a reward
+        distribution that changes with time (the restless bandit
+        setting). Call it on a schedule, once per unit of time.
 
         Parameters
         ----------
-        X : ContextType
-            Context matrix (required by the learner interface; used
-            by context-dependent estimators).
-        decay_rate : float or None, default=None
-            Override the learner's default ``learning_rate``. Values
-            less than 1 geometrically shrink posterior precision.
+        forgetting : ExponentialForgetting or StabilizedForgetting, optional
+            The rule to tick with, carrying its own rate. Default: the
+            learner's own, at ``decay_rate``.
+        steps : float, default=1
+            Number of ticks; the rule's rate is raised to this power.
+        decay_rate : float, optional
+            Shorthand for the learner's default rule at this rate.
         """
         assert self.learner is not None
-        self.learner.decay(X, decay_rate=decay_rate)
+        self.learner.decay(forgetting, steps=steps, decay_rate=decay_rate)
 
     def __repr__(self) -> str:
         return (

--- a/src/bayesianbandits/_arm.py
+++ b/src/bayesianbandits/_arm.py
@@ -130,8 +130,8 @@ class Learner(Protocol[X_contra]):
         self,
         forgetting: Any = None,
         *,
-        steps: float = 1,
         decay_rate: Optional[float] = None,
+        steps: float = 1,
     ) -> None: ...
     def predict(self, X: X_contra) -> NDArray[np.float64]: ...
     @property
@@ -552,8 +552,8 @@ class Arm(MemoryUsageMixin, Generic[ContextType, TokenType]):
         self,
         forgetting: Any = None,
         *,
-        steps: float = 1,
         decay_rate: Optional[float] = None,
+        steps: float = 1,
     ) -> None:
         """Forget: the clock ticked ``steps`` times with no new observations.
 
@@ -572,7 +572,7 @@ class Arm(MemoryUsageMixin, Generic[ContextType, TokenType]):
             Shorthand for the learner's default rule at this rate.
         """
         assert self.learner is not None
-        self.learner.decay(forgetting, steps=steps, decay_rate=decay_rate)
+        self.learner.decay(forgetting, decay_rate=decay_rate, steps=steps)
 
     def __repr__(self) -> str:
         return (

--- a/src/bayesianbandits/_eb_estimators.py
+++ b/src/bayesianbandits/_eb_estimators.py
@@ -44,6 +44,7 @@ from ._estimators import (
     _invalidate_cached_properties,
     compute_effective_weights,
 )
+from ._forgetting import StabilizedForgetting, resolve_tick
 from ._gaussian import LaplaceApproximator, LinkFunction, PosteriorApproximator
 from ._np_utils import groupby_array
 from ._sparse_bayesian_linear_regression import (
@@ -205,26 +206,35 @@ class _StabilizedPriorMixin(_BayesianLinearModel):
 
         return result
 
+    _default_tick_rule: type = StabilizedForgetting
+
     def decay(
         self,
-        X: Union[NDArray[Any], csc_array],
+        forgetting: Any = None,
         *,
+        steps: float = 1,
         decay_rate: Optional[float] = None,
     ) -> None:
         """
-        Decay the precision matrix with stabilized prior re-injection.
+        Forget: the clock ticked ``steps`` times with no new observations.
 
-        Applies ``Λ_new = γⁿ·Λ_old`` and re-injects ``(1 - γⁿ)·alpha``
-        onto the diagonal (Kulhavy & Zarrop 1993), so the prior's
-        contribution converges to ``alpha`` rather than zero. The
-        running statistics behind the online EB step decay alongside.
+        Defaults to stabilized forgetting (Kulhavy & Zarrop 1993):
+        ``Λ ← γ·Λ + (1 - γ)·alpha·I`` with ``γ = rate ** steps``, so the
+        prior's contribution converges to the tuned ``alpha`` rather than
+        zero. The running statistics behind the online EB step decay
+        alongside. :class:`~bayesianbandits.ExponentialForgetting` is
+        accepted; the directional rules are not, because the EB step
+        relies on the prior being a scalar on the diagonal.
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
-            Used only for its number of rows ``n``.
-        decay_rate : float, default=None
-            Decay factor in (0, 1]. If None, uses ``learning_rate``.
+        forgetting : StabilizedForgetting or ExponentialForgetting, optional
+            The rule to tick with, carrying its own rate. Default:
+            ``StabilizedForgetting(decay_rate)``.
+        steps : float, default=1
+            Number of ticks; the rule's rate is raised to this power.
+        decay_rate : float, optional
+            Shorthand for ``forgetting=StabilizedForgetting(decay_rate)``.
 
         See Also
         --------
@@ -232,26 +242,23 @@ class _StabilizedPriorMixin(_BayesianLinearModel):
         """
         if not hasattr(self, "coef_"):
             return
-
-        if decay_rate is None:
-            decay_rate = self.learning_rate
-
-        assert X.shape is not None
-        prior_decay = decay_rate ** X.shape[0]
-
-        prior_reinjection = 0.0
+        rule, steps, _ = resolve_tick(
+            forgetting,
+            steps=steps,
+            decay_rate=decay_rate,
+            learning_rate=self.learning_rate,
+            default=self._default_tick_rule,
+        )
+        gamma = rule.rate**steps
         if hasattr(self, "_prior_scalar"):
-            self._prior_scalar = (
-                prior_decay * self._prior_scalar + (1 - prior_decay) * self.alpha
-            )
-            prior_reinjection = (1 - prior_decay) * self.alpha
+            if isinstance(rule, StabilizedForgetting):
+                floor = rule.floor(self.alpha)
+                self._prior_scalar = gamma * self._prior_scalar + (1 - gamma) * floor
+            else:
+                self._prior_scalar = gamma * self._prior_scalar
         if hasattr(self, "_effective_n"):
-            self._decay_stats(prior_decay)
-
-        # Base class applies uniform decay: cov_inv_ *= prior_decay
-        super().decay(X, decay_rate=decay_rate)
-
-        self._reinject_prior(prior_reinjection)
+            self._decay_stats(gamma)
+        self._apply_tick(rule, steps)
 
     # ---- shared mechanics -------------------------------------------------
 
@@ -271,32 +278,6 @@ class _StabilizedPriorMixin(_BayesianLinearModel):
             self.__dict__.pop("_prior_scalar", None)
         else:
             self.__dict__["_prior_scalar"] = prior_scalar_old
-
-    def _drop_factor(self) -> None:
-        """Drop the cached factor, keeping it as the hint ``_sparse_factor``
-        refactorizes from: a diagonal shift leaves the pattern alone."""
-        factor = self.__dict__.pop("_precision_factor")
-        if self.sparse:
-            self._factor_hint = factor
-
-    def _reinject_prior(self, prior_reinjection: float) -> None:
-        """Add stabilized prior re-injection to the precision diagonal.
-
-        After exponential decay the prior contribution shrinks toward zero.
-        This adds back ``prior_reinjection`` to every diagonal entry so that
-        the prior converges to ``alpha`` instead (Kulhavy & Zarrop, 1993).
-        """
-        if prior_reinjection == 0.0:
-            return
-        if self.sparse:
-            cov_inv = cast(csc_array, self.cov_inv_)
-            self._shift_diagonal(cov_inv, prior_reinjection)
-            self.cov_inv_ = cov_inv
-        else:
-            diag_idx = np.diag_indices_from(self.cov_inv_)
-            self.cov_inv_[diag_idx] += prior_reinjection
-        if "_precision_factor" in self.__dict__:
-            self._drop_factor()
 
     def _shift_diagonal(self, cov_inv: csc_array, shift: float) -> None:
         """``cov_inv += shift * I`` in place.
@@ -1549,39 +1530,9 @@ class EmpiricalBayesDirichletClassifier(DirichletClassifier):
 
         return result
 
-    def decay(
-        self,
-        X: NDArray[Any],
-        *,
-        decay_rate: Optional[float] = None,
-    ) -> None:
-        """Decay with stabilized prior re-injection.
-
-        Applies exponential forgetting and re-injects the EB-tuned
-        prior so that the prior contribution converges to ``prior_``
-        rather than zero. This ensures that effective counts
-        (``known_alphas - prior``) remain correct after decay.
-
-        Parameters
-        ----------
-        X : array-like of shape (n_samples, 1)
-            Used to identify which groups to decay.
-        decay_rate : float, default=None
-            Decay factor in (0, 1]. If None, uses ``self.learning_rate``.
-        """
-        if not hasattr(self, "known_alphas_"):
-            self._initialize_prior()
-
-        if decay_rate is None:
-            decay_rate = self.learning_rate
-
-        for x in X:
-            key = x.item()
-            # Stabilized forgetting: decay + re-inject prior
-            self.known_alphas_[key] = np.asarray(
-                decay_rate * self.known_alphas_[key] + (1 - decay_rate) * self.prior_,
-                dtype=np.float64,
-            )
+    # decay() defaults to stabilized forgetting toward the tuned prior_, so
+    # effective counts (known_alphas - prior) stay right after a tick.
+    _default_tick_rule: type = StabilizedForgetting
 
 
 class EmpiricalBayesGammaRegressor(GammaRegressor):
@@ -1864,27 +1815,5 @@ class EmpiricalBayesGammaRegressor(GammaRegressor):
 
         return result
 
-    def decay(
-        self,
-        X: NDArray[Any],
-        *,
-        decay_rate: Optional[float] = None,
-    ) -> None:
-        """Decay with stabilized prior re-injection.
-
-        Applies exponential forgetting and re-injects the EB-tuned
-        prior so that the prior contribution converges to ``prior_``
-        rather than zero.
-        """
-        if not hasattr(self, "coef_"):
-            self._initialize_prior()
-
-        if decay_rate is None:
-            decay_rate = self.learning_rate
-
-        for x in X:
-            key = x.item()
-            self.coef_[key] = np.asarray(
-                decay_rate * self.coef_[key] + (1 - decay_rate) * self.prior_,
-                dtype=np.float64,
-            )
+    # decay() defaults to stabilized forgetting toward the tuned prior_.
+    _default_tick_rule: type = StabilizedForgetting

--- a/src/bayesianbandits/_eb_estimators.py
+++ b/src/bayesianbandits/_eb_estimators.py
@@ -212,8 +212,8 @@ class _StabilizedPriorMixin(_BayesianLinearModel):
         self,
         forgetting: Any = None,
         *,
-        steps: float = 1,
         decay_rate: Optional[float] = None,
+        steps: float = 1,
     ) -> None:
         """
         Forget: the clock ticked ``steps`` times with no new observations.

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -48,6 +48,12 @@ from ._blas_helpers import (
     standard_normal_f,
     update_precision_dense,
 )
+from ._forgetting import (
+    ExponentialForgetting,
+    TickRule,
+    resolve_tick,
+    tick_groups,
+)
 from ._gaussian import (
     LaplaceApproximator,
     LinkFunction,
@@ -414,26 +420,35 @@ class DirichletClassifier(MemoryUsageMixin, BaseEstimator, ClassifierMixin):
             list(dirichlet.rvs(alpha, size, self.random_state_) for alpha in alphas),
         ).transpose(1, 0, 2)
 
-    def decay(self, X: NDArray[Any], *, decay_rate: Optional[float] = None) -> None:
+    _default_tick_rule: type = ExponentialForgetting
+
+    def decay(
+        self,
+        forgetting: Any = None,
+        *,
+        steps: float = 1,
+        decay_rate: Optional[float] = None,
+    ) -> None:
         """
-        Decay concentration parameters to increase uncertainty.
+        Forget: the clock ticked ``steps`` times with no new observations.
 
-        Scales the posterior concentration parameters
-        :math:`\\alpha_k \\leftarrow \\gamma \\, \\alpha_k` for each
-        group present in ``X``. This uniformly increases posterior
-        variance, allowing the model to adapt to non-stationary
-        environments.
+        Every group seen so far has its posterior concentration scaled
+        by :math:`\\gamma^{\\text{steps}}`. Under
+        :class:`~bayesianbandits.StabilizedForgetting` the prior
+        concentration is mixed back in, so a group forgotten for long
+        enough returns to the prior instead of to zero.
 
-        Has no effect if the model has not been fitted.
+        Has no effect on groups not yet observed.
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, 1)
-            Input features. Each unique value of ``X[:, 0]`` identifies
-            a group whose concentration parameters are decayed.
-        decay_rate : float, default=None
-            Multiplicative decay factor :math:`\\gamma` in (0, 1].
-            If None, uses ``self.learning_rate``.
+        forgetting : ExponentialForgetting or StabilizedForgetting, optional
+            The rule to tick with, carrying its own rate. Default:
+            ``ExponentialForgetting(decay_rate)``.
+        steps : float, default=1
+            Number of ticks; the rule's rate is raised to this power.
+        decay_rate : float, optional
+            Shorthand for ``forgetting=ExponentialForgetting(decay_rate)``.
 
         See Also
         --------
@@ -441,12 +456,15 @@ class DirichletClassifier(MemoryUsageMixin, BaseEstimator, ClassifierMixin):
         """
         if not hasattr(self, "known_alphas_"):
             self._initialize_prior()
-
-        if decay_rate is None:
-            decay_rate = self.learning_rate
-
-        for x in X:
-            self.known_alphas_[x.item()] *= decay_rate
+        tick_groups(
+            self.known_alphas_,
+            forgetting,
+            steps=steps,
+            decay_rate=decay_rate,
+            learning_rate=self.learning_rate,
+            prior=self.prior_,
+            default=self._default_tick_rule,
+        )
 
 
 class GammaRegressor(MemoryUsageMixin, BaseEstimator, RegressorMixin):
@@ -773,27 +791,37 @@ class GammaRegressor(MemoryUsageMixin, BaseEstimator, RegressorMixin):
             list(rv_gen(alpha, scale=1 / beta) for alpha, beta in shape_params),
         ).T
 
-    def decay(self, X: NDArray[Any], *, decay_rate: Optional[float] = None) -> None:
+    _default_tick_rule: type = ExponentialForgetting
+
+    def decay(
+        self,
+        forgetting: Any = None,
+        *,
+        steps: float = 1,
+        decay_rate: Optional[float] = None,
+    ) -> None:
         """
-        Decay posterior parameters to increase uncertainty.
+        Forget: the clock ticked ``steps`` times with no new observations.
 
-        Scales both shape and rate by the decay factor:
-        :math:`\\alpha \\leftarrow \\gamma \\alpha,\\;
-        \\beta \\leftarrow \\gamma \\beta`. Because both parameters
-        are scaled equally, the posterior mean
-        :math:`\\alpha / \\beta` is preserved but the variance
-        :math:`\\alpha / \\beta^2` increases.
+        Every group seen so far has both shape and rate scaled by
+        :math:`\\gamma^{\\text{steps}}`, which keeps the posterior mean
+        :math:`\\alpha / \\beta` and grows the variance
+        :math:`\\alpha / \\beta^2`. Under
+        :class:`~bayesianbandits.StabilizedForgetting` the prior
+        parameters are mixed back in, so a group forgotten for long
+        enough returns to the prior instead of to zero.
 
-        Has no effect if the model has not been fitted.
+        Has no effect on groups not yet observed.
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, 1)
-            Input features. Each unique value of ``X[:, 0]`` identifies
-            a group whose parameters are decayed.
-        decay_rate : float, default=None
-            Multiplicative decay factor :math:`\\gamma` in (0, 1].
-            If None, uses ``self.learning_rate``.
+        forgetting : ExponentialForgetting or StabilizedForgetting, optional
+            The rule to tick with, carrying its own rate. Default:
+            ``ExponentialForgetting(decay_rate)``.
+        steps : float, default=1
+            Number of ticks; the rule's rate is raised to this power.
+        decay_rate : float, optional
+            Shorthand for ``forgetting=ExponentialForgetting(decay_rate)``.
 
         See Also
         --------
@@ -801,12 +829,15 @@ class GammaRegressor(MemoryUsageMixin, BaseEstimator, RegressorMixin):
         """
         if not hasattr(self, "coef_"):
             self._initialize_prior()
-
-        if decay_rate is None:
-            decay_rate = self.learning_rate
-
-        for x in X:
-            self.coef_[x.item()] *= decay_rate
+        tick_groups(
+            self.coef_,
+            forgetting,
+            steps=steps,
+            decay_rate=decay_rate,
+            learning_rate=self.learning_rate,
+            prior=self.prior_,
+            default=self._default_tick_rule,
+        )
 
 
 def _scaled_identity_f(n: int, scale: float) -> NDArray[np.float64]:
@@ -1264,10 +1295,32 @@ class _BayesianLinearModel(MemoryUsageMixin, BaseEstimator):
         here; :class:`BayesianGLM` applies its link."""
         return eta
 
-    def _apply_decay(self, prior_decay: float) -> None:
-        """Scale the parameters ``decay`` forgets by. Only the variance
-        grows, so the posterior mean is untouched."""
-        self.cov_inv_ = prior_decay * self.cov_inv_
+    _default_tick_rule: type = ExponentialForgetting
+
+    def _apply_tick(self, rule: TickRule, steps: float) -> None:
+        """Forget ``steps`` ticks of ``rule`` on the precision. Only the
+        variance grows, so the posterior mean is untouched; the cached
+        factor follows a scalar rule and is dropped for any other."""
+        self.cov_inv_ = rule.tick(self.cov_inv_, alpha=self._prior_floor(), steps=steps)
+        if "_precision_factor" in self.__dict__:
+            if isinstance(rule, ExponentialForgetting):
+                self._precision_factor = scale_factor(
+                    self._precision_factor, rule.rate**steps
+                )
+            else:
+                self._drop_factor()
+
+    def _prior_floor(self) -> Optional[float]:
+        """The scalar prior precision a stabilized tick floors at; ``None``
+        when the prior is not a scalar."""
+        return self.alpha
+
+    def _drop_factor(self) -> None:
+        """Drop the cached factor, keeping it as the hint ``_sparse_factor``
+        refactorizes from: a diagonal shift leaves the pattern alone."""
+        factor = self.__dict__.pop("_precision_factor")
+        if self.sparse:
+            self._factor_hint = factor
 
     # ---- prior and factor ------------------------------------------------
 
@@ -1643,27 +1696,33 @@ class _BayesianLinearModel(MemoryUsageMixin, BaseEstimator):
     @_invalidate_cached_properties
     def decay(
         self,
-        X: Union[NDArray[Any], csc_array],
+        forgetting: Any = None,
         *,
+        steps: float = 1,
         decay_rate: Optional[float] = None,
     ) -> None:
         """
-        Decay the posterior precision to increase uncertainty.
+        Forget: the clock ticked ``steps`` times with no new observations.
 
-        Scales the precision matrix by :math:`\\gamma^n`, where
-        :math:`\\gamma` is the decay rate and :math:`n` is the number
-        of rows in ``X``. This uniformly increases posterior variance
-        while leaving the posterior mean unchanged, allowing the model
-        to adapt to non-stationary environments.
+        Applies a uniform forgetting rule to the posterior precision,
+        :math:`\\Lambda \\leftarrow \\gamma^{\\text{steps}}\\Lambda`
+        under :class:`~bayesianbandits.ExponentialForgetting`, or the same
+        with :math:`(1 - \\gamma^{\\text{steps}})\\,\\alpha I` added
+        back under :class:`~bayesianbandits.StabilizedForgetting` so the
+        prior is never forgotten. Either way the posterior mean is
+        unchanged and every direction widens; this is the step for
+        change that happens with time, whether or not the model is
+        observing. Call it on a schedule, once per unit of time.
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
-            Used only for its number of rows ``n``.
-        decay_rate : float, default=None
-            Decay factor :math:`\\gamma` in (0, 1]. If None, uses
-            ``self.learning_rate``. Values less than 1 increase
-            uncertainty; a value of 1 has no effect.
+        forgetting : ExponentialForgetting or StabilizedForgetting, optional
+            The rule to tick with, carrying its own rate. Default:
+            ``ExponentialForgetting(decay_rate)``.
+        steps : float, default=1
+            Number of ticks; the rule's rate is raised to this power.
+        decay_rate : float, optional
+            Shorthand for ``forgetting=ExponentialForgetting(decay_rate)``.
 
         See Also
         --------
@@ -1672,19 +1731,14 @@ class _BayesianLinearModel(MemoryUsageMixin, BaseEstimator):
         # If the model has not been fit, there is no prior to decay
         if not hasattr(self, "coef_"):
             return
-
-        if decay_rate is None:
-            decay_rate = self.learning_rate
-
-        assert X.shape is not None  # for the type checker
-        prior_decay = decay_rate ** X.shape[0]
-
-        # Decay the prior without making an update. Because we're only
-        # increasing the prior variance, we do not need to update the
-        # mean.
-        self._apply_decay(prior_decay)
-        if "_precision_factor" in self.__dict__:
-            self._precision_factor = scale_factor(self._precision_factor, prior_decay)
+        rule, steps, _ = resolve_tick(
+            forgetting,
+            steps=steps,
+            decay_rate=decay_rate,
+            learning_rate=self.learning_rate,
+            default=self._default_tick_rule,
+        )
+        self._apply_tick(rule, steps)
 
     # ---- sampling mechanics ----------------------------------------------
 
@@ -2435,13 +2489,17 @@ scipy.sparse.csc_array
         scale = np.sqrt((self.b_ / self.a_) * df / g)
         return draw.joint(size, self.random_state_, mean, scale)
 
-    def _apply_decay(self, prior_decay: float) -> None:
+    def _prior_floor(self) -> Optional[float]:
+        return float(cast(Any, self.lam)) if np.isscalar(self.lam) else None
+
+    def _apply_tick(self, rule: TickRule, steps: float) -> None:
         """Forget the Inverse-Gamma parameters alongside the precision, so
         the marginal t widens on both counts: fewer degrees of freedom and
         a higher scale."""
-        super()._apply_decay(prior_decay)
-        self.a_ = prior_decay * self.a_
-        self.b_ = prior_decay * self.b_
+        super()._apply_tick(rule, steps)
+        gamma = rule.rate**steps
+        self.a_ = gamma * self.a_
+        self.b_ = gamma * self.b_
 
 
 class BayesianGLM(_BayesianLinearModel, RegressorMixin):

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -426,8 +426,8 @@ class DirichletClassifier(MemoryUsageMixin, BaseEstimator, ClassifierMixin):
         self,
         forgetting: Any = None,
         *,
-        steps: float = 1,
         decay_rate: Optional[float] = None,
+        steps: float = 1,
     ) -> None:
         """
         Forget: the clock ticked ``steps`` times with no new observations.
@@ -797,8 +797,8 @@ class GammaRegressor(MemoryUsageMixin, BaseEstimator, RegressorMixin):
         self,
         forgetting: Any = None,
         *,
-        steps: float = 1,
         decay_rate: Optional[float] = None,
+        steps: float = 1,
     ) -> None:
         """
         Forget: the clock ticked ``steps`` times with no new observations.
@@ -1698,8 +1698,8 @@ class _BayesianLinearModel(MemoryUsageMixin, BaseEstimator):
         self,
         forgetting: Any = None,
         *,
-        steps: float = 1,
         decay_rate: Optional[float] = None,
+        steps: float = 1,
     ) -> None:
         """
         Forget: the clock ticked ``steps`` times with no new observations.

--- a/src/bayesianbandits/_forgetting.py
+++ b/src/bayesianbandits/_forgetting.py
@@ -16,12 +16,18 @@ current precision:
 
 See ``docs/math/forgetting.rst`` for the full mathematical reference.
 
-Each forgetting rule is a frozen dataclass callable with signature::
+Each rule is a frozen dataclass carrying its own forgetting factor
+``rate``. Two events can forget:
 
-    (precision, X, y, lam) -> (R_bar, X_eff, y_eff) | None
-
-where ``R_bar`` is the forgotten precision, ``(X_eff, y_eff)`` is the
-effective batch for the RLS update, and ``None`` means "skip this batch."
+- A **tick** of the clock, with no batch: ``rule.tick(precision, alpha=...,
+  steps=n)`` returns the precision after ``n`` steps. Only the uniform
+  rules (:class:`ExponentialForgetting`, :class:`StabilizedForgetting`)
+  implement it; this is what an estimator's ``decay`` applies.
+- An **update** on a batch: ``rule.update(precision, X, y, alpha=...)``
+  returns ``(R_bar, X_eff, y_eff)`` or ``None``, where ``R_bar`` is the
+  forgotten precision, ``(X_eff, y_eff)`` is the effective batch for the
+  RLS update, and ``None`` means "skip this batch." Every rule implements
+  it; the directional rules forget only along what the batch excites.
 
 The caller then does::
 
@@ -32,8 +38,9 @@ The caller then does::
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
-from typing import Any, NamedTuple, Union, cast
+from typing import Any, NamedTuple, Optional, Protocol, Union, cast, runtime_checkable
 
 import numpy as np
 from numpy.typing import NDArray
@@ -46,6 +53,28 @@ from bayesianbandits._blas_helpers import dsyrk
 ArrayType = Union[NDArray[Any], csc_array]
 
 ForgettingResult = tuple[ArrayType, NDArray[Any], NDArray[Any]]
+
+
+@runtime_checkable
+class TickRule(Protocol):
+    """A forgetting rule that can be applied without a batch: the clock ticked."""
+
+    rate: float
+
+    def tick(
+        self, precision: ArrayType, *, alpha: Optional[float], steps: float = 1
+    ) -> ArrayType: ...
+
+
+@runtime_checkable
+class UpdateRule(Protocol):
+    """A forgetting rule applied to a batch before it is absorbed."""
+
+    rate: float
+
+    def update(
+        self, precision: ArrayType, X: ArrayType, y: NDArray[Any], *, alpha: float
+    ) -> ForgettingResult | None: ...
 
 
 class _SparseFilterResult(NamedTuple):
@@ -287,34 +316,55 @@ def _sift_downdate_sparse(
 
 @dataclass(frozen=True)
 class ExponentialForgetting:
-    """Uniform scalar decay: ``R_bar = lam * R``.
+    """Uniform scalar decay: ``R_bar = rate * R``.
 
     Equivalent to the predict step of a Kalman filter with random-walk
-    process noise ``Q = (1 - lam) * Sigma``.  All eigenvalues of the
-    precision are scaled equally.  Risk: covariance windup when
-    excitation is non-uniform (unexcited eigenvalues → 0).
+    process noise ``Q = (1 - rate) * Sigma``.  All eigenvalues of the
+    precision are scaled equally, the prior included.  Risk: covariance
+    windup when excitation is non-uniform (unexcited eigenvalues → 0).
+
+    Parameters
+    ----------
+    rate : float
+        Forgetting factor in (0, 1], applied once per tick or per batch.
     """
 
-    def __call__(
+    rate: float
+
+    def tick(
+        self, precision: ArrayType, *, alpha: Optional[float], steps: float = 1
+    ) -> ArrayType:
+        return (self.rate**steps) * precision
+
+    def update(
         self,
         precision: ArrayType,
         X: ArrayType,
         y: NDArray[Any],
-        lam: float,
+        *,
+        alpha: float,
     ) -> ForgettingResult:
-        return lam * precision, np.asarray(X), y
+        return self.rate * precision, np.asarray(X), y
 
 
 @dataclass(frozen=True)
 class StabilizedForgetting:
-    """Kulhavy-Zarrop stabilized forgetting [1]_.
+    """Kulhavy-Zarrop stabilized forgetting.
 
-    ``R_bar = lam * R + (1 - lam) * alpha * I``
+    ``R_bar = rate * R + (1 - rate) * alpha * I``, from [1]_.
 
-    The prior floor ``(1 - lam) * alpha * I`` prevents precision from
+    The prior floor ``(1 - rate) * alpha * I`` prevents precision from
     collapsing to zero under sustained forgetting.  The prior scalar
     converges to ``alpha`` under repeated application regardless of
     starting value.  Still isotropic: all directions decay equally.
+
+    Parameters
+    ----------
+    rate : float
+        Forgetting factor in (0, 1], applied once per tick or per batch.
+    alpha : float, optional
+        The prior precision to floor at. ``None`` (the default) means the
+        estimator's own ``alpha``.
 
     References
     ----------
@@ -322,28 +372,52 @@ class StabilizedForgetting:
        forgetting." *Int. J. Control*, 58(4), 905--924.
     """
 
-    alpha: float
+    rate: float
+    alpha: Optional[float] = None
 
-    def __call__(
+    def floor(self, alpha: Optional[float]) -> float:
+        """The prior precision this rule floors at, given the estimator's;
+        ``None`` means the estimator has no scalar prior precision."""
+        if self.alpha is not None:
+            return self.alpha
+        if alpha is None:
+            raise TypeError(
+                "StabilizedForgetting needs a scalar prior precision to floor "
+                "at, and this estimator's prior is not a scalar; pass "
+                "StabilizedForgetting(rate, alpha=...)."
+            )
+        return alpha
+
+    def _apply(self, precision: ArrayType, lam: float, alpha: float) -> ArrayType:
+        n = precision.shape[0]
+        if sparse.issparse(precision):
+            floor = (1 - lam) * alpha * sparse.eye(n, format="csc")
+        else:
+            floor = (1 - lam) * alpha * np.eye(n)
+        return precision * lam + floor
+
+    def tick(
+        self, precision: ArrayType, *, alpha: Optional[float], steps: float = 1
+    ) -> ArrayType:
+        return self._apply(precision, self.rate**steps, self.floor(alpha))
+
+    def update(
         self,
         precision: ArrayType,
         X: ArrayType,
         y: NDArray[Any],
-        lam: float,
+        *,
+        alpha: float,
     ) -> ForgettingResult:
-        n = precision.shape[0]
-        if sparse.issparse(precision):
-            floor = (1 - lam) * self.alpha * sparse.eye(n, format="csc")
-        else:
-            floor = (1 - lam) * self.alpha * np.eye(n)
-        return precision * lam + floor, np.asarray(X), y
+        return self._apply(precision, self.rate, self.floor(alpha)), np.asarray(X), y
 
 
 @dataclass(frozen=True)
 class SiftForgetting:
-    """Directional forgetting via SIFt-RLS [1]_ [2]_.
+    """Directional forgetting via SIFt-RLS.
 
-    ``R_bar = R - (1 - lam) * R @ X_bar.T @ inv(X_bar @ R @ X_bar.T) @ X_bar @ R``
+    ``R_bar = R - (1 - rate) * R @ X_bar.T @ inv(X_bar @ R @ X_bar.T) @ X_bar @ R``,
+    from [1]_ [2]_.
 
     Decomposes precision relative to the information subspace of the
     current batch and forgets only in excited directions.  Unexcited
@@ -359,7 +433,10 @@ class SiftForgetting:
 
     Parameters
     ----------
-    eps : float
+    rate : float
+        Forgetting factor in (0, 1], applied once per batch along the
+        directions the batch excites.
+    eps : float, default=1e-10
         Eigenvalue threshold for :func:`filter_batch`.  Eigenvalues of
         the batch Gram below this value are discarded.
 
@@ -373,15 +450,18 @@ class SiftForgetting:
        *arXiv:2404.10844*.
     """
 
-    eps: float
+    rate: float
+    eps: float = 1e-10
 
-    def __call__(
+    def update(
         self,
         precision: ArrayType,
         X: ArrayType,
         y: NDArray[Any],
-        lam: float,
+        *,
+        alpha: float,
     ) -> ForgettingResult | None:
+        lam = self.rate
         if sparse.issparse(X):
             result = _filter_batch_sparse(X, y, self.eps)
             if result is None:
@@ -423,14 +503,14 @@ def _active_counts(X: ArrayType) -> NDArray[np.intp]:
 class FeatureWiseForgetting:
     """Vector-type forgetting with the factors chosen from the batch support.
 
-    ``R_bar = D R D`` with ``D = diag(lam ** (m_i / 2))``, where ``m_i``
+    ``R_bar = D R D`` with ``D = diag(rate ** (m_i / 2))``, where ``m_i``
     is the number of rows of ``X`` in which feature ``i`` is nonzero.  A
     feature present in every row of an ``n``-row batch decays by
-    ``lam ** n``, exactly as under :class:`ExponentialForgetting`; a
+    ``rate ** n``, exactly as under :class:`ExponentialForgetting`; a
     feature absent from the batch is untouched.
 
     In covariance form this inflates the standard deviation of each
-    observed coefficient by ``lam ** (-m_i / 2)`` and leaves every
+    observed coefficient by ``rate ** (-m_i / 2)`` and leaves every
     correlation and every unobserved coefficient's marginal unchanged.
     Because it only scales rows and columns, the sparsity pattern of
     ``R`` is preserved and the cost is one pass over its nonzeros.
@@ -445,6 +525,12 @@ class FeatureWiseForgetting:
     with an unobserved one it is correlated with can come out tighter
     than before, by an amount that grows with that correlation.  For
     dense or strongly correlated regressors prefer :class:`SiftForgetting`.
+
+    Parameters
+    ----------
+    rate : float
+        Forgetting factor in (0, 1], applied once per row a feature appears
+        in.
 
     References
     ----------
@@ -467,14 +553,17 @@ class FeatureWiseForgetting:
        *IEEE Trans. Automatic Control*. *arXiv:2308.04259*.
     """
 
-    def __call__(
+    rate: float
+
+    def update(
         self,
         precision: ArrayType,
         X: ArrayType,
         y: NDArray[Any],
-        lam: float,
+        *,
+        alpha: float,
     ) -> ForgettingResult:
-        d = lam ** (_active_counts(X) / 2.0)
+        d = self.rate ** (_active_counts(X) / 2.0)
         if sparse.issparse(precision):
             R = csc_array(precision)
             assert R.shape is not None
@@ -490,3 +579,95 @@ class FeatureWiseForgetting:
         # in the sparse SIFt path.
         X_eff = cast(NDArray[Any], X) if sparse.issparse(X) else np.asarray(X)
         return R_bar, X_eff, y
+
+
+def resolve_tick(
+    forgetting: Any,
+    *,
+    steps: float,
+    decay_rate: Optional[float],
+    learning_rate: float,
+    default: type = ExponentialForgetting,
+    stacklevel: int = 3,
+) -> tuple[TickRule, float, Any]:
+    """Sort out the arguments of an estimator's ``decay``.
+
+    Returns ``(rule, steps, legacy_X)``. ``rule`` is the tick rule to
+    apply: ``forgetting`` itself, or ``default`` built from ``decay_rate``
+    (or, deprecated, from ``learning_rate``). A context array passed where
+    the rule goes is the pre-rule calling convention; it is returned as
+    ``legacy_X`` with ``steps`` set to its row count, so estimators that
+    read the rows (the grouped conjugate models) can keep doing so.
+    """
+    legacy_X = None
+    if forgetting is not None and not isinstance(forgetting, TickRule):
+        if isinstance(forgetting, UpdateRule):
+            raise TypeError(
+                f"{type(forgetting).__name__} forgets along a batch, so it "
+                "belongs on the learner's forgetting= argument, not decay()."
+            )
+        warnings.warn(
+            "Passing a context array to decay() is deprecated; pass "
+            "steps=<number of ticks> and a forgetting rule or decay_rate.",
+            FutureWarning,
+            stacklevel=stacklevel,
+        )
+        legacy_X = forgetting
+        forgetting = None
+        steps = legacy_X.shape[0] if hasattr(legacy_X, "shape") else len(legacy_X)
+    if forgetting is None:
+        if decay_rate is None:
+            warnings.warn(
+                "decay() without a forgetting rule or decay_rate falls back "
+                "to learning_rate; this default is deprecated. Pass a rule "
+                "such as StabilizedForgetting(0.95), or decay_rate=.",
+                FutureWarning,
+                stacklevel=stacklevel,
+            )
+            decay_rate = learning_rate
+        forgetting = default(decay_rate)
+    elif decay_rate is not None:
+        raise TypeError(
+            "Pass either a forgetting rule or decay_rate, not both; the rule "
+            "carries its own rate."
+        )
+    return forgetting, steps, legacy_X
+
+
+def tick_groups(
+    table: dict[Any, NDArray[np.float64]],
+    forgetting: Any,
+    *,
+    steps: float,
+    decay_rate: Optional[float],
+    learning_rate: float,
+    prior: NDArray[np.float64],
+    default: type = ExponentialForgetting,
+) -> None:
+    """``decay`` for a grouped conjugate model: one parameter vector per
+    group in ``table``, all sharing ``prior``. Scales every group by
+    ``rate ** steps``, mixing ``prior`` back in under
+    :class:`StabilizedForgetting`. A legacy context array ticks once per
+    row, on that row's group."""
+    rule, steps, legacy_X = resolve_tick(
+        forgetting,
+        steps=steps,
+        decay_rate=decay_rate,
+        learning_rate=learning_rate,
+        default=default,
+        stacklevel=4,
+    )
+
+    def tick(value: NDArray[np.float64], n: float) -> NDArray[np.float64]:
+        gamma = rule.rate**n
+        if isinstance(rule, StabilizedForgetting):
+            floor = prior if rule.alpha is None else rule.alpha
+            return np.asarray(gamma * value + (1 - gamma) * floor, dtype=np.float64)
+        return np.asarray(gamma * value, dtype=np.float64)
+
+    if legacy_X is not None:
+        for x in legacy_X:
+            table[x.item()] = tick(table[x.item()], 1)
+        return
+    for key in list(table):
+        table[key] = tick(table[key], steps)

--- a/src/bayesianbandits/_forgetting.py
+++ b/src/bayesianbandits/_forgetting.py
@@ -38,6 +38,7 @@ The caller then does::
 
 from __future__ import annotations
 
+import numbers
 import warnings
 from dataclasses import dataclass
 from typing import Any, NamedTuple, Optional, Protocol, Union, cast, runtime_checkable
@@ -600,6 +601,11 @@ def resolve_tick(
     read the rows (the grouped conjugate models) can keep doing so.
     """
     legacy_X = None
+    if isinstance(forgetting, numbers.Real) and not isinstance(forgetting, bool):
+        raise TypeError(
+            "decay() takes a forgetting rule, not a bare rate; pass "
+            "decay_rate=... or a rule such as ExponentialForgetting(rate)."
+        )
     if forgetting is not None and not isinstance(forgetting, TickRule):
         if isinstance(forgetting, UpdateRule):
             raise TypeError(

--- a/src/bayesianbandits/api.py
+++ b/src/bayesianbandits/api.py
@@ -526,21 +526,29 @@ class ContextualAgent(MemoryUsageMixin, Generic[ContextType, TokenType]):
 
     def decay(
         self,
-        X: ContextType,
+        forgetting: Any = None,
+        *,
+        steps: float = 1,
         decay_rate: Optional[float] = None,
     ) -> None:
-        """Decay all arms of the bandit len(X) times.
+        """Forget on every arm: the clock ticked ``steps`` times.
+
+        Widens each arm's posterior so the bandit can follow rewards
+        that change with time. Call it on a schedule, once per unit of
+        time, independently of ``update``.
 
         Parameters
         ----------
-        X : ContextType
-            Context matrix to use for decaying the arm.
-        decay_rate : Optional[float], default=None
-            Decay rate to use for decaying the arm. If None, the decay rate
-            of the arm's learner is used.
+        forgetting : ExponentialForgetting or StabilizedForgetting, optional
+            The rule to tick with, carrying its own rate. Default: each
+            learner's own rule at ``decay_rate``.
+        steps : float, default=1
+            Number of ticks; the rule's rate is raised to this power.
+        decay_rate : float, optional
+            Shorthand for each learner's default rule at this rate.
         """
         for arm in self.arms:
-            arm.decay(X, decay_rate=decay_rate)
+            arm.decay(forgetting, steps=steps, decay_rate=decay_rate)
 
 
 class Agent(MemoryUsageMixin, Generic[TokenType]):
@@ -798,16 +806,26 @@ class Agent(MemoryUsageMixin, Generic[TokenType]):
         X_update: NDArray[np.float64] = np.ones_like(y, dtype=np.float64)[:, np.newaxis]
         self._inner.update(X_update, y, sample_weight=sample_weight)
 
-    def decay(self, decay_rate: Optional[float] = None) -> None:
-        """Decay all arms of the bandit.
+    def decay(
+        self,
+        forgetting: Any = None,
+        *,
+        steps: float = 1,
+        decay_rate: Optional[float] = None,
+    ) -> None:
+        """Forget on every arm: the clock ticked ``steps`` times.
 
         Parameters
         ----------
-        decay_rate : Optional[float], default=None
-            Decay rate to use for decaying the arm. If None, the decay rate
-            of the arm's learner is used.
+        forgetting : ExponentialForgetting or StabilizedForgetting, optional
+            The rule to tick with, carrying its own rate. Default: each
+            learner's own rule at ``decay_rate``.
+        steps : float, default=1
+            Number of ticks; the rule's rate is raised to this power.
+        decay_rate : float, optional
+            Shorthand for each learner's default rule at this rate.
         """
-        self._inner.decay(np.array([[1]], dtype=np.float64), decay_rate=decay_rate)
+        self._inner.decay(forgetting, steps=steps, decay_rate=decay_rate)
 
 
 class LipschitzContextualAgent(MemoryUsageMixin, Generic[TokenType]):
@@ -1446,30 +1464,29 @@ class LipschitzContextualAgent(MemoryUsageMixin, Generic[TokenType]):
 
     def decay(
         self,
-        X: Sized,
+        forgetting: Any = None,
+        *,
+        steps: float = 1,
         decay_rate: Optional[float] = None,
     ) -> None:
-        """
-        Decay the shared learner with all arms' features.
+        """Forget on the shared learner: the clock ticked ``steps`` times.
+
+        The shared learner is ticked once, whatever the number of arms.
 
         Parameters
         ----------
-        X : Sized
-            Context matrix to use for decaying.
-        decay_rate : Optional[float], default=None
-            Decay rate to use. If None, the learner's default decay rate is used.
-
-        Notes
-        -----
-        This method enriches contexts with a single arm's features and applies
-        decay to the shared learner once. This ensures we decay based on the
-        number of contexts, not the number of arms.
+        forgetting : ExponentialForgetting or StabilizedForgetting, optional
+            The rule to tick with, carrying its own rate. A context
+            array here is the deprecated calling convention; it is
+            enriched with one arm's features before it is passed on.
+        steps : float, default=1
+            Number of ticks; the rule's rate is raised to this power.
+        decay_rate : float, optional
+            Shorthand for the learner's default rule at this rate.
         """
-        # Use any single arm's token - we just need the enriched shape for one arm
-        single_token = [self.arms[0].action_token]
-
-        # Enrich context with single arm features
-        X_enriched = self.arm_featurizer.transform(X, action_tokens=single_token)
-
-        # Decay the shared learner once
-        self.learner.decay(X_enriched, decay_rate=decay_rate)
+        if forgetting is not None and not hasattr(forgetting, "tick"):
+            single_token = [self.arms[0].action_token]
+            forgetting = self.arm_featurizer.transform(
+                forgetting, action_tokens=single_token
+            )
+        self.learner.decay(forgetting, steps=steps, decay_rate=decay_rate)

--- a/src/bayesianbandits/api.py
+++ b/src/bayesianbandits/api.py
@@ -528,8 +528,8 @@ class ContextualAgent(MemoryUsageMixin, Generic[ContextType, TokenType]):
         self,
         forgetting: Any = None,
         *,
-        steps: float = 1,
         decay_rate: Optional[float] = None,
+        steps: float = 1,
     ) -> None:
         """Forget on every arm: the clock ticked ``steps`` times.
 
@@ -548,7 +548,7 @@ class ContextualAgent(MemoryUsageMixin, Generic[ContextType, TokenType]):
             Shorthand for each learner's default rule at this rate.
         """
         for arm in self.arms:
-            arm.decay(forgetting, steps=steps, decay_rate=decay_rate)
+            arm.decay(forgetting, decay_rate=decay_rate, steps=steps)
 
 
 class Agent(MemoryUsageMixin, Generic[TokenType]):
@@ -810,8 +810,8 @@ class Agent(MemoryUsageMixin, Generic[TokenType]):
         self,
         forgetting: Any = None,
         *,
-        steps: float = 1,
         decay_rate: Optional[float] = None,
+        steps: float = 1,
     ) -> None:
         """Forget on every arm: the clock ticked ``steps`` times.
 
@@ -825,7 +825,7 @@ class Agent(MemoryUsageMixin, Generic[TokenType]):
         decay_rate : float, optional
             Shorthand for each learner's default rule at this rate.
         """
-        self._inner.decay(forgetting, steps=steps, decay_rate=decay_rate)
+        self._inner.decay(forgetting, decay_rate=decay_rate, steps=steps)
 
 
 class LipschitzContextualAgent(MemoryUsageMixin, Generic[TokenType]):
@@ -1466,8 +1466,8 @@ class LipschitzContextualAgent(MemoryUsageMixin, Generic[TokenType]):
         self,
         forgetting: Any = None,
         *,
-        steps: float = 1,
         decay_rate: Optional[float] = None,
+        steps: float = 1,
     ) -> None:
         """Forget on the shared learner: the clock ticked ``steps`` times.
 
@@ -1489,4 +1489,4 @@ class LipschitzContextualAgent(MemoryUsageMixin, Generic[TokenType]):
             forgetting = self.arm_featurizer.transform(
                 forgetting, action_tokens=single_token
             )
-        self.learner.decay(forgetting, steps=steps, decay_rate=decay_rate)
+        self.learner.decay(forgetting, decay_rate=decay_rate, steps=steps)

--- a/src/bayesianbandits/pipelines/_agent.py
+++ b/src/bayesianbandits/pipelines/_agent.py
@@ -175,21 +175,27 @@ class AgentPipeline(MemoryUsageMixin, Generic[ContextType, TokenType]):
 
     def decay(
         self,
-        X: Any,
+        forgetting: Any = None,
+        *,
+        steps: float = 1,
         decay_rate: Optional[float] = None,
     ) -> None:
-        """Decay all arms of the wrapped agent.
+        """Forget on every arm of the wrapped agent: the clock ticked.
 
         Parameters
         ----------
-        X : Any
-            Input data to transform and use for decaying the arms.
-            Will be transformed through the pipeline steps to ContextType.
-        decay_rate : Optional[float], default=None
-            Decay rate to use for decaying the arms.
+        forgetting : ExponentialForgetting or StabilizedForgetting, optional
+            The rule to tick with, carrying its own rate. A context
+            array here is the deprecated calling convention and is
+            transformed through the pipeline steps before it is passed on.
+        steps : float, default=1
+            Number of ticks; the rule's rate is raised to this power.
+        decay_rate : float, optional
+            Shorthand for each learner's default rule at this rate.
         """
-        X_transformed = self.transform(X)
-        self._agent.decay(X_transformed, decay_rate=decay_rate)
+        if forgetting is not None and not hasattr(forgetting, "tick"):
+            forgetting = self.transform(forgetting)
+        self._agent.decay(forgetting, steps=steps, decay_rate=decay_rate)
 
     # Delegation methods
     def add_arm(self, arm: Arm[Any, TokenType]) -> None:

--- a/src/bayesianbandits/pipelines/_agent.py
+++ b/src/bayesianbandits/pipelines/_agent.py
@@ -177,8 +177,8 @@ class AgentPipeline(MemoryUsageMixin, Generic[ContextType, TokenType]):
         self,
         forgetting: Any = None,
         *,
-        steps: float = 1,
         decay_rate: Optional[float] = None,
+        steps: float = 1,
     ) -> None:
         """Forget on every arm of the wrapped agent: the clock ticked.
 
@@ -195,7 +195,7 @@ class AgentPipeline(MemoryUsageMixin, Generic[ContextType, TokenType]):
         """
         if forgetting is not None and not hasattr(forgetting, "tick"):
             forgetting = self.transform(forgetting)
-        self._agent.decay(forgetting, steps=steps, decay_rate=decay_rate)
+        self._agent.decay(forgetting, decay_rate=decay_rate, steps=steps)
 
     # Delegation methods
     def add_arm(self, arm: Arm[Any, TokenType]) -> None:

--- a/src/bayesianbandits/pipelines/_learner.py
+++ b/src/bayesianbandits/pipelines/_learner.py
@@ -369,8 +369,8 @@ class LearnerPipeline(MemoryUsageMixin, Generic[X_contra]):
         self,
         forgetting: Any = None,
         *,
-        steps: float = 1,
         decay_rate: Optional[float] = None,
+        steps: float = 1,
     ) -> None:
         """Forget on the wrapped learner: the clock ticked ``steps`` times.
 
@@ -387,7 +387,7 @@ class LearnerPipeline(MemoryUsageMixin, Generic[X_contra]):
         """
         if forgetting is not None and not hasattr(forgetting, "tick"):
             forgetting = self._apply_transformers(forgetting)
-        self._learner.decay(forgetting, steps=steps, decay_rate=decay_rate)
+        self._learner.decay(forgetting, decay_rate=decay_rate, steps=steps)
 
     def predict(self, X: X_contra) -> NDArray[np.float64]:
         """Predict expected values.

--- a/src/bayesianbandits/pipelines/_learner.py
+++ b/src/bayesianbandits/pipelines/_learner.py
@@ -365,18 +365,29 @@ class LearnerPipeline(MemoryUsageMixin, Generic[X_contra]):
         self._learner.partial_fit(X_transformed, y, sample_weight)
         return self
 
-    def decay(self, X: X_contra, *, decay_rate: Optional[float] = None) -> None:
-        """Decay the learner's parameters.
+    def decay(
+        self,
+        forgetting: Any = None,
+        *,
+        steps: float = 1,
+        decay_rate: Optional[float] = None,
+    ) -> None:
+        """Forget on the wrapped learner: the clock ticked ``steps`` times.
 
         Parameters
         ----------
-        X : X_contra
-            Input data (enriched features from ArmFeaturizer)
+        forgetting : ExponentialForgetting or StabilizedForgetting, optional
+            The rule to tick with, carrying its own rate. A context
+            array here is the deprecated calling convention and is
+            transformed through the pipeline steps before it is passed on.
+        steps : float, default=1
+            Number of ticks; the rule's rate is raised to this power.
         decay_rate : float, optional
-            Rate of decay
+            Shorthand for the learner's default rule at this rate.
         """
-        X_transformed = self._apply_transformers(X)
-        self._learner.decay(X_transformed, decay_rate=decay_rate)
+        if forgetting is not None and not hasattr(forgetting, "tick"):
+            forgetting = self._apply_transformers(forgetting)
+        self._learner.decay(forgetting, steps=steps, decay_rate=decay_rate)
 
     def predict(self, X: X_contra) -> NDArray[np.float64]:
         """Predict expected values.

--- a/tests/test_agent_pipeline.py
+++ b/tests/test_agent_pipeline.py
@@ -209,10 +209,8 @@ class TestAgentPipeline:
 
         pipeline = AgentPipeline(steps, agent)
 
-        X = np.array([[1.0]])
-
         # Should not raise
-        pipeline.decay(X, decay_rate=0.5)
+        pipeline.decay(decay_rate=0.5)
 
     def test_transform(self):
         """Test direct transform method."""
@@ -603,8 +601,7 @@ class TestCoverage:
         agent = ContextualAgent(arms, ThompsonSampling())
         pipeline = AgentPipeline([("identity", FunctionTransformer())], agent)
 
-        X = np.array([[1.0]])
-        pipeline.decay(X, decay_rate=0.7)
+        pipeline.decay(decay_rate=0.7)
 
     def test_pipeline_len_and_getitem_edge_cases(self):
         """Test pipeline length and indexing edge cases."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -163,9 +163,9 @@ class TestBandits:
         ],
     ) -> None:
         if isinstance(bandit_instance, Agent):
-            bandit_instance.decay()
+            bandit_instance.decay(decay_rate=0.5)
         else:
-            bandit_instance.decay(np.array([[2.0]]), decay_rate=0.5)
+            bandit_instance.decay(decay_rate=0.5)
 
         # Check that no exception is raised
 

--- a/tests/test_bayesian_glm.py
+++ b/tests/test_bayesian_glm.py
@@ -112,11 +112,10 @@ def test_bayesian_glm_cov_before_fit_dense() -> None:
 @pytest.mark.parametrize("sparse", [True, False])
 def test_bayesian_glm_decay_before_fit_does_nothing(sparse: bool) -> None:
     """Test decay before fit does nothing."""
-    X = np.random.randn(10, 5)
     clf = BayesianGLM(alpha=0.1, link="logit", sparse=sparse)
 
     # Decay should not raise or change anything
-    clf.decay(X, decay_rate=0.9)
+    clf.decay(decay_rate=0.9)
 
 
 @pytest.mark.parametrize("sparse", [True, False])
@@ -251,7 +250,7 @@ def test_bayesian_glm_uncertainty_increases_with_decay(
     std_before = np.std(samples_before, axis=0)
 
     # Apply decay
-    clf.decay(X_fit, decay_rate=0.7)
+    clf.decay(decay_rate=0.7, steps=X.shape[0])
 
     # Get uncertainty after decay
     samples_after = clf.sample(X_fit[:5], size=100)
@@ -355,7 +354,7 @@ def test_bayesian_glm_decay(binary_data, sparse: bool) -> None:
         precision_before = np.diag(clf.cov_inv_)
 
     # Apply decay
-    clf.decay(X_fit)
+    clf.decay(decay_rate=clf.learning_rate, steps=X.shape[0])
 
     # Predictions should stay the same
     preds_after = clf.predict(X_fit)

--- a/tests/test_decay_api.py
+++ b/tests/test_decay_api.py
@@ -18,7 +18,9 @@ from bayesianbandits import (
     EmpiricalBayesNormalRegressor,
     ExponentialForgetting,
     FeatureWiseForgetting,
+    FunctionArmFeaturizer,
     GammaRegressor,
+    LipschitzContextualAgent,
     NormalInverseGammaRegressor,
     NormalRegressor,
     SiftForgetting,
@@ -34,6 +36,15 @@ def _dense(P):
 
 def _learner(arm) -> Any:
     return arm.learner
+
+
+def _one_hot_arm(X, action_tokens, n_arms=3):
+    """Intercept plus a one-hot column per arm, for any subset of tokens."""
+    out = np.zeros((X.shape[0], 1 + n_arms, len(action_tokens)))
+    for i, token in enumerate(action_tokens):
+        out[:, 0, i] = X[:, 0]
+        out[:, 1 + token, i] = 1.0
+    return out
 
 
 def _fit_normal(sparse, learning_rate=1.0, **kwargs):
@@ -284,6 +295,32 @@ class TestPassThrough:
         assert_allclose(
             _dense(cast(Any, learner.learner).cov_inv_), 0.5 * before + 0.5 * np.eye(2)
         )
+        with pytest.warns(FutureWarning):
+            learner.decay(np.vstack([X, X]), decay_rate=0.5)
+        assert_allclose(
+            _dense(cast(Any, learner.learner).cov_inv_),
+            0.25 * (0.5 * before + 0.5 * np.eye(2)),
+        )
+
+    def test_lipschitz_agent_ticks_the_shared_learner_once(self):
+        arms = [Arm(i) for i in range(3)]
+        agent = LipschitzContextualAgent(
+            arms=arms,
+            policy=ThompsonSampling(),
+            arm_featurizer=FunctionArmFeaturizer(_one_hot_arm),
+            learner=NormalRegressor(alpha=1.0, beta=1.0),
+            random_seed=0,
+        )
+        X = np.array([[1.0]])
+        agent.select_for_update(1).update(X, np.array([1.0]))
+        shared: Any = agent.learner
+        before = _dense(shared.cov_inv_)
+        agent.decay(ExponentialForgetting(0.5), steps=2)
+        assert_allclose(_dense(shared.cov_inv_), 0.25 * before)
+        # The deprecated array form: one tick per context row, not per arm.
+        with pytest.warns(FutureWarning):
+            agent.decay(np.vstack([X, X]), decay_rate=0.5)
+        assert_allclose(_dense(shared.cov_inv_), 0.0625 * before)
 
 
 class TestBreakingChanges:

--- a/tests/test_decay_api.py
+++ b/tests/test_decay_api.py
@@ -1,0 +1,286 @@
+"""``decay(rule, steps=)``: the clock-tick forgetting API."""
+
+from typing import Any, cast
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+from scipy import sparse as sp
+from sklearn.preprocessing import FunctionTransformer
+
+from bayesianbandits import (
+    Agent,
+    Arm,
+    ContextualAgent,
+    DirichletClassifier,
+    EmpiricalBayesDirichletClassifier,
+    EmpiricalBayesGammaRegressor,
+    EmpiricalBayesNormalRegressor,
+    ExponentialForgetting,
+    FeatureWiseForgetting,
+    GammaRegressor,
+    NormalInverseGammaRegressor,
+    NormalRegressor,
+    SiftForgetting,
+    StabilizedForgetting,
+    ThompsonSampling,
+)
+from bayesianbandits.pipelines import AgentPipeline, LearnerPipeline
+
+
+def _dense(P):
+    return P.toarray() if sp.issparse(P) else np.asarray(P)
+
+
+def _learner(arm) -> Any:
+    return arm.learner
+
+
+def _fit_normal(sparse, learning_rate=1.0, **kwargs):
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((30, 4))
+    y = X @ np.array([1.0, -1.0, 0.5, 0.0]) + rng.normal(0, 0.1, 30)
+    est = NormalRegressor(
+        alpha=2.0, beta=1.0, sparse=sparse, learning_rate=learning_rate, **kwargs
+    )
+    est.fit(sp.csc_array(X) if sparse else X, y)
+    return est, X
+
+
+class TestTickRules:
+    @pytest.mark.parametrize("sparse", [False, True])
+    def test_steps_raise_the_rate_to_that_power(self, sparse):
+        est, _ = _fit_normal(sparse)
+        before = _dense(est.cov_inv_)
+        est.decay(ExponentialForgetting(0.9), steps=3)
+        assert_allclose(_dense(est.cov_inv_), 0.9**3 * before)
+
+    @pytest.mark.parametrize("sparse", [False, True])
+    def test_decay_rate_is_shorthand_for_the_default_rule(self, sparse):
+        est, _ = _fit_normal(sparse)
+        twin, _ = _fit_normal(sparse)
+        est.decay(decay_rate=0.8, steps=2)
+        twin.decay(ExponentialForgetting(0.8), steps=2)
+        assert_allclose(_dense(est.cov_inv_), _dense(twin.cov_inv_))
+
+    @pytest.mark.parametrize("sparse", [False, True])
+    def test_stabilized_floors_at_the_estimator_alpha(self, sparse):
+        est, _ = _fit_normal(sparse)
+        before = _dense(est.cov_inv_)
+        est.decay(StabilizedForgetting(0.9), steps=2)
+        g = 0.9**2
+        assert_allclose(_dense(est.cov_inv_), g * before + (1 - g) * 2.0 * np.eye(4))
+
+    def test_stabilized_with_its_own_alpha(self):
+        est, _ = _fit_normal(False)
+        before = _dense(est.cov_inv_)
+        est.decay(StabilizedForgetting(0.9, alpha=7.0))
+        assert_allclose(_dense(est.cov_inv_), 0.9 * before + 0.1 * 7.0 * np.eye(4))
+
+    @pytest.mark.parametrize("sparse", [False, True])
+    def test_stabilized_drops_the_cached_factor_and_sampling_still_matches(
+        self, sparse
+    ):
+        est, X = _fit_normal(sparse)
+        est.sample(sp.csc_array(X[:3]) if sparse else X[:3])  # builds the factor
+        assert "_precision_factor" in est.__dict__
+        est.decay(StabilizedForgetting(0.9))
+        assert "_precision_factor" not in est.__dict__
+        # The rebuilt factor agrees with the precision it factors.
+        S = np.linalg.inv(_dense(est.cov_inv_))
+        Xq = X[:5]
+        draws = est.sample(sp.csc_array(Xq) if sparse else Xq, size=20_000)
+        assert_allclose(np.var(draws, axis=0), np.diag(Xq @ S @ Xq.T), rtol=0.1)
+
+    def test_exponential_scales_the_cached_factor_in_place(self):
+        est, X = _fit_normal(False)
+        est.sample(X[:3])
+        factor = est._precision_factor
+        est.decay(ExponentialForgetting(0.5), steps=2)
+        assert est._precision_factor._scale == pytest.approx(factor._scale * 0.25)
+
+    def test_rule_and_decay_rate_together_is_an_error(self):
+        est, _ = _fit_normal(False)
+        with pytest.raises(TypeError, match="not both"):
+            est.decay(ExponentialForgetting(0.9), decay_rate=0.9)
+
+    @pytest.mark.parametrize("rule", [FeatureWiseForgetting(0.9), SiftForgetting(0.9)])
+    def test_directional_rules_are_refused_with_a_pointer(self, rule):
+        est, _ = _fit_normal(False)
+        with pytest.raises(TypeError, match="forgetting="):
+            est.decay(rule)
+
+    def test_unfitted_estimator_ignores_decay(self):
+        est = NormalRegressor(alpha=1.0, beta=1.0)
+        est.decay(StabilizedForgetting(0.5))
+        assert not hasattr(est, "coef_")
+
+
+class TestDeprecatedCallingConvention:
+    def test_context_array_means_steps_from_its_rows(self):
+        est, X = _fit_normal(False)
+        twin, _ = _fit_normal(False)
+        with pytest.warns(FutureWarning, match="steps="):
+            est.decay(X[:4], decay_rate=0.9)
+        twin.decay(decay_rate=0.9, steps=4)
+        assert_allclose(_dense(est.cov_inv_), _dense(twin.cov_inv_))
+
+    def test_falling_back_to_learning_rate_warns(self):
+        est, _ = _fit_normal(False, learning_rate=0.7)
+        before = _dense(est.cov_inv_)
+        with pytest.warns(FutureWarning, match="learning_rate"):
+            est.decay(steps=2)
+        assert_allclose(_dense(est.cov_inv_), 0.7**2 * before)
+
+
+class TestNormalInverseGamma:
+    def test_stabilized_needs_a_scalar_prior_precision(self):
+        rng = np.random.default_rng(0)
+        X = rng.standard_normal((20, 3))
+        y = rng.standard_normal(20)
+        est = NormalInverseGammaRegressor(lam=np.array([1.0, 2.0, 3.0]))
+        est.fit(X, y)
+        with pytest.raises(TypeError, match="alpha="):
+            est.decay(StabilizedForgetting(0.9))
+        est.decay(StabilizedForgetting(0.9, alpha=1.0))  # explicit floor works
+
+    def test_tick_forgets_the_inverse_gamma_too(self):
+        rng = np.random.default_rng(0)
+        X = rng.standard_normal((20, 3))
+        y = rng.standard_normal(20)
+        est = NormalInverseGammaRegressor(lam=1.0)
+        est.fit(X, y)
+        a, b = est.a_, est.b_
+        est.decay(StabilizedForgetting(0.8), steps=2)
+        assert est.a_ == pytest.approx(0.8**2 * a)
+        assert est.b_ == pytest.approx(0.8**2 * b)
+
+
+class TestEmpiricalBayes:
+    @pytest.mark.parametrize("sparse", [False, True])
+    def test_default_is_stabilized_at_the_tuned_alpha(self, sparse):
+        rng = np.random.default_rng(1)
+        X = rng.standard_normal((40, 3))
+        y = X @ np.array([1.0, 0.0, -1.0]) + rng.normal(0, 0.3, 40)
+        est = EmpiricalBayesNormalRegressor(alpha=1.0, beta=1.0, sparse=sparse)
+        est.fit(sp.csc_array(X) if sparse else X, y)
+        before = _dense(est.cov_inv_)
+        s_before = est._prior_scalar
+        est.decay(decay_rate=0.9, steps=2)
+        g = 0.9**2
+        assert_allclose(
+            _dense(est.cov_inv_), g * before + (1 - g) * est.alpha * np.eye(3)
+        )
+        assert est._prior_scalar == pytest.approx(g * s_before + (1 - g) * est.alpha)
+
+    def test_exponential_is_accepted_and_books_the_prior_scalar(self):
+        rng = np.random.default_rng(1)
+        X = rng.standard_normal((40, 3))
+        y = rng.standard_normal(40)
+        est = EmpiricalBayesNormalRegressor(alpha=1.0, beta=1.0)
+        est.fit(X, y)
+        before = _dense(est.cov_inv_)
+        s_before = est._prior_scalar
+        est.decay(ExponentialForgetting(0.9))
+        assert_allclose(_dense(est.cov_inv_), 0.9 * before)
+        assert est._prior_scalar == pytest.approx(0.9 * s_before)
+
+    def test_directional_is_refused(self):
+        est = EmpiricalBayesNormalRegressor(alpha=1.0, beta=1.0)
+        est.fit(np.eye(3), np.ones(3))
+        with pytest.raises(TypeError, match="forgetting="):
+            est.decay(SiftForgetting(0.9))
+
+
+class TestGroupedModels:
+    def test_dirichlet_ticks_every_seen_group(self):
+        clf = DirichletClassifier({0: 1.0, 1: 1.0}, random_state=0)
+        clf.fit(np.array([[1], [1], [2]]), np.array([0, 1, 1]))
+        a1, a2 = clf.known_alphas_[1].copy(), clf.known_alphas_[2].copy()
+        clf.decay(ExponentialForgetting(0.5), steps=2)
+        assert_allclose(clf.known_alphas_[1], 0.25 * a1)
+        assert_allclose(clf.known_alphas_[2], 0.25 * a2)
+
+    def test_dirichlet_stabilized_mixes_the_prior_back_in(self):
+        clf = DirichletClassifier({0: 1.0, 1: 3.0}, random_state=0)
+        clf.fit(np.array([[1], [1]]), np.array([0, 0]))
+        a1 = clf.known_alphas_[1].copy()
+        clf.decay(StabilizedForgetting(0.5))
+        assert_allclose(clf.known_alphas_[1], 0.5 * a1 + 0.5 * np.array([1.0, 3.0]))
+
+    def test_gamma_stabilized_returns_to_the_prior(self):
+        model = GammaRegressor(alpha=2.0, beta=3.0, random_state=0)
+        model.fit(np.array([[1], [1]]), np.array([4, 6]))
+        for _ in range(200):
+            model.decay(StabilizedForgetting(0.8))
+        assert_allclose(model.coef_[1], [2.0, 3.0], atol=1e-6)
+
+    def test_legacy_array_ticks_only_the_listed_groups(self):
+        clf = DirichletClassifier({0: 1.0, 1: 1.0}, random_state=0)
+        clf.fit(np.array([[1], [2]]), np.array([0, 1]))
+        a1, a2 = clf.known_alphas_[1].copy(), clf.known_alphas_[2].copy()
+        with pytest.warns(FutureWarning):
+            clf.decay(np.array([[1], [1]]), decay_rate=0.5)
+        assert_allclose(clf.known_alphas_[1], 0.25 * a1)
+        assert_allclose(clf.known_alphas_[2], a2)
+
+    @pytest.mark.parametrize(
+        "cls, kwargs",
+        [
+            (EmpiricalBayesDirichletClassifier, {"alphas": {0: 1.0, 1: 1.0}}),
+            (EmpiricalBayesGammaRegressor, {"alpha": 2.0, "beta": 3.0}),
+        ],
+    )
+    def test_eb_grouped_defaults_to_stabilized(self, cls, kwargs):
+        model = cls(**kwargs, random_state=0)
+        table = model.known_alphas_ if hasattr(model, "known_alphas_") else None
+        model.decay(decay_rate=0.5)  # before any fit: nothing to tick, no error
+        if table is not None:
+            assert len(table) == 0
+
+
+class TestPassThrough:
+    def test_contextual_agent_passes_the_rule_and_steps_to_each_arm(self):
+        arms = [Arm(i, learner=NormalRegressor(alpha=1.0, beta=1.0)) for i in range(2)]
+        agent = ContextualAgent(arms, ThompsonSampling(), random_seed=0)
+        X = np.array([[1.0, 0.0]])
+        for arm in arms:
+            arm.update(X, np.array([1.0]))
+        before = [_dense(_learner(arm).cov_inv_) for arm in arms]
+        agent.decay(StabilizedForgetting(0.5), steps=2)
+        for arm, b in zip(arms, before):
+            assert_allclose(_dense(_learner(arm).cov_inv_), 0.25 * b + 0.75 * np.eye(2))
+
+    def test_agent_decay_takes_no_context(self):
+        agent = Agent(
+            [Arm(i, learner=GammaRegressor(alpha=1.0, beta=1.0)) for i in range(2)],
+            ThompsonSampling(),
+            random_seed=0,
+        )
+        agent.select_for_update(0).update(np.array([3.0]))
+        before = _learner(agent.arm(0)).coef_[1].copy()
+        agent.decay(decay_rate=0.5, steps=2)
+        assert_allclose(_learner(agent.arm(0)).coef_[1], 0.25 * before)
+
+    def test_pipelines_pass_through_and_transform_a_legacy_array(self):
+        arms = [Arm(0, learner=NormalRegressor(alpha=1.0, beta=1.0))]
+        agent = ContextualAgent(arms, ThompsonSampling(), random_seed=0)
+        pipeline = AgentPipeline([("id", FunctionTransformer())], agent)
+        X = np.array([[1.0, 2.0]])
+        arms[0].update(X, np.array([1.0]))
+        before = _dense(_learner(arms[0]).cov_inv_)
+        pipeline.decay(ExponentialForgetting(0.5))
+        assert_allclose(_dense(_learner(arms[0]).cov_inv_), 0.5 * before)
+        with pytest.warns(FutureWarning):
+            pipeline.decay(np.vstack([X, X]), decay_rate=0.5)
+        assert_allclose(_dense(_learner(arms[0]).cov_inv_), 0.125 * before)
+
+        learner = LearnerPipeline(
+            [("id", FunctionTransformer())], NormalRegressor(alpha=1.0, beta=1.0)
+        )
+        learner.partial_fit(X, np.array([1.0]))
+        before = _dense(cast(Any, learner.learner).cov_inv_)
+        learner.decay(StabilizedForgetting(0.5))
+        assert_allclose(
+            _dense(cast(Any, learner.learner).cov_inv_), 0.5 * before + 0.5 * np.eye(2)
+        )

--- a/tests/test_decay_api.py
+++ b/tests/test_decay_api.py
@@ -284,3 +284,20 @@ class TestPassThrough:
         assert_allclose(
             _dense(cast(Any, learner.learner).cov_inv_), 0.5 * before + 0.5 * np.eye(2)
         )
+
+
+class TestBreakingChanges:
+    def test_decay_rate_is_keyword_only(self):
+        est, X = _fit_normal(False)
+        with pytest.raises(TypeError):
+            est.decay(X, 0.9)  # type: ignore[misc]
+
+    def test_a_bare_rate_is_refused_with_a_pointer(self):
+        agent = Agent(
+            [Arm(0, learner=GammaRegressor(alpha=1.0, beta=1.0))],
+            ThompsonSampling(),
+            random_seed=0,
+        )
+        agent.select_for_update(0).update(np.array([3.0]))
+        with pytest.raises(TypeError, match="decay_rate="):
+            agent.decay(0.5)

--- a/tests/test_eb_estimators.py
+++ b/tests/test_eb_estimators.py
@@ -288,7 +288,7 @@ class TestEBNormalRegressor:
         eff_yTy_before = model._eff_yTy
         eff_XTy_before = model._eff_XTy.copy()
 
-        model.decay(X[:1])  # decay by 1 observation
+        model.decay(decay_rate=0.99)  # one tick
 
         decay = 0.99**1
         # Stabilized forgetting: prior_scalar converges to alpha instead of
@@ -311,7 +311,7 @@ class TestEBNormalRegressor:
             model.cov_inv_.toarray().copy() if sparse else model.cov_inv_.copy()
         )
 
-        model.decay(X[:1], decay_rate=1.0)
+        model.decay(decay_rate=1.0)
 
         precision_after = model.cov_inv_.toarray() if sparse else model.cov_inv_
         np.testing.assert_allclose(precision_after, precision_before)
@@ -371,7 +371,7 @@ class TestEBNormalRegressor:
         prior_decay = 0.99**n_obs
         expected_reinjection = (1 - prior_decay) * model.alpha
 
-        model.decay(X[:1])
+        model.decay(decay_rate=0.99)
 
         if sparse:
             diag_after = model.cov_inv_.toarray().diagonal()
@@ -393,10 +393,8 @@ class TestEBNormalRegressor:
             learning_rate=0.99,
             sparse=sparse,
         )
-        rng = np.random.default_rng(0)
-        X = rng.standard_normal((5, 3))
         # Should not raise
-        model.decay(X)
+        model.decay(decay_rate=0.99, steps=5)
 
     def test_partial_fit_cold_start(self, regression_data, sparse):
         """partial_fit with no prior fit() or sample() delegates to fit()."""
@@ -1109,10 +1107,9 @@ class TestEBDirichletClassifier:
         model.fit(X, y)
         prior_after_fit = model.prior_.copy()
 
-        # Decay ALL groups (pass unique group IDs)
-        group_ids = np.array([[1], [2], [3]])
+        # Decay all groups
         for _ in range(200):
-            model.decay(group_ids)
+            model.decay(decay_rate=model.learning_rate)
 
         # Alphas should converge to prior, not zero
         for key in list(model.known_alphas_.keys()):
@@ -1204,7 +1201,7 @@ class TestEBDirichletClassifier:
             model.partial_fit(np.array([[g]]), np.array([cls]))
 
             if i % 3 == 0:
-                model.decay(np.array([[rng.integers(0, 10)]]))
+                model.decay(decay_rate=model.learning_rate)
 
             for key, val in model.known_alphas_.items():
                 if hasattr(val, "__len__"):
@@ -1293,7 +1290,7 @@ class TestEBDirichletClassifier:
         model = EmpiricalBayesDirichletClassifier(
             {0: 2.0, 1: 3.0}, learning_rate=lr, random_state=42
         )
-        model.decay(np.array([[1], [2]]))
+        model.decay(decay_rate=lr)
 
         expected = np.array([2.0, 3.0])
         for key in [1, 2]:
@@ -1448,9 +1445,8 @@ class TestEBGammaRegressor:
         model.fit(X, y)
         prior_after_fit = model.prior_.copy()
 
-        group_ids = np.array([[1], [2], [3]])
         for _ in range(200):
-            model.decay(group_ids)
+            model.decay(decay_rate=model.learning_rate)
 
         for key in list(model.coef_.keys()):
             np.testing.assert_allclose(
@@ -1469,7 +1465,7 @@ class TestEBGammaRegressor:
         model = EmpiricalBayesGammaRegressor(
             alpha=2.0, beta=3.0, learning_rate=lr, random_state=42
         )
-        model.decay(np.array([[1], [2]]))
+        model.decay(decay_rate=lr)
 
         expected = np.array([2.0, 3.0])
         for key in [1, 2]:
@@ -1551,7 +1547,7 @@ class TestEBGammaRegressor:
             model.partial_fit(np.array([[g]]), np.array([count]))
 
             if i % 3 == 0:
-                model.decay(np.array([[rng.integers(0, 10)]]))
+                model.decay(decay_rate=model.learning_rate)
 
             for key, val in model.coef_.items():
                 counts = val - model.prior_

--- a/tests/test_eb_glm.py
+++ b/tests/test_eb_glm.py
@@ -311,7 +311,7 @@ class TestEBGLM:
         diag_before = _diag(model)
         s_before = model._prior_scalar
         n_eff_before = model._effective_n
-        model.decay(_X(X[:3], sparse))
+        model.decay(decay_rate=0.9, steps=3)
         g = 0.9**3
         np.testing.assert_allclose(
             _diag(model), g * diag_before + (1 - g) * model.alpha
@@ -392,7 +392,7 @@ class TestEBGLM:
         model = EmpiricalBayesGLM(link=link, sparse=sparse, learning_rate=0.99)
         model.fit(_X(X, sparse), y)
         model.partial_fit(_X(X[:50], sparse), y[:50])
-        model.decay(_X(X[:5], sparse))
+        model.decay(decay_rate=0.99, steps=5)
         restored = pickle.loads(pickle.dumps(model))
         assert "_factor_hint" not in restored.__dict__
         np.testing.assert_allclose(
@@ -420,7 +420,7 @@ class TestEBGLM:
             with pytest.raises(RuntimeError):
                 model.fit(_X(X, sparse), y)
         assert not hasattr(model, "_effective_n")
-        model.decay(_X(X[:5], sparse))
+        model.decay(decay_rate=0.9, steps=5)
 
 
 class TestEBGLMGuardrail:

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -210,7 +210,7 @@ def test_dirichletclassifier_decay(
 
     pre_decay = clf.predict(X)
 
-    clf.decay(X)
+    clf.decay(decay_rate=clf.learning_rate, steps=len(X))
 
     assert_almost_equal(clf.predict(X), pre_decay)
 
@@ -228,7 +228,7 @@ def test_dirichletclassifier_manual_decay(
 
     pre_decay = clf.predict(X)
 
-    clf.decay(X, decay_rate=0.9)
+    clf.decay(decay_rate=0.9, steps=len(X))
 
     assert_almost_equal(clf.predict(X), pre_decay)
 
@@ -627,7 +627,7 @@ def test_gamma_regressor_decay(
 
     pre_decay = clf.predict(X)
 
-    clf.decay(X)
+    clf.decay(decay_rate=clf.learning_rate, steps=len(X))
 
     assert_almost_equal(clf.predict(X), pre_decay)
 
@@ -643,7 +643,7 @@ def test_gamma_regressor_manual_decay(
 
     pre_decay = clf.predict(X)
 
-    clf.decay(X, decay_rate=0.9)
+    clf.decay(decay_rate=0.9, steps=len(X))
 
     assert_almost_equal(clf.predict(X), pre_decay)
 
@@ -956,7 +956,7 @@ def test_gamma_regressor_decay_with_weights() -> None:
     assert_almost_equal(pred_before, 20.9 / 2.9)  # ≈ 7.2069
 
     # Apply decay
-    clf.decay(X, decay_rate=0.5)
+    clf.decay(decay_rate=0.5, steps=len(X))
 
     # After decay: [20.9, 2.9] * 0.5 = [10.45, 1.45]
     assert_almost_equal(clf.coef_[1], np.array([10.45, 1.45]))

--- a/tests/test_forgetting.py
+++ b/tests/test_forgetting.py
@@ -1,5 +1,8 @@
 """Tests for forgetting rules: exponential, stabilized (KZ), SIFt, and feature-wise."""
 
+from dataclasses import replace
+from typing import Any
+
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
@@ -17,6 +20,11 @@ from bayesianbandits._forgetting import (
     filter_batch,
 )
 from tests._helpers import symmetrize
+
+
+def _apply(rule, R, X, y, lam) -> Any:
+    """Run ``rule`` at forgetting factor ``lam`` on one batch."""
+    return replace(rule, rate=lam).update(R, X, y, alpha=1.0)
 
 
 def _random_pd(n, rng, cond=10.0):
@@ -44,13 +52,13 @@ def _naive_sift_downdate(R, X_bar, lam):
 @pytest.fixture(params=["exponential", "stabilized", "sift", "feature-wise"])
 def rule(request):
     if request.param == "exponential":
-        return ExponentialForgetting()
+        return ExponentialForgetting(rate=1.0)
     elif request.param == "stabilized":
-        return StabilizedForgetting(alpha=1.0)
+        return StabilizedForgetting(rate=1.0, alpha=1.0)
     elif request.param == "sift":
-        return SiftForgetting(eps=1e-10)
+        return SiftForgetting(rate=1.0, eps=1e-10)
     else:
-        return FeatureWiseForgetting()
+        return FeatureWiseForgetting(rate=1.0)
 
 
 # ---------------------------------------------------------------------------
@@ -72,7 +80,7 @@ class TestSharedInterface:
 
     def test_return_type(self, rule, shared_data):
         R, X, y = shared_data
-        result = rule(R, X, y, 0.95)
+        result = _apply(rule, R, X, y, 0.95)
         assert result is not None
         R_bar, X_eff, y_eff = result
         assert isinstance(R_bar, np.ndarray) or sparse.issparse(R_bar)
@@ -81,14 +89,14 @@ class TestSharedInterface:
 
     def test_passthrough_at_lam_1(self, rule, shared_data):
         R, X, y = shared_data
-        result = rule(R, X, y, 1.0)
+        result = _apply(rule, R, X, y, 1.0)
         assert result is not None
         R_bar, _, _ = result
         assert_allclose(np.asarray(R_bar), R, atol=1e-12)
 
     def test_format_preservation_dense(self, rule, shared_data):
         R, X, y = shared_data
-        result = rule(R, X, y, 0.95)
+        result = _apply(rule, R, X, y, 0.95)
         if result is not None:
             R_bar, _, _ = result
             assert isinstance(R_bar, np.ndarray)
@@ -96,7 +104,7 @@ class TestSharedInterface:
     def test_format_preservation_sparse(self, rule, shared_data):
         R, X, y = shared_data
         R_sparse = sparse.csc_array(R)
-        result = rule(R_sparse, X, y, 0.95)
+        result = _apply(rule, R_sparse, X, y, 0.95)
         if result is not None:
             R_bar, _, _ = result
             if not isinstance(rule, SiftForgetting):
@@ -212,8 +220,8 @@ class TestExponentialForgetting:
         y = rng.standard_normal(3)
         lam = 0.95
 
-        rule = ExponentialForgetting()
-        R_bar, X_eff, y_eff = rule(R, X, y, lam)
+        rule = ExponentialForgetting(rate=1.0)
+        R_bar, X_eff, y_eff = _apply(rule, R, X, y, lam)
 
         assert_allclose(R_bar, lam * R)
         assert_allclose(X_eff, X)
@@ -234,8 +242,8 @@ class TestStabilizedForgetting:
         alpha = 2.0
         lam = 0.9
 
-        rule = StabilizedForgetting(alpha=alpha)
-        R_bar, _, _ = rule(R, X, y, lam)
+        rule = StabilizedForgetting(rate=1.0, alpha=alpha)
+        R_bar, _, _ = _apply(rule, R, X, y, lam)
 
         expected = lam * R + (1 - lam) * alpha * np.eye(5)
         assert_allclose(R_bar, expected, atol=1e-12)
@@ -246,14 +254,14 @@ class TestStabilizedForgetting:
         alpha = 1.5
         lam = 0.8
 
-        rule = StabilizedForgetting(alpha=alpha)
+        rule = StabilizedForgetting(rate=1.0, alpha=alpha)
 
         for _ in range(20):
             R = _random_pd(8, rng)
             X = rng.standard_normal((3, 8))
             y = rng.standard_normal(3)
 
-            R_bar, _, _ = rule(R, X, y, lam)
+            R_bar, _, _ = _apply(rule, R, X, y, lam)
             min_eig = eigvalsh(np.asarray(R_bar))[0]
             assert min_eig >= (1 - lam) * alpha - 1e-10
 
@@ -263,8 +271,8 @@ class TestStabilizedForgetting:
         X = rng.standard_normal((3, 5))
         y = rng.standard_normal(3)
 
-        rule = StabilizedForgetting(alpha=1.0)
-        R_bar, _, _ = rule(R, X, y, 0.9)
+        rule = StabilizedForgetting(rate=1.0, alpha=1.0)
+        R_bar, _, _ = _apply(rule, R, X, y, 0.9)
         assert sparse.issparse(R_bar)
 
 
@@ -399,8 +407,8 @@ class TestSiftForgetting:
             X = rng.standard_normal((3, 5)) * 1e-15
         y = rng.standard_normal(3)
 
-        rule = SiftForgetting(eps=1e-10)
-        result = rule(R, X, y, 0.9)
+        rule = SiftForgetting(rate=1.0, eps=1e-10)
+        result = _apply(rule, R, X, y, 0.9)
         assert result is None
 
     @pytest.mark.parametrize(
@@ -429,8 +437,8 @@ class TestSiftForgetting:
             y = rng.standard_normal(p)
             lam = rng.uniform(0.8, 0.99)
 
-            rule = SiftForgetting(eps=1e-12)
-            result = rule(R, X, y, lam)
+            rule = SiftForgetting(rate=1.0, eps=1e-12)
+            result = _apply(rule, R, X, y, lam)
             assert result is not None
             R_bar, X_bar, y_bar = result
 
@@ -485,7 +493,7 @@ class TestSiftForgetting:
         lam_min_R0 = eigvalsh(R)[0]
         lower_bound = min(eps / (1 - lam), lam_min_R0)
 
-        rule = SiftForgetting(eps=eps)
+        rule = SiftForgetting(rate=1.0, eps=eps)
 
         updates_applied = 0
         for step in range(150):
@@ -493,7 +501,7 @@ class TestSiftForgetting:
             X = rng.standard_normal((p, n))
             y = rng.standard_normal(p)
 
-            result = rule(R, X, y, lam)
+            result = _apply(rule, R, X, y, lam)
             assert result is not None, f"Step {step}: no excitation"
             R_bar, X_bar, y_bar = result
             R_bar_full = symmetrize(R_bar) if isinstance(R_bar, np.ndarray) else R_bar
@@ -524,8 +532,8 @@ class TestSiftForgetting:
         y = rng.standard_normal(p)
 
         # SIFt path
-        rule = SiftForgetting(eps=1e-12)
-        result = rule(R, X, y, lam)
+        rule = SiftForgetting(rate=1.0, eps=1e-12)
+        result = _apply(rule, R, X, y, lam)
         assert result is not None
         R_bar_raw, X_bar, y_bar = result
         R_bar = symmetrize(R_bar_raw)
@@ -569,8 +577,8 @@ class TestSiftForgetting:
             R = sparse.csc_array(R)
             X = sparse.csc_array(X)
 
-        rule = SiftForgetting(eps=1e-10)
-        result = rule(R, X, y, lam)
+        rule = SiftForgetting(rate=1.0, eps=1e-10)
+        result = _apply(rule, R, X, y, lam)
         assert result is not None
         R_bar, X_bar, y_bar = result
 
@@ -616,7 +624,9 @@ class TestFeatureWiseForgetting:
         X = _one_hot_rows(6, [[0, 1], [0, 2]])  # feature 0 in two rows, 1 and 2 in one
         lam = 0.8
 
-        R_bar, X_eff, y_eff = FeatureWiseForgetting()(R, X, np.zeros(2), lam)
+        R_bar, X_eff, y_eff = _apply(
+            FeatureWiseForgetting(rate=1.0), R, X, np.zeros(2), lam
+        )
 
         d = np.array([lam, np.sqrt(lam), np.sqrt(lam), 1.0, 1.0, 1.0])
         assert_allclose(np.asarray(R_bar), np.diag(d) @ R @ np.diag(d), atol=1e-12)
@@ -632,7 +642,7 @@ class TestFeatureWiseForgetting:
         R = sparse.csc_array(np.eye(30) + X_hist.T @ X_hist)
         X = _one_hot_rows(30, [[3, 7, 11]])
 
-        R_bar, _, _ = FeatureWiseForgetting()(R, X, np.zeros(1), 0.9)
+        R_bar, _, _ = _apply(FeatureWiseForgetting(rate=1.0), R, X, np.zeros(1), 0.9)
 
         assert sparse.issparse(R_bar)
         R_bar = sparse.csc_array(R_bar)
@@ -644,9 +654,13 @@ class TestFeatureWiseForgetting:
         R = _random_pd(8, rng)
         X = _one_hot_rows(8, [[1, 4], [4, 6]])
 
-        dense, _, _ = FeatureWiseForgetting()(R, X, np.zeros(2), 0.85)
-        sp, _, _ = FeatureWiseForgetting()(
-            sparse.csc_array(R), sparse.csc_array(X), np.zeros(2), 0.85
+        dense, _, _ = _apply(FeatureWiseForgetting(rate=1.0), R, X, np.zeros(2), 0.85)
+        sp, _, _ = _apply(
+            FeatureWiseForgetting(rate=1.0),
+            sparse.csc_array(R),
+            sparse.csc_array(X),
+            np.zeros(2),
+            0.85,
         )
 
         assert_allclose(sparse.csc_array(sp).toarray(), np.asarray(dense), atol=1e-12)
@@ -660,8 +674,8 @@ class TestFeatureWiseForgetting:
         X = _one_hot_rows(6, [[0]])
         lam = 0.6
 
-        fw, _, _ = FeatureWiseForgetting()(R, X, np.zeros(1), lam)
-        result = SiftForgetting(eps=1e-12)(R, X, np.zeros(1), lam)
+        fw, _, _ = _apply(FeatureWiseForgetting(rate=1.0), R, X, np.zeros(1), lam)
+        result = _apply(SiftForgetting(rate=1.0, eps=1e-12), R, X, np.zeros(1), lam)
         assert result is not None
         sift, _, _ = result
 
@@ -678,7 +692,7 @@ class TestFeatureWiseForgetting:
         rest = [1, 3, 4, 5, 6]
         X = _one_hot_rows(7, [obs])
 
-        R_bar, _, _ = FeatureWiseForgetting()(R, X, np.zeros(1), 0.5)
+        R_bar, _, _ = _apply(FeatureWiseForgetting(rate=1.0), R, X, np.zeros(1), 0.5)
         R_bar = np.asarray(R_bar)
 
         def marginal(M):
@@ -706,7 +720,62 @@ class TestFeatureWiseForgetting:
             (np.array([1.0, 0.0]), (np.array([0, 0]), np.array([1, 3]))), shape=(1, 4)
         )
 
-        R_bar, _, _ = FeatureWiseForgetting()(R, X, np.zeros(1), 0.5)
+        R_bar, _, _ = _apply(FeatureWiseForgetting(rate=1.0), R, X, np.zeros(1), 0.5)
 
         d = np.array([1.0, np.sqrt(0.5), 1.0, 1.0])
         assert_allclose(np.asarray(R_bar), np.diag(d) @ R @ np.diag(d), atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Tick (clock) interface
+# ---------------------------------------------------------------------------
+
+
+class TestTick:
+    def test_exponential_tick_scales_by_rate_to_the_steps(self):
+        rng = np.random.default_rng(0)
+        R = _random_pd(4, rng)
+        R_bar = ExponentialForgetting(0.9).tick(R, alpha=1.0, steps=3)
+        assert_allclose(np.asarray(R_bar), 0.9**3 * R)
+
+    def test_stabilized_tick_floors_at_the_estimator_alpha_by_default(self):
+        rng = np.random.default_rng(0)
+        R = _random_pd(4, rng)
+        R_bar = StabilizedForgetting(0.9).tick(R, alpha=2.0)
+        assert_allclose(np.asarray(R_bar), 0.9 * R + 0.1 * 2.0 * np.eye(4), atol=1e-12)
+        R_own = StabilizedForgetting(0.9, alpha=5.0).tick(R, alpha=2.0)
+        assert_allclose(np.asarray(R_own), 0.9 * R + 0.1 * 5.0 * np.eye(4), atol=1e-12)
+
+    def test_stabilized_tick_composes_over_steps(self):
+        rng = np.random.default_rng(0)
+        R = _random_pd(4, rng)
+        rule = StabilizedForgetting(0.8)
+        three = rule.tick(R, alpha=1.0, steps=3)
+        one_at_a_time = R
+        for _ in range(3):
+            one_at_a_time = rule.tick(one_at_a_time, alpha=1.0)
+        assert_allclose(np.asarray(three), np.asarray(one_at_a_time), atol=1e-12)
+
+    def test_stabilized_tick_keeps_sparse_format(self):
+        rng = np.random.default_rng(0)
+        R = sparse.csc_array(_random_pd(4, rng))
+        R_bar = StabilizedForgetting(0.9).tick(R, alpha=1.0)
+        assert sparse.issparse(R_bar)
+        assert_allclose(
+            sparse.csc_array(R_bar).toarray(), 0.9 * R.toarray() + 0.1 * np.eye(4)
+        )
+
+    def test_directional_rules_have_no_tick(self):
+        from bayesianbandits._forgetting import TickRule, UpdateRule
+
+        assert isinstance(ExponentialForgetting(0.9), TickRule)
+        assert isinstance(StabilizedForgetting(0.9), TickRule)
+        assert not isinstance(FeatureWiseForgetting(0.9), TickRule)
+        assert not isinstance(SiftForgetting(0.9), TickRule)
+        for rule in (
+            ExponentialForgetting(0.9),
+            StabilizedForgetting(0.9),
+            FeatureWiseForgetting(0.9),
+            SiftForgetting(0.9),
+        ):
+            assert isinstance(rule, UpdateRule)

--- a/tests/test_howto_decay.py
+++ b/tests/test_howto_decay.py
@@ -28,7 +28,7 @@ def test_decoupled_decay():
     precision_before = updated_arm.learner.cov_inv_.copy()
 
     # Decay all arms
-    agent.decay(np.array([[0.0, 0.0]]), decay_rate=0.95)
+    agent.decay(decay_rate=0.95)
 
     # Precision should have shrunk
     precision_after = updated_arm.learner.cov_inv_
@@ -107,7 +107,7 @@ def test_eb_stabilized_forgetting():
 
     # Decay aggressively many times
     for _ in range(100):
-        learner.decay(X, decay_rate=0.5)
+        learner.decay(decay_rate=0.5, steps=len(X))
 
     # With stabilized forgetting, the prior contribution converges to alpha
     # instead of zero. The diagonal should stay bounded above zero.

--- a/tests/test_howto_delayed_rewards.py
+++ b/tests/test_howto_delayed_rewards.py
@@ -114,7 +114,7 @@ def test_decay_then_update():
     precision_after_fit = agent.arm(token).learner.cov_inv_.copy()
 
     # Decay widens posterior (lower precision) -- RST uses 0.99
-    agent.decay(np.array([[0.0, 0.0]]), decay_rate=0.99)
+    agent.decay(decay_rate=0.99)
     precision_after_decay = agent.arm(token).learner.cov_inv_.copy()
     assert np.all(np.diag(precision_after_decay) < np.diag(precision_after_fit))
 

--- a/tests/test_learner_pipeline.py
+++ b/tests/test_learner_pipeline.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any, Optional
+
 import numpy as np
 import pytest
 from numpy.typing import NDArray
@@ -39,8 +41,14 @@ class MockLearner:
         self.predict_calls.append(X)
         return np.zeros(len(X))
 
-    def decay(self, X, *, decay_rate=None):
-        self.decay_calls.append((X, decay_rate))
+    def decay(
+        self,
+        forgetting: Any = None,
+        *,
+        steps: float = 1,
+        decay_rate: Optional[float] = None,
+    ) -> None:
+        self.decay_calls.append((forgetting, steps, decay_rate))
 
 
 class TestLearnerPipelineInit:
@@ -189,9 +197,10 @@ class TestLearnerPipelineTransformers:
         predict_X = mock_learner.predict_calls[0]
         np.testing.assert_array_equal(predict_X, X)
 
-        pipeline.decay(X, decay_rate=0.9)
-        decay_X, decay_rate = mock_learner.decay_calls[0]
-        np.testing.assert_array_equal(decay_X, X)
+        pipeline.decay(decay_rate=0.9, steps=3)
+        forgetting, steps, decay_rate = mock_learner.decay_calls[0]
+        assert forgetting is None
+        assert steps == 3
         assert decay_rate == 0.9
 
     def test_transformer_not_fitted_error(self):
@@ -269,12 +278,13 @@ class TestLearnerPipelineInterface:
         self.pipeline.partial_fit(X, np.array([1]))
 
         # Now decay
-        self.pipeline.decay(X, decay_rate=0.9)
+        self.pipeline.decay(decay_rate=0.9)
 
         assert len(self.mock_learner.decay_calls) == 1
-        received_X, decay_rate = self.mock_learner.decay_calls[0]
+        forgetting, steps, decay_rate = self.mock_learner.decay_calls[0]
+        assert forgetting is None
+        assert steps == 1
         assert decay_rate == 0.9
-        assert received_X.shape == X.shape
 
     def test_random_state_property(self):
         """Test random_state property delegation."""
@@ -315,7 +325,7 @@ class TestLearnerPipelineIntegration:
         assert predictions.shape == (5,)
 
         # Decay should work
-        pipeline.decay(X[:5], decay_rate=0.95)
+        pipeline.decay(decay_rate=0.95, steps=5)
 
     def test_with_arm_and_lipschitz_agent(self):
         """Test LearnerPipeline used as learner in LipschitzContextualAgent."""

--- a/tests/test_learner_pipeline.py
+++ b/tests/test_learner_pipeline.py
@@ -45,8 +45,8 @@ class MockLearner:
         self,
         forgetting: Any = None,
         *,
-        steps: float = 1,
         decay_rate: Optional[float] = None,
+        steps: float = 1,
     ) -> None:
         self.decay_calls.append((forgetting, steps, decay_rate))
 

--- a/tests/test_lipschitz_contextual_agent.py
+++ b/tests/test_lipschitz_contextual_agent.py
@@ -222,13 +222,11 @@ def test_lipschitz_agent_decay(learner_class, policy, arm_featurizer):
         random_seed=42,
     )
 
-    X = np.array([[25, 50000]])
-
-    # Test decay without rate
-    agent.decay(X)
+    # Test decay
+    agent.decay(decay_rate=0.9)
 
     # Test decay with rate
-    agent.decay(X, decay_rate=0.9)
+    agent.decay(decay_rate=0.9)
 
     # No assertion errors means decay worked
 
@@ -478,7 +476,7 @@ def test_lipschitz_agent_dirichlet_classifier():
     assert all(len(context_result) == 2 for context_result in top_k_result)
 
     # Test decay
-    agent.decay(X, decay_rate=0.95)
+    agent.decay(decay_rate=0.95)
 
 
 def test_lipschitz_agent_gamma_regressor():
@@ -530,7 +528,7 @@ def test_lipschitz_agent_gamma_regressor():
     assert all(len(context_result) == 2 for context_result in top_k_result)
 
     # Test decay
-    agent.decay(X, decay_rate=0.95)
+    agent.decay(decay_rate=0.95)
 
 
 def test_lipschitz_integration():
@@ -697,7 +695,7 @@ def test_lipschitz_integration():
     assert 0 <= new_older_rec < 20, "Should make valid recommendations for new contexts"
 
     # Test decay functionality
-    agent.decay(np.vstack([young_contexts, older_contexts]), decay_rate=0.8)
+    agent.decay(decay_rate=0.8)
 
     post_decay_young = [agent.pull(young_contexts[:1])[0] for _ in range(3)]
     post_decay_older = [agent.pull(older_contexts[:1])[0] for _ in range(3)]

--- a/tests/test_marginal_sampling.py
+++ b/tests/test_marginal_sampling.py
@@ -89,7 +89,7 @@ class TestMarginalSd:
         X = sp.csc_array(
             sp.random(6, 400, density=0.05, random_state=3)  # type: ignore[call-arg]
         )
-        est.decay(X.toarray(), decay_rate=0.9)
+        est.decay(decay_rate=0.9)
         draws = est.sample_marginal(X, size=100_000)
         sd_ref = _reference_sd(est, X.toarray())
         assert_allclose(draws.std(axis=0), sd_ref, rtol=3e-2)

--- a/tests/test_mathematical_correctness.py
+++ b/tests/test_mathematical_correctness.py
@@ -621,7 +621,7 @@ class TestDirichletClassifierDecay:
         # known_alphas_[1] = [3, 2]
 
         gamma = 0.8
-        clf.decay(np.array([[1]]), decay_rate=gamma)
+        clf.decay(decay_rate=gamma)
 
         assert_allclose(clf.known_alphas_[1], [3.0 * gamma, 2.0 * gamma], atol=1e-10)
 
@@ -633,7 +633,7 @@ class TestDirichletClassifierDecay:
         clf.fit(X, y)
 
         mean_before = clf.known_alphas_[1] / clf.known_alphas_[1].sum()
-        clf.decay(np.array([[1]]), decay_rate=0.7)
+        clf.decay(decay_rate=0.7)
         mean_after = clf.known_alphas_[1] / clf.known_alphas_[1].sum()
 
         assert_allclose(mean_after, mean_before, atol=1e-10)
@@ -649,7 +649,7 @@ class TestGammaRegressorDecay:
         # coef_[1] = [11, 6]
 
         gamma = 0.9
-        model.decay(np.array([[1]]), decay_rate=gamma)
+        model.decay(decay_rate=gamma)
 
         assert_allclose(model.coef_[1], [11.0 * gamma, 6.0 * gamma], atol=1e-10)
 
@@ -661,7 +661,7 @@ class TestGammaRegressorDecay:
         model.fit(X, y)
 
         mean_before = model.coef_[1][0] / model.coef_[1][1]
-        model.decay(np.array([[1]]), decay_rate=0.7)
+        model.decay(decay_rate=0.7)
         mean_after = model.coef_[1][0] / model.coef_[1][1]
 
         assert_allclose(mean_after, mean_before, atol=1e-10)
@@ -684,10 +684,7 @@ class TestNormalRegressorDecay:
 
         gamma = 0.8
         # Decay with 2 rows => factor = gamma^2
-        X_decay = np.array([[0.0, 0.0], [0.0, 0.0]])
-        if sparse:
-            X_decay = sp.csc_array(X_decay)
-        reg.decay(X_decay, decay_rate=gamma)
+        reg.decay(decay_rate=gamma, steps=2)
 
         factor = gamma**2
         assert_allclose(reg.coef_, coef_before, atol=1e-10)  # mean unchanged
@@ -706,10 +703,7 @@ class TestNormalRegressorDecay:
         prec_before = cov_inv_dense(reg).copy()
 
         gamma = 0.5
-        X_decay = np.array([[0.0, 0.0]])
-        if sparse:
-            X_decay = sp.csc_array(X_decay)
-        reg.decay(X_decay, decay_rate=gamma)
+        reg.decay(decay_rate=gamma)
 
         assert_allclose(cov_inv_dense(reg), gamma * prec_before, atol=1e-10)
 
@@ -734,10 +728,7 @@ class TestNIGDecay:
         b_before = reg.b_
 
         gamma = 0.9
-        X_decay = np.array([[0.0]])
-        if sparse:
-            X_decay = sp.csc_array(X_decay)
-        reg.decay(X_decay, decay_rate=gamma)
+        reg.decay(decay_rate=gamma)
 
         assert_allclose(reg.coef_, coef_before, atol=1e-10)
         assert_allclose(cov_inv_dense(reg), gamma * prec_before, atol=1e-10)
@@ -761,10 +752,7 @@ class TestBayesianGLMDecay:
         prec_before = cov_inv_dense(glm).copy()
 
         gamma = 0.75
-        X_decay = np.array([[0.0]])
-        if sparse:
-            X_decay = sp.csc_array(X_decay)
-        glm.decay(X_decay, decay_rate=gamma)
+        glm.decay(decay_rate=gamma)
 
         assert_allclose(glm.coef_, coef_before, atol=1e-10)
         assert_allclose(cov_inv_dense(glm), gamma * prec_before, atol=1e-10)
@@ -803,10 +791,7 @@ class TestEBDecay:
         eff_XTy_before = eb._eff_XTy.copy()
 
         gamma = 0.8
-        X_decay = np.array([[0.0]])
-        if sparse:
-            X_decay = sp.csc_array(X_decay)
-        eb.decay(X_decay, decay_rate=gamma)
+        eb.decay(decay_rate=gamma)
 
         # _prior_scalar: 0.8 * 5.0 + 0.2 * 1.0 = 4.2
         expected_prior_scalar = gamma * prior_scalar_before + (1 - gamma) * eb.alpha
@@ -837,12 +822,8 @@ class TestEBDecay:
         # Start far from fixed point
         eb._prior_scalar = 10.0
 
-        X_decay = np.array([[0.0]])
-        if sparse:
-            X_decay = sp.csc_array(X_decay)
-
         for _ in range(200):
-            eb.decay(X_decay, decay_rate=0.9)
+            eb.decay(decay_rate=0.9)
 
         # Fixed point of s = 0.9*s + 0.1*2.0 is s = 2.0 = alpha
         assert_allclose(eb._prior_scalar, eb.alpha, atol=1e-4)

--- a/tests/test_normal_estimators.py
+++ b/tests/test_normal_estimators.py
@@ -294,7 +294,7 @@ def test_normal_regressor_decay(
 
     pre_decay = clf.predict(X_fit)
 
-    clf.decay(X_fit)
+    clf.decay(decay_rate=clf.learning_rate, steps=X.shape[0])
 
     assert_almost_equal(clf.predict(X_fit), pre_decay)
 
@@ -318,7 +318,7 @@ def test_normal_regressor_manual_decay(
 
     pre_decay = clf.predict(X_fit)
 
-    clf.decay(X_fit, decay_rate=0.9)
+    clf.decay(decay_rate=0.9, steps=X.shape[0])
 
     assert_almost_equal(clf.predict(X_fit), pre_decay)
 
@@ -1007,7 +1007,7 @@ def test_normal_inverse_gamma_regressor_decay(
 
     pre_decay = clf.predict(X_fit)
 
-    clf.decay(X_fit)
+    clf.decay(decay_rate=clf.learning_rate, steps=X.shape[0])
 
     assert_almost_equal(clf.predict(X_fit), pre_decay)
 
@@ -1046,7 +1046,7 @@ def test_normal_inverse_gamma_regressor_manual_decay(
 
     pre_decay = clf.predict(X_fit)
 
-    clf.decay(X_fit, decay_rate=0.9)
+    clf.decay(decay_rate=0.9, steps=X.shape[0])
 
     assert_almost_equal(clf.predict(X_fit), pre_decay)
 
@@ -1597,8 +1597,8 @@ def test_normal_inverse_gamma_decay_then_sample(sparse: bool) -> None:
     reg.fit(X_fit, y)
     pre_decay_pred = reg.predict(X_fit)
 
-    # Decay scales the cached factor by prior_decay (0.95^50)
-    reg.decay(X_fit)
+    # Decay scales the cached factor by 0.95^50
+    reg.decay(decay_rate=0.95, steps=50)
     assert reg._precision_factor._scale == pytest.approx(0.95**50)
 
     # Predictions should be unchanged (decay only widens variance)
@@ -1621,8 +1621,7 @@ def test_normal_inverse_gamma_scale_factor_identity(sparse: bool) -> None:
 
     original_factor = reg._precision_factor
 
-    # learning_rate=1.0 means prior_decay = 1.0^N = 1.0, so scale_factor
-    # should return the original factor unchanged
-    reg.decay(sp.csc_array(X) if sparse else X)
+    # a rate of 1.0 means scale_factor returns the original factor unchanged
+    reg.decay(decay_rate=1.0)
 
     assert reg._precision_factor is original_factor

--- a/tests/test_reward_space_sampling.py
+++ b/tests/test_reward_space_sampling.py
@@ -102,7 +102,7 @@ class TestPredictiveCholesky:
         assert dense.M.shape[1] == 0
         assert_allclose(dense.L, L, atol=1e-10)
 
-        est.decay(X.toarray(), decay_rate=0.9)
+        est.decay(decay_rate=0.9)
         _, draw = est._predictive_cholesky(X)
         assert _relative_error(draw.L @ draw.L.T, _reference_S(est, X.toarray())) < 1e-9
 

--- a/tests/test_rvga_approximator.py
+++ b/tests/test_rvga_approximator.py
@@ -797,7 +797,7 @@ class TestRVGAIntegration:
         )
         glm.fit(X, y)
         prec_before = glm.cov_inv_.copy()
-        glm.decay(X[:5])
+        glm.decay(decay_rate=0.9, steps=5)
         prec_after = glm.cov_inv_.copy()
         # Precision should decrease (uncertainty increases)
         assert np.all(np.diag(prec_after) < np.diag(prec_before))


### PR DESCRIPTION
## Summary

First half of the forgetting API from issue #236. Forgetting has two triggers, the clock and an observation. This PR does the clock.

- `decay(forgetting=None, *, decay_rate=None, steps=1)` on every estimator, arm, agent and pipeline. `agent.decay(StabilizedForgetting(0.95), steps=7)` is seven ticks at 0.95 with the prior floored at the learner's α. `decay_rate=0.95` stays as shorthand for the estimator's default rule at that rate.
- The four rules in `_forgetting.py` are public and each carries its `rate`. Exponential and stabilized have `tick()` and `update()`; feature-wise and SIFt only `update()`, so passing one to `decay()` is a `TypeError` that points at the learner's update path (the next PR).
- Stabilized forgetting can now be passed to the plain estimators. Defaults are unchanged: exponential on the plain estimators, stabilized on EB. The EB estimators drop their own re-injection code in favour of the shared tick.
- The context array is deprecated, not removed: it still works with a `FutureWarning` and keeps its old meaning, including the per-group ticks on the Dirichlet and Gamma models. Falling back to `learning_rate` when neither a rule nor `decay_rate` is given also warns.
- No mixins: the shared pieces are two module functions, `resolve_tick` and `tick_groups`.

## Breaking changes (documented in the changelog)

- `decay_rate` is keyword-only on the agents and pipelines, where it was positional.
- `Agent.decay(0.9)` is a `TypeError` that says to pass `decay_rate=`.
- The `Learner` protocol requires the new signature; a custom learner with `decay(X, *, decay_rate=None)` no longer works inside an `Arm`.
- Private: `_apply_decay` is replaced by `_apply_tick(rule, steps)`, EB's `_reinject_prior` is gone, and the rule objects are built with a `rate` and applied through `update`/`tick` rather than called.

## Test plan

- [x] `uv run pytest tests -W error::FutureWarning`: 2999 passed, every legacy call site in the suite migrated
- [x] `tests/test_decay_api.py`: rules, steps, factor handling, the deprecated array form, NIG floor, EB bookkeeping, grouped models, agent and pipeline pass-through, the two new errors
- [x] pyright: 283 messages vs 293 on master
- [x] `make html` clean, four new rule pages under the API reference
