### PR TITLE
Replace learning_rate with forgetting= on every estimator

### DIFF
--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -7,6 +7,7 @@ import pytest
 from scipy.sparse import csc_array
 from scipy.sparse import random as sparse_random
 
+from bayesianbandits import StabilizedForgetting
 from bayesianbandits._eb_estimators import EmpiricalBayesNormalRegressor
 from bayesianbandits._estimators import (
     BayesianGLM,
@@ -35,7 +36,7 @@ def _make_estimator(estimator_type, sparse):
         )
     elif estimator_type == "eb_normal":
         return EmpiricalBayesNormalRegressor(
-            alpha=1.0, beta=1.0, learning_rate=0.99999, sparse=sparse
+            alpha=1.0, beta=1.0, forgetting=StabilizedForgetting(0.99999), sparse=sparse
         )
     else:
         raise ValueError(f"Unknown estimator type: {estimator_type}")

--- a/benchmarks/test_bench_estimators.py
+++ b/benchmarks/test_bench_estimators.py
@@ -5,6 +5,7 @@ import pytest
 from scipy.sparse import csc_array
 from scipy.sparse import random as sparse_random
 
+from bayesianbandits import StabilizedForgetting
 from bayesianbandits._eb_estimators import EmpiricalBayesNormalRegressor
 from bayesianbandits._estimators import (
     BayesianGLM,
@@ -500,7 +501,7 @@ def test_fit_eb_normal_dense_100(benchmark):
 
     def run():
         est = EmpiricalBayesNormalRegressor(
-            alpha=1.0, beta=1.0, learning_rate=0.99999, sparse=False
+            alpha=1.0, beta=1.0, forgetting=StabilizedForgetting(0.99999), sparse=False
         )
         est.fit(X, y)
 
@@ -551,7 +552,7 @@ def test_fit_eb_normal_dense_1k(benchmark):
 
     def run():
         est = EmpiricalBayesNormalRegressor(
-            alpha=1.0, beta=1.0, learning_rate=0.99999, sparse=False
+            alpha=1.0, beta=1.0, forgetting=StabilizedForgetting(0.99999), sparse=False
         )
         est.fit(X, y)
 
@@ -602,7 +603,7 @@ def test_fit_eb_normal_sparse_1k(benchmark):
 
     def run():
         est = EmpiricalBayesNormalRegressor(
-            alpha=1.0, beta=1.0, learning_rate=0.99999, sparse=True
+            alpha=1.0, beta=1.0, forgetting=StabilizedForgetting(0.99999), sparse=True
         )
         est.fit(X, y)
 
@@ -655,7 +656,7 @@ def test_fit_eb_normal_sparse_100k(benchmark):
 
     def run():
         est = EmpiricalBayesNormalRegressor(
-            alpha=1.0, beta=1.0, learning_rate=0.99999, sparse=True
+            alpha=1.0, beta=1.0, forgetting=StabilizedForgetting(0.99999), sparse=True
         )
         est.fit(X, y)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,9 +28,41 @@ Unreleased
   ``alpha``; the empirical Bayes estimators default to it, as before.
   ``decay_rate=`` is shorthand for the estimator's default rule at that
   rate. Passing a directional rule to ``decay`` is a ``TypeError``
-  pointing at where it belongs: the learner's update, coming next.
+  pointing at where it belongs: the learner's update.
+
+- ``forgetting=`` on every estimator: the rule applied on each
+  ``partial_fit`` before the batch is absorbed, for change that happens
+  because you observed. The linear estimators take any rule; the
+  directional ones, ``FeatureWiseForgetting`` and ``SiftForgetting``,
+  forget only along what the batch excites and leave everything else at
+  full precision. ``SiftForgetting`` is refused on a sparse estimator,
+  since its correction fills in the precision; the grouped conjugate
+  models and the empirical Bayes estimators take the uniform rules only.
+  Combined with ``decay()`` on a schedule this is the TrueSkill 2 model
+  of change: some from each observation, some from the passage of time.
 
 **Breaking changes**
+
+- ``learning_rate`` is removed from every estimator. What it did,
+  forgetting on each ``partial_fit`` before the batch is absorbed, is now
+  ``forgetting=`` taking a rule that carries its rate. To migrate:
+
+  - ``NormalRegressor(..., learning_rate=0.99)`` and the other plain
+    estimators: ``forgetting=ExponentialForgetting(0.99)``.
+  - ``EmpiricalBayesNormalRegressor(..., learning_rate=0.99)`` and the
+    other empirical Bayes estimators, which always forgot with the prior
+    floored: ``forgetting=StabilizedForgetting(0.99)``.
+  - ``learning_rate=1.0``: drop it; ``forgetting=None`` is the default.
+
+  The numbers are unchanged: a uniform rule takes one step per row, so
+  a batch of ``n`` rows scales the prior by ``rate ** n`` and weighs its
+  older rows less, as before. Models pickled with ``learning_rate`` load
+  unchanged and are converted on load, to the rule the class used to
+  apply. ``decay()`` no longer falls back to a constructor rate: with
+  neither a rule nor ``decay_rate`` it raises. The
+  ``PosteriorApproximator`` protocol takes ``prior_decay`` (the factor
+  already raised to the batch size) instead of ``learning_rate``, with
+  ``sample_weight`` arriving as the final per-row weights.
 
 - ``decay`` has one signature everywhere,
   ``decay(forgetting=None, *, decay_rate=None, steps=1)``, and the

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,18 +4,6 @@ Changelog
 Unreleased
 ----------
 
-**Deprecations**
-
-- ``decay()`` no longer takes a context array. It was only ever read for
-  its row count (the grouped conjugate models also read the groups in
-  it), and it invited passing the last batch to a method that is meant
-  to be called on a clock. Pass ``steps=`` for the number of ticks
-  instead; an array still works for now, with a ``FutureWarning``, and
-  keeps its old meaning. ``decay()`` with neither a rule nor
-  ``decay_rate`` still falls back to ``learning_rate``, also with a
-  ``FutureWarning``: a nightly job should not inherit a per-observation
-  number.
-
 **New features**
 
 - The forgetting rules are public, ``ExponentialForgetting``,
@@ -66,7 +54,10 @@ Unreleased
 
 - ``decay`` has one signature everywhere,
   ``decay(forgetting=None, *, decay_rate=None, steps=1)``, and the
-  ``Learner`` protocol requires it. ``decay_rate`` is keyword-only on the
+  ``Learner`` protocol requires it. It no longer takes a context array:
+  the array was only ever read for its row count (and, on the grouped
+  conjugate models, for which groups to tick), so pass ``steps=`` for the
+  number of ticks and let a tick reach every group. ``decay_rate`` is keyword-only on the
   agents and pipelines, where it used to be positional, and
   ``Agent.decay(0.9)`` is a ``TypeError`` that says to pass
   ``decay_rate=``. A learner of your own with the old

--- a/docs/howto/decay.rst
+++ b/docs/howto/decay.rst
@@ -12,21 +12,23 @@ two ways to apply it:
    posteriors drive re-exploration via more diverse Thompson samples
    and higher UCB values.
 
-``learning_rate < 1`` on the estimator
-    Decay is coupled to ``partial_fit``: every update automatically
-    down-weights the prior by ``learning_rate ** n_samples`` before
-    incorporating new data.
+``forgetting=`` on the estimator
+    Forgetting is coupled to ``partial_fit``: every update forgets
+    before incorporating the new data, one step per row under a
+    uniform rule such as ``ExponentialForgetting(0.99)``. This is for
+    change that happens *because you observed*.
 
 Explicit ``agent.decay()`` calls
-    Decay is decoupled from updates. You call ``decay()`` on your own
-    schedule, independently of when observations arrive.
+    Forgetting is decoupled from updates. You call ``decay()`` on your
+    own schedule, independently of when observations arrive. This is
+    for change that happens *with time*.
 
 
 Start with no decay
 --------------------
 
 If you are unsure whether your environment is non-stationary, start
-with ``learning_rate=1.0`` (the default) and no ``decay()`` calls.
+with no ``forgetting`` rule (the default) and no ``decay()`` calls.
 Adding decay when you don't need it throws away information and
 widens your posterior for no benefit.
 
@@ -37,11 +39,11 @@ Decouple decay from updates
 Consider a product recommendation system. You ``pull()`` thousands of
 times per day as users visit the site, and ``update()`` as purchases
 arrive. But user preferences don't shift on a per-request basis --
-they shift over weeks or months. If you set ``learning_rate < 1``,
-the amount of forgetting depends on how many observations land in
-each update batch, not how fast tastes actually change. Keep
-``learning_rate=1.0`` and call ``decay()`` on a schedule that matches
-the timescale of change in your environment:
+they shift over weeks or months. If you set ``forgetting=`` on the
+estimator, the amount of forgetting depends on how many observations
+land in each update batch, not how fast tastes actually change. Leave
+it unset and call ``decay()`` on a schedule that matches the
+timescale of change in your environment:
 
 .. code-block:: python
 
@@ -66,7 +68,7 @@ the timescale of change in your environment:
 
 One call is one tick. If the job missed a few days, pass
 ``steps=3`` and the rate is raised to that power. Per-observation
-decay via ``learning_rate < 1`` is usually too aggressive for the
+forgetting through ``forgetting=`` is usually too aggressive for the
 same reason: most real systems make many decisions per natural time
 period (thousands of recommendations per day), and forgetting once
 per observation in that setting tracks traffic, not time.

--- a/docs/howto/delayed-rewards.rst
+++ b/docs/howto/delayed-rewards.rst
@@ -65,7 +65,7 @@ instead of N sequential ones:
 
 The posterior is the same whether you update in one batch or one row
 at a time: the sufficient statistics are identical either way. (With
-``learning_rate < 1``, each row triggers decay, so order matters. See
+``forgetting=`` set, each row is one forgetting step, so order matters. See
 :doc:`decay` for why decoupling decay from updates avoids this.)
 
 

--- a/docs/math/dirichlet-eb.rst
+++ b/docs/math/dirichlet-eb.rst
@@ -122,7 +122,7 @@ Stabilized forgetting
 \boldsymbol{\alpha}_g` drives all concentrations to zero.
 
 **The solution.** Every decay (both explicit via ``decay()`` and
-implicit via ``learning_rate`` in ``partial_fit``) re-injects the
+implicit via ``forgetting=`` in ``partial_fit``) re-injects the
 EB-tuned prior:
 
 .. math::
@@ -173,9 +173,10 @@ Hyperparameter semantics
    * - ``eb_tol``
      - Convergence tolerance on log evidence change.
      - 1e-4 (default).
-   * - ``learning_rate``
-     - Decay factor :math:`\gamma`. See :doc:`/howto/decay`.
-     - 1.0 (default) for stationary environments.
+   * - ``forgetting``
+     - Forgetting rule applied on ``partial_fit``, carrying its rate
+       :math:`\gamma`. See :doc:`/howto/decay`.
+     - ``None`` (default) for stationary environments.
 
 
 Robustness to misspecified priors

--- a/docs/math/empirical-bayes.rst
+++ b/docs/math/empirical-bayes.rst
@@ -312,9 +312,10 @@ Hyperparameter semantics
        iterations.
      - 1e-4 (default). Lower values give tighter convergence at the
        cost of more iterations.
-   * - ``learning_rate``
-     - Decay factor :math:`\gamma`. See :doc:`/howto/decay`.
-     - 1.0 (default) for stationary environments.
+   * - ``forgetting``
+     - Forgetting rule applied on ``partial_fit``, carrying its rate
+       :math:`\gamma`. See :doc:`/howto/decay`.
+     - ``None`` (default) for stationary environments.
    * - ``trace_method``
      - Method for computing
        :math:`\operatorname{tr}(\boldsymbol{\Lambda}^{-1})`.

--- a/docs/math/gamma-eb.rst
+++ b/docs/math/gamma-eb.rst
@@ -136,7 +136,7 @@ Stabilized forgetting
 drives all parameters to zero.
 
 **The solution.** Every decay (both explicit via ``decay()`` and
-implicit via ``learning_rate`` in ``partial_fit``) re-injects the
+implicit via ``forgetting=`` in ``partial_fit``) re-injects the
 EB-tuned prior:
 
 .. math::
@@ -189,9 +189,10 @@ Hyperparameter semantics
    * - ``eb_tol``
      - Convergence tolerance on log evidence change.
      - 1e-4 (default).
-   * - ``learning_rate``
-     - Decay factor :math:`\gamma`. See :doc:`/howto/decay`.
-     - 1.0 (default) for stationary environments.
+   * - ``forgetting``
+     - Forgetting rule applied on ``partial_fit``, carrying its rate
+       :math:`\gamma`. See :doc:`/howto/decay`.
+     - ``None`` (default) for stationary environments.
 
 
 Robustness to misspecified priors

--- a/docs/math/glm-eb.rst
+++ b/docs/math/glm-eb.rst
@@ -245,9 +245,10 @@ Hyperparameter semantics
      - Default ``LaplaceApproximator(n_iter=25, tol=1e-6)``. With
        ``RVGAApproximator`` the precision is an expected rather than
        observed curvature and ``log_evidence_`` is a heuristic.
-   * - ``learning_rate``
-     - Decay factor :math:`\gamma`. See :doc:`/howto/decay`.
-     - 1.0 (default) for stationary environments.
+   * - ``forgetting``
+     - Forgetting rule applied on ``partial_fit``, carrying its rate
+       :math:`\gamma`. See :doc:`/howto/decay`.
+     - ``None`` (default) for stationary environments.
    * - ``trace_method``
      - Method for computing
        :math:`\operatorname{tr}(\boldsymbol{\Lambda}^{-1})`.

--- a/docs/math/glm.rst
+++ b/docs/math/glm.rst
@@ -286,9 +286,10 @@ Hyperparameter semantics
        ``LaplaceApproximator(n_iter=5, tol=1e-4)``.
      - ``RVGAApproximator()`` for better-calibrated uncertainty.
        See the R-VGA section above.
-   * - ``learning_rate``
-     - Decay factor :math:`\gamma`. See :doc:`/howto/decay`.
-     - 1.0 (default) for stationary environments.
+   * - ``forgetting``
+     - Forgetting rule applied on ``partial_fit``, carrying its rate
+       :math:`\gamma`. See :doc:`/howto/decay`.
+     - ``None`` (default) for stationary environments.
 
 
 Trade-offs

--- a/docs/math/normal-inverse-gamma.rst
+++ b/docs/math/normal-inverse-gamma.rst
@@ -200,9 +200,10 @@ Hyperparameter semantics
      - Prior rate of the IG. The prior mean of :math:`\sigma^2` is
        :math:`b/(a-1)` for :math:`a > 1`.
      - 0.1 (default).
-   * - ``learning_rate``
-     - Decay factor :math:`\gamma`. See :doc:`/howto/decay`.
-     - 1.0 (default) for stationary environments.
+   * - ``forgetting``
+     - Forgetting rule applied on ``partial_fit``, carrying its rate
+       :math:`\gamma`. See :doc:`/howto/decay`.
+     - ``None`` (default) for stationary environments.
 
 
 References

--- a/docs/math/normal.rst
+++ b/docs/math/normal.rst
@@ -187,10 +187,11 @@ Hyperparameter semantics
      - Set to :math:`1/\sigma^2` if the noise scale is known.
        Otherwise consider
        :class:`~bayesianbandits.NormalInverseGammaRegressor`.
-   * - ``learning_rate``
-     - Decay factor :math:`\gamma`. Applied per observation during
-       ``partial_fit`` and per row during ``decay``.
-     - 1.0 (default) for stationary environments. See
+   * - ``forgetting``
+     - Forgetting rule applied on ``partial_fit``, one step per row
+       for a uniform rule at rate :math:`\gamma`, or along what the
+       batch excites for a directional one.
+     - ``None`` (default) for stationary environments. See
        :doc:`/howto/decay` for tuning advice.
 
 

--- a/docs/notebooks/empirical-bayes.ipynb
+++ b/docs/notebooks/empirical-bayes.ipynb
@@ -199,7 +199,9 @@
     "\n",
     "# Agent 4: Empirical Bayes + decay (defensive against non-stationarity)\n",
     "eb_decay_agent = make_agent(\n",
-    "    EmpiricalBayesNormalRegressor(alpha=10.0, beta=0.1, forgetting=StabilizedForgetting(0.997)),\n",
+    "    EmpiricalBayesNormalRegressor(\n",
+    "        alpha=10.0, beta=0.1, forgetting=StabilizedForgetting(0.997)\n",
+    "    ),\n",
     "    seed=0,\n",
     ")"
    ]

--- a/docs/notebooks/empirical-bayes.ipynb
+++ b/docs/notebooks/empirical-bayes.ipynb
@@ -124,7 +124,7 @@
     "1. **Default `NormalRegressor`** (`alpha=1.0, beta=1.0`) — reasonable hyperparameters that happen to work okay\n",
     "2. **Misspecified `NormalRegressor`** (`alpha=10.0, beta=0.1`) — tight prior and underestimated noise precision; the model barely updates from data\n",
     "3. **`EmpiricalBayesNormalRegressor`** (`alpha=10.0, beta=0.1`) — same bad initialization, but EB corrects the hyperparameters automatically\n",
-    "4. **`EmpiricalBayesNormalRegressor` + decay** (`learning_rate=0.997`) — same as above, with exponential decay to forget old data. This agent pays a regret cost in the stationary first phase, but after the regime shift it adapts while the others cannot. The estimator uses **stabilized forgetting** (Kulhavý & Zarrop, 1993) to continuously re-inject the EB-tuned prior, preventing it from decaying to zero."
+    "4. **`EmpiricalBayesNormalRegressor` + decay** (`forgetting=StabilizedForgetting(0.997)`) — same as above, forgetting a little on every observation so it can follow a change. This agent pays a regret cost in the stationary first phase, but after the regime shift it adapts while the others cannot. The estimator uses **stabilized forgetting** (Kulhavý & Zarrop, 1993) to continuously re-inject the EB-tuned prior, preventing it from decaying to zero."
    ]
   },
   {
@@ -147,6 +147,7 @@
     "    FunctionArmFeaturizer,\n",
     "    LipschitzContextualAgent,\n",
     "    NormalRegressor,\n",
+    "    StabilizedForgetting,\n",
     "    ThompsonSampling,\n",
     ")\n",
     "\n",
@@ -198,7 +199,7 @@
     "\n",
     "# Agent 4: Empirical Bayes + decay (defensive against non-stationarity)\n",
     "eb_decay_agent = make_agent(\n",
-    "    EmpiricalBayesNormalRegressor(alpha=10.0, beta=0.1, learning_rate=0.997),\n",
+    "    EmpiricalBayesNormalRegressor(alpha=10.0, beta=0.1, forgetting=StabilizedForgetting(0.997)),\n",
     "    seed=0,\n",
     ")"
    ]
@@ -558,7 +559,7 @@
     "\n",
     "- **`alpha` separates them more sharply**, because it depends on the coefficients themselves rather than on the residuals. EB + decay reaches the new value within about 300 rounds. The stationary agent never does: it is at 17.7 by round 5000, less than half of the 37.2 the new regime calls for, because 2500 rounds of phase-1 evidence anchor `||w||^2` near its old value and new data cannot outvote it.\n",
     "\n",
-    "- The EB + decay traces are noisier throughout, reflecting the smaller effective sample size (~330 observations at `learning_rate=0.997`). This is the cost of adaptability."
+    "- The EB + decay traces are noisier throughout, reflecting the smaller effective sample size (~330 observations at rate 0.997). This is the cost of adaptability."
    ]
   },
   {
@@ -593,7 +594,7 @@
     "- The EB-estimated `alpha` always influences new/dormant coefficients\n",
     "- Cold-start features receive the current population-level regularization, not a decayed remnant\n",
     "\n",
-    "The tradeoff is visible in phase 1: EB + decay pays a regret cost compared to stationary EB because its effective sample size is smaller (~200 vs 2500). In practice, the right `learning_rate` depends on your expected rate of environmental change — faster change warrants more aggressive decay.\n",
+    "The tradeoff is visible in phase 1: EB + decay pays a regret cost compared to stationary EB because its effective sample size is smaller (~200 vs 2500). In practice, the right forgetting rate depends on your expected rate of environmental change — faster change warrants more aggressive decay.\n",
     "\n",
     "### Key takeaway\n",
     "\n",

--- a/src/bayesianbandits/__init__.py
+++ b/src/bayesianbandits/__init__.py
@@ -85,8 +85,11 @@ Forgetting Rules
 ================
 
 A forgetting rule says how a posterior widens and carries its own rate.
-The uniform rules are what `decay` applies on a schedule; the directional
-rules forget only along what a batch excited.
+Pass one as an estimator's `forgetting=` to forget on every `partial_fit`,
+for change that happens because you observed, or to `decay` on a
+schedule, for change that happens with time. The uniform rules serve
+both; the directional rules forget only along what a batch excited and
+belong on `forgetting=`.
 
 .. autosummary::
 

--- a/src/bayesianbandits/_blas_helpers.py
+++ b/src/bayesianbandits/_blas_helpers.py
@@ -7,7 +7,13 @@ from typing import Any, Optional, Tuple, Union, cast
 import numpy as np
 from numpy.typing import NDArray
 from scipy.linalg import LinAlgError
-from scipy.linalg.blas import dgemm, dgemv, dsymv, dsyrk  # type: ignore[attr-defined]
+from scipy.linalg.blas import (
+    dgemm,  # type: ignore[attr-defined]
+    dgemv,  # type: ignore[attr-defined]
+    dsymm,  # type: ignore[attr-defined]
+    dsymv,  # type: ignore[attr-defined]
+    dsyrk,  # type: ignore[attr-defined]
+)
 from scipy.linalg.lapack import (
     dgeqrf,  # type: ignore[attr-defined]
     dgeqrf_lwork,  # type: ignore[attr-defined]
@@ -18,6 +24,7 @@ from scipy.sparse import csc_array
 __all__ = [
     "dgemv",
     "dsymv",
+    "dsymm",
     "dsyrk",
     "fortran_view",
     "update_precision_dense",

--- a/src/bayesianbandits/_eb_estimators.py
+++ b/src/bayesianbandits/_eb_estimators.py
@@ -239,11 +239,8 @@ class _StabilizedPriorMixin(_BayesianLinearModel):
         """
         if not hasattr(self, "coef_"):
             return
-        rule, steps, _ = resolve_tick(
-            forgetting,
-            steps=steps,
-            decay_rate=decay_rate,
-            default=self._default_tick_rule,
+        rule = resolve_tick(
+            forgetting, decay_rate=decay_rate, default=self._default_tick_rule
         )
         gamma = rule.rate**steps
         if hasattr(self, "_prior_scalar"):
@@ -274,7 +271,8 @@ class _StabilizedPriorMixin(_BayesianLinearModel):
         check_update_rule(
             self.forgetting, estimator=type(self).__name__, uniform_only=True
         )
-        return uniform_batch(self.forgetting, n_samples, alpha=self.alpha)
+        rule = cast(Optional[UniformRule], self.forgetting)
+        return uniform_batch(rule, n_samples, alpha=self.alpha)
 
     def _restore_prior_scalar(self, prior_scalar_old: Optional[float]) -> None:
         """Put ``_prior_scalar`` back where a failed update found it, and

--- a/src/bayesianbandits/_eb_estimators.py
+++ b/src/bayesianbandits/_eb_estimators.py
@@ -13,18 +13,12 @@ from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import numpy as np
 from numpy.typing import NDArray
-from scipy.linalg import cho_solve
 from scipy.sparse import csc_array
 from sklearn.utils.validation import check_X_y
 from typing_extensions import Self
 
 from ._blas_helpers import (
-    cho_factor_f,
-    compute_eta_dense,
-    dgemv,
     dsymv,
-    fortran_view,
-    update_precision_dense,
 )
 from ._empirical_bayes import (
     accumulate_sufficient_stats,
@@ -44,12 +38,15 @@ from ._estimators import (
     _invalidate_cached_properties,
     compute_effective_weights,
 )
-from ._forgetting import StabilizedForgetting, resolve_tick
+from ._forgetting import (
+    StabilizedForgetting,
+    UniformRule,
+    check_update_rule,
+    resolve_tick,
+    uniform_batch,
+)
 from ._gaussian import LaplaceApproximator, LinkFunction, PosteriorApproximator
-from ._np_utils import groupby_array
 from ._sparse_bayesian_linear_regression import (
-    DenseFactor,
-    PrecisionFactor,
     scale_factor,
 )
 
@@ -129,10 +126,10 @@ class _StabilizedPriorMixin(_BayesianLinearModel):
         online EB step from the running statistics, and corrects the
         precision to the retuned hyperparameters.
 
-        When ``learning_rate < 1``, stabilized forgetting (Kulhavy &
-        Zarrop 1993) re-injects ``(1 - γⁿ)·alpha`` into the precision
-        diagonal so that the prior contribution converges to ``alpha``
-        instead of decaying to zero.
+        Under ``forgetting=StabilizedForgetting(γ)`` the prior
+        contribution is floored at the tuned ``alpha`` (Kulhavy & Zarrop
+        1993): ``(1 - γⁿ)·alpha`` is re-injected into the precision
+        diagonal so it converges to ``alpha`` instead of zero.
 
         Parameters
         ----------
@@ -158,11 +155,11 @@ class _StabilizedPriorMixin(_BayesianLinearModel):
         prior_scalar_old = self.__dict__.get("_prior_scalar")
 
         n_samples = X.shape[0] if hasattr(X, "shape") else len(X)  # type: ignore[arg-type]
-        prior_decay = self.learning_rate**n_samples
+        prior_decay, floor = self._batch_forgetting(n_samples)
 
         if had_prior_scalar:
             self._prior_scalar = (
-                prior_decay * self._prior_scalar + (1 - prior_decay) * self.alpha
+                prior_decay * self._prior_scalar + (1 - prior_decay) * floor
             )
         self._book_update(prior_decay, had_prior_scalar)
         old = self._hyperparams()
@@ -246,7 +243,6 @@ class _StabilizedPriorMixin(_BayesianLinearModel):
             forgetting,
             steps=steps,
             decay_rate=decay_rate,
-            learning_rate=self.learning_rate,
             default=self._default_tick_rule,
         )
         gamma = rule.rate**steps
@@ -266,9 +262,19 @@ class _StabilizedPriorMixin(_BayesianLinearModel):
         self, n_samples: int, sample_weight: Optional[NDArray[Any]]
     ) -> NDArray[np.float64]:
         """The effective row weights the precision is built with: sample
-        weight times within-batch decay. Every EB statistic that is set
-        against the precision has to carry the same weights."""
-        return compute_effective_weights(n_samples, sample_weight, self.learning_rate)
+        weight times within-batch forgetting. Every EB statistic that is
+        set against the precision has to carry the same weights."""
+        rate = 1.0 if self.forgetting is None else self.forgetting.rate
+        return compute_effective_weights(n_samples, sample_weight, rate)
+
+    def _batch_forgetting(self, n_samples: int) -> tuple[float, float]:
+        """``(prior_decay, floor)`` of this batch's forgetting. Only the
+        uniform rules keep the prior a scalar on the diagonal, which the
+        EB step relies on."""
+        check_update_rule(
+            self.forgetting, estimator=type(self).__name__, uniform_only=True
+        )
+        return uniform_batch(self.forgetting, n_samples, alpha=self.alpha)
 
     def _restore_prior_scalar(self, prior_scalar_old: Optional[float]) -> None:
         """Put ``_prior_scalar`` back where a failed update found it, and
@@ -278,30 +284,6 @@ class _StabilizedPriorMixin(_BayesianLinearModel):
             self.__dict__.pop("_prior_scalar", None)
         else:
             self.__dict__["_prior_scalar"] = prior_scalar_old
-
-    def _shift_diagonal(self, cov_inv: csc_array, shift: float) -> None:
-        """``cov_inv += shift * I`` in place.
-
-        The diagonal is always stored (the prior is ``alpha * I``), so
-        its positions, found once per pattern by running ``diagonal()``
-        over entry numbers and cached against the index array's
-        identity, make this a gather-add; ``setdiag`` relocates it on
-        every call.
-        """
-        if shift == 0.0:
-            return
-        cached = self.__dict__.get("_diag_pos")
-        if cached is None or cached[0] is not cov_inv.indices:
-            values = cov_inv.data
-            cov_inv.data = np.arange(1, values.size + 1, dtype=np.float64)
-            pos = cov_inv.diagonal().astype(np.intp) - 1
-            cov_inv.data = values
-            if np.any(pos < 0):  # missing diagonal entry: let scipy insert it
-                cov_inv.setdiag(cov_inv.diagonal() + shift)
-                return
-            cached = (cov_inv.indices, pos)
-            self._diag_pos = cached
-        cov_inv.data[cached[1]] += shift
 
 
 class EmpiricalBayesNormalRegressor(_StabilizedPriorMixin, NormalRegressor):
@@ -314,10 +296,10 @@ class EmpiricalBayesNormalRegressor(_StabilizedPriorMixin, NormalRegressor):
     likelihood. During ``partial_fit``, a single online MacKay step is
     performed using accumulated sufficient statistics.
 
-    When ``learning_rate < 1``, exponential forgetting is applied to the
-    precision matrix. To prevent the prior contribution from collapsing
-    to zero under repeated decay, *stabilized forgetting* [2]_ re-injects
-    a fixed prior floor after each decay step.
+    Forgetting, on ``partial_fit`` through ``forgetting=`` and on the
+    clock through ``decay``, defaults to *stabilized forgetting* [2]_:
+    the prior contribution is floored at the tuned ``alpha`` instead of
+    collapsing to zero under repeated decay.
 
     Parameters
     ----------
@@ -342,11 +324,12 @@ class EmpiricalBayesNormalRegressor(_StabilizedPriorMixin, NormalRegressor):
     eb_tol : float, default=1e-4
         Convergence tolerance on the change in log marginal likelihood
         between successive EB iterations.
-    learning_rate : float, default=1.0
-        Decay rate for sequential updates. Values less than 1
-        geometrically shrink the precision matrix on each call to
-        ``decay`` or ``partial_fit``, enabling adaptation to
-        non-stationary environments.
+    forgetting : ExponentialForgetting or StabilizedForgetting, optional
+        Forgetting applied on every ``partial_fit`` before the batch is
+        absorbed, one step per row, for change that happens because you
+        observed; ``StabilizedForgetting`` floors at the tuned prior.
+        ``None`` (default) forgets nothing. Forgetting with time is
+        ``decay``.
     sparse : bool, default=False
         If True, use sparse matrix operations for the precision matrix.
         Input ``X`` must be a ``scipy.sparse.csc_array``. When CHOLMOD
@@ -458,7 +441,7 @@ class EmpiricalBayesNormalRegressor(_StabilizedPriorMixin, NormalRegressor):
     Online learning with forgetting for non-stationary environments:
 
     >>> model = EmpiricalBayesNormalRegressor(
-    ...     learning_rate=0.99, random_state=42
+    ...     forgetting=StabilizedForgetting(0.99), random_state=42
     ... )
     >>> for i in range(10):  # doctest: +SKIP
     ...     X_batch = rng.standard_normal((5, 3))
@@ -474,7 +457,7 @@ class EmpiricalBayesNormalRegressor(_StabilizedPriorMixin, NormalRegressor):
         alpha_prior_strength: float = 0.2,
         n_eb_iter: int = 10,
         eb_tol: float = 1e-4,
-        learning_rate: float = 1.0,
+        forgetting: Optional[UniformRule] = None,
         sparse: bool = False,
         random_state: Union[int, np.random.Generator, None] = None,
         trace_method: str = "auto",
@@ -482,7 +465,7 @@ class EmpiricalBayesNormalRegressor(_StabilizedPriorMixin, NormalRegressor):
         super().__init__(
             alpha=alpha,
             beta=beta,
-            learning_rate=learning_rate,
+            forgetting=forgetting,
             sparse=sparse,
             random_state=random_state,
         )
@@ -623,7 +606,7 @@ class EmpiricalBayesNormalRegressor(_StabilizedPriorMixin, NormalRegressor):
             accept_sparse="csc" if self.sparse else False,
         )
 
-        prior_decay = self.learning_rate ** y.shape[0]
+        prior_decay, _ = self._batch_forgetting(y.shape[0])
 
         self.eb_updates_rejected_ = 0
 
@@ -781,127 +764,32 @@ class EmpiricalBayesNormalRegressor(_StabilizedPriorMixin, NormalRegressor):
         else:
             self.cov_inv_ *= ratio
 
-    @_invalidate_cached_properties
     def _fit_helper(
         self,
         X: Union[NDArray[Any], csc_array],
         y: NDArray[Any],
         sample_weight: Optional[NDArray[Any]] = None,
-    ) -> None:  # type: ignore[override]
-        """Override to fold prior reinjection into precision construction,
-        and to take the prior information vector from ``partial_fit``.
-
-        When ``_pending_reinjection > 0``, adds ``(1 - γ) · α · I`` to
-        the precision during the decay + data update.  This means the
-        factorization for the linear solve already reflects the
-        reinjected prior — no separate ``_reinject_prior`` call or
-        refactorization needed.
-
-        When ``_pending_prior_eta`` is set, a MacKay correction left the
-        posterior mean unsolved (see the ``coef_`` property) and handed
-        the information vector here instead.  ``Λ·coef_`` is exactly
-        that vector, so using it skips both the deferred solve and the
-        matvec that would undo it.
-        """
-        reinjection = getattr(self, "_pending_reinjection", 0.0)
-        pending_eta = getattr(self, "_pending_prior_eta", None)
+        *,
+        pending_eta: Optional[NDArray[np.float64]] = None,
+    ) -> None:
+        """Take the prior information vector from ``partial_fit`` when a
+        MacKay correction left the posterior mean unsolved (see the
+        ``coef_`` property): ``Λ·coef_`` is exactly that vector, so using
+        it skips both the deferred solve and the matvec that would undo
+        it."""
+        if pending_eta is None:
+            pending_eta = getattr(self, "_pending_prior_eta", None)
         # Consumed here, so partial_fit can tell an update that raised
         # before this point from one that used the vector.
         self._pending_prior_eta = None
-        if reinjection == 0.0 and pending_eta is None:
-            # Nothing to fold in — delegate to base class.
-            super()._fit_helper(X, y, sample_weight)
-            return
-
-        # -- Below: base class logic with reinjection folded in --
-
-        if self.sparse:
-            X = csc_array(X)
-
-        assert X.shape is not None
-
-        if sample_weight is None:
-            sample_weight = np.ones(X.shape[0], dtype=np.float64)
-        else:
-            sample_weight = np.asarray(sample_weight, dtype=np.float64)
-
-        effective_weights = compute_effective_weights(
-            X.shape[0], sample_weight, self.learning_rate
-        )
-
-        prior_decay = self.learning_rate ** X.shape[0]
-
-        y_weighted = y * effective_weights
-
-        if self.sparse:
-            # Element-wise scaling; absorb beta into weights
-            assert isinstance(X, csc_array)
-            w_sqrt = np.sqrt(self.beta * effective_weights)
-            X_weighted = X.multiply(w_sqrt.reshape(-1, 1)).tocsc()
-            prior = cast(csc_array, self.cov_inv_)
-            if prior_decay != 1.0:
-                # New data array, not in-place: leaves cov_inv_ untouched if the solve below fails.
-                prior = csc_array(
-                    (prior.data * prior_decay, prior.indices, prior.indptr),
-                    shape=prior.shape,
-                )
-            prior_eta = (
-                prior @ self.coef_ if pending_eta is None else prior_decay * pending_eta
-            )
-            cov_inv = cast(csc_array, prior + X_weighted.T @ X_weighted)
-            self._shift_diagonal(cov_inv, reinjection)
-            eta = cast(NDArray[np.float64], prior_eta + X.T @ (self.beta * y_weighted))
-            factor: PrecisionFactor = self._sparse_factor(cov_inv)
-            coef = factor.solve(eta)
-            self._precision_factor = factor
-        else:
-            assert isinstance(X, np.ndarray)
-            w_sqrt = np.sqrt(effective_weights)
-            X_weighted = X * w_sqrt[:, np.newaxis]
-            if pending_eta is None:
-                eta = compute_eta_dense(
-                    prior_decay, self.cov_inv_, self.coef_, self.beta, X, y_weighted
-                )
-            else:
-                # As compute_eta_dense, but dgemv accumulates onto the already-done dsymv term.
-                XF, xt = fortran_view(X)
-                eta = dgemv(
-                    self.beta,
-                    XF,
-                    y_weighted,
-                    trans=1 - xt,
-                    beta=1.0,
-                    y=prior_decay * pending_eta,
-                    overwrite_y=True,
-                )
-            # Copy, not a view: dsyrk below writes this buffer, so aliasing cov_inv_
-            # would corrupt it before cho_factor gets a chance to reject the update.
-            prior_scaled = np.array(self.cov_inv_, order="F", copy=True)
-            if prior_decay != 1.0:
-                prior_scaled *= prior_decay
-            if reinjection != 0.0:
-                diag_idx = np.diag_indices_from(prior_scaled)
-                prior_scaled[diag_idx] += reinjection
-            # Fused X^T W X + prior via dsyrk (upper triangle only)
-            cov_inv = update_precision_dense(self.beta, X_weighted, prior_scaled)
-            # Cache the Cholesky factor for reuse in cov_/sample
-            cho = cho_factor_f(cov_inv)
-            self._precision_factor = DenseFactor(_U=cho[0], _n_features=cho[0].shape[0])
-            coef = cho_solve(cho, eta, check_finite=False)
-
-        self.cov_inv_ = cov_inv
-        self.coef_ = coef
+        super()._fit_helper(X, y, sample_weight, pending_eta=pending_eta)
 
     def _book_update(self, prior_decay: float, had_prior_scalar: bool) -> None:
-        # Folded into _fit_helper's precision build; the pending eta is popped
-        # here, before super()'s check_is_fitted would read coef_ and force it.
-        self._pending_reinjection = (
-            (1 - prior_decay) * self.alpha if had_prior_scalar else 0.0
-        )
+        # The pending eta is popped here, before super()'s check_is_fitted
+        # would read coef_ and force it.
         self._pending_prior_eta = self.__dict__.pop("_pending_eta", None)
 
     def _unbook_update(self) -> None:
-        self._pending_reinjection = 0.0
         if self._pending_prior_eta is not None:
             # The update raised before _fit_helper consumed it; hand it
             # back so coef_ stays solvable and the correction is not
@@ -947,10 +835,10 @@ class EmpiricalBayesGLM(_StabilizedPriorMixin, BayesianGLM):
     the mode, so the fixed point sits near, not at, the evidence
     maximum (within a few percent in practice).
 
-    When ``learning_rate < 1``, stabilized forgetting [2]_ re-injects
-    ``(1 - γⁿ)·alpha`` onto the precision diagonal after each decay so
-    the prior's contribution converges to ``alpha`` instead of
-    vanishing, which keeps ``alpha`` tuning load-bearing indefinitely.
+    Under stabilized forgetting [2]_, ``(1 - γⁿ)·alpha`` is re-injected
+    onto the precision diagonal after each forget so the prior's
+    contribution converges to ``alpha`` instead of vanishing, which
+    keeps ``alpha`` tuning load-bearing indefinitely.
 
     Parameters
     ----------
@@ -967,8 +855,12 @@ class EmpiricalBayesGLM(_StabilizedPriorMixin, BayesianGLM):
     eb_tol : float, default=1e-4
         Convergence tolerance on the change in log evidence between
         successive EB iterations.
-    learning_rate : float, default=1.0
-        Decay rate for sequential updates; see :class:`BayesianGLM`.
+    forgetting : ExponentialForgetting or StabilizedForgetting, optional
+        Forgetting applied on every ``partial_fit`` before the batch is
+        absorbed, one step per row, for change that happens because you
+        observed; ``StabilizedForgetting`` floors at the tuned prior.
+        ``None`` (default) forgets nothing. Forgetting with time is
+        ``decay``.
     approximator : PosteriorApproximator, optional
         Defaults to ``LaplaceApproximator(n_iter=25, tol=1e-6)`` rather
         than the base class's 5 fixed iterations: the evidence is only
@@ -1024,7 +916,7 @@ class EmpiricalBayesGLM(_StabilizedPriorMixin, BayesianGLM):
         alpha_prior_strength: float = 0.2,
         n_eb_iter: int = 10,
         eb_tol: float = 1e-4,
-        learning_rate: float = 1.0,
+        forgetting: Optional[UniformRule] = None,
         approximator: Optional[PosteriorApproximator] = None,
         sparse: bool = False,
         random_state: Union[int, np.random.Generator, None] = None,
@@ -1033,7 +925,7 @@ class EmpiricalBayesGLM(_StabilizedPriorMixin, BayesianGLM):
         super().__init__(
             alpha=alpha,
             link=link,
-            learning_rate=learning_rate,
+            forgetting=forgetting,
             approximator=approximator,
             sparse=sparse,
             random_state=random_state,
@@ -1118,9 +1010,8 @@ class EmpiricalBayesGLM(_StabilizedPriorMixin, BayesianGLM):
             accept_sparse="csc" if self.sparse else False,
         )
 
-        prior_decay = self.learning_rate ** y.shape[0]
+        prior_decay, _ = self._batch_forgetting(y.shape[0])
         self.eb_updates_rejected_ = 0
-        self._pending_floor = 0.0
         effective_n = float(np.sum(self._row_weights(y.shape[0], sample_weight)))
 
         self._initialize_prior(X_fit)
@@ -1194,12 +1085,6 @@ class EmpiricalBayesGLM(_StabilizedPriorMixin, BayesianGLM):
             self._drop_factor()
         self.coef_ = self._precision_factor.solve(data_eta)
 
-    def _book_update(self, prior_decay: float, had_prior_scalar: bool) -> None:
-        self._pending_floor = self.alpha if had_prior_scalar else 0.0
-
-    def _unbook_update(self) -> None:
-        self._pending_floor = 0.0
-
     def _hyperparams(self) -> tuple[float]:
         return (self.alpha,)
 
@@ -1247,9 +1132,8 @@ class EmpiricalBayesDirichletClassifier(DirichletClassifier):
     measure (prior shape). The ``m`` and ``s`` updates are alternated
     for faster convergence.
 
-    When ``learning_rate < 1``, exponential forgetting is applied.
-    Stabilized forgetting re-injects the EB-tuned prior after each
-    decay step, ensuring the prior contribution converges to the tuned
+    Forgetting defaults to stabilized: the EB-tuned prior is re-injected
+    after each forget, so the prior contribution converges to the tuned
     value rather than zero.
 
     Parameters
@@ -1260,8 +1144,12 @@ class EmpiricalBayesDirichletClassifier(DirichletClassifier):
         Maximum number of EB iterations during ``fit``.
     eb_tol : float, default=1e-4
         Convergence tolerance on change in log marginal likelihood.
-    learning_rate : float, default=1.0
-        Decay rate for sequential updates.
+    forgetting : ExponentialForgetting or StabilizedForgetting, optional
+        Forgetting applied on every ``partial_fit`` before the batch is
+        absorbed, one step per row, for change that happens because you
+        observed; ``StabilizedForgetting`` floors at the tuned prior.
+        ``None`` (default) forgets nothing. Forgetting with time is
+        ``decay``.
     random_state : int, np.random.Generator, or None, default=None
         Controls RNG for ``sample``.
 
@@ -1299,9 +1187,8 @@ class EmpiricalBayesDirichletClassifier(DirichletClassifier):
 
     **Stabilized forgetting**
 
-    Every time ``learning_rate`` :math:`\\gamma < 1` causes decay
-    (both in ``partial_fit`` and in ``decay``), the prior is
-    re-injected:
+    Every forget at rate :math:`\\gamma` (``forgetting=`` in
+    ``partial_fit`` and ``decay``) re-injects the prior:
 
     .. math::
 
@@ -1354,58 +1241,16 @@ class EmpiricalBayesDirichletClassifier(DirichletClassifier):
         *,
         n_eb_iter: int = 10,
         eb_tol: float = 1e-4,
-        learning_rate: float = 1.0,
+        forgetting: Optional[UniformRule] = None,
         random_state: Union[int, np.random.Generator, None] = None,
     ) -> None:
         super().__init__(
             alphas=alphas,
-            learning_rate=learning_rate,
+            forgetting=forgetting,
             random_state=random_state,
         )
         self.n_eb_iter = n_eb_iter
         self.eb_tol = eb_tol
-
-    def _fit_helper(
-        self,
-        X: NDArray[Any],
-        y: NDArray[Any],
-        sample_weight: Optional[NDArray[Any]],
-    ) -> None:
-        """Override to add stabilized prior re-injection after decay.
-
-        The base class ``_fit_helper`` decays the existing posterior by
-        ``learning_rate ** n_obs`` when stacking with new observations,
-        but does not re-inject the prior. Without re-injection the prior
-        contribution decays toward zero, breaking the invariant
-        ``known_alphas_[g] - prior_ = decayed_counts``.
-        """
-        if sample_weight is None:
-            sample_weight = np.ones(X.shape[0], dtype=np.float64)
-        else:
-            sample_weight = np.asarray(sample_weight, dtype=np.float64)
-            if sample_weight.shape[0] != X.shape[0]:
-                raise ValueError(
-                    f"sample_weight.shape[0]={sample_weight.shape[0]} should be "
-                    f"equal to X.shape[0]={X.shape[0]}"
-                )
-
-        for group, arr, weights in groupby_array(X[:, 0], y, sample_weight, by=X[:, 0]):
-            key = group[0].item()
-
-            weighted_arr = arr * weights[:, np.newaxis]
-
-            vals = np.vstack((self.known_alphas_[key], weighted_arr))
-
-            decay_idx = np.flip(np.arange(len(vals)))
-            posterior = vals * (self.learning_rate**decay_idx)[:, np.newaxis]
-
-            # Stabilized forgetting: the prior was decayed by lr^n_obs,
-            # reinject (1 - lr^n_obs) * prior so the prior contribution
-            # converges to prior_ instead of zero.
-            n_obs = len(arr)
-            reinjection = (1 - self.learning_rate**n_obs) * self.prior_
-
-            self.known_alphas_[key] = posterior.sum(axis=0) + reinjection
 
     def fit(
         self,
@@ -1551,9 +1396,8 @@ class EmpiricalBayesGammaRegressor(GammaRegressor):
     for the shared prior, using the generalized Newton method for the
     shape parameter [1]_.
 
-    When ``learning_rate < 1``, exponential forgetting is applied.
-    Stabilized forgetting re-injects the EB-tuned prior after each
-    decay step, ensuring the prior contribution converges to the tuned
+    Forgetting defaults to stabilized: the EB-tuned prior is re-injected
+    after each forget, so the prior contribution converges to the tuned
     value rather than zero.
 
     Parameters
@@ -1566,8 +1410,12 @@ class EmpiricalBayesGammaRegressor(GammaRegressor):
         Maximum number of EB iterations during ``fit``.
     eb_tol : float, default=1e-4
         Convergence tolerance on change in log marginal likelihood.
-    learning_rate : float, default=1.0
-        Decay rate for sequential updates.
+    forgetting : ExponentialForgetting or StabilizedForgetting, optional
+        Forgetting applied on every ``partial_fit`` before the batch is
+        absorbed, one step per row, for change that happens because you
+        observed; ``StabilizedForgetting`` floors at the tuned prior.
+        ``None`` (default) forgets nothing. Forgetting with time is
+        ``decay``.
     random_state : int, np.random.Generator, or None, default=None
         Controls RNG for ``sample``.
 
@@ -1630,8 +1478,8 @@ class EmpiricalBayesGammaRegressor(GammaRegressor):
 
     **Stabilized forgetting**
 
-    Every time ``learning_rate`` :math:`\\gamma < 1` causes decay,
-    the prior is re-injected:
+    Every forget at rate :math:`\\gamma` (``forgetting=`` in
+    ``partial_fit`` and ``decay``) re-injects the prior:
 
     .. math::
 
@@ -1671,62 +1519,17 @@ class EmpiricalBayesGammaRegressor(GammaRegressor):
         *,
         n_eb_iter: int = 10,
         eb_tol: float = 1e-4,
-        learning_rate: float = 1.0,
+        forgetting: Optional[UniformRule] = None,
         random_state: Union[int, np.random.Generator, None] = None,
     ) -> None:
         super().__init__(
             alpha=alpha,
             beta=beta,
-            learning_rate=learning_rate,
+            forgetting=forgetting,
             random_state=random_state,
         )
         self.n_eb_iter = n_eb_iter
         self.eb_tol = eb_tol
-
-    def _fit_helper(
-        self,
-        X: NDArray[Any],
-        y: NDArray[Any],
-        sample_weight: Optional[NDArray[Any]],
-    ) -> None:
-        """Override to add stabilized prior re-injection after decay.
-
-        The base class ``_fit_helper`` decays the existing posterior by
-        ``learning_rate ** n_obs`` when stacking with new observations,
-        but does not re-inject the prior. Without re-injection the prior
-        contribution decays toward zero, breaking the invariant
-        ``coef_[g] - prior_ = decayed_counts``.
-        """
-        if sample_weight is None:
-            sample_weight = np.ones(X.shape[0], dtype=np.float64)
-        else:
-            sample_weight = np.asarray(sample_weight, dtype=np.float64)
-            if sample_weight.shape[0] != X.shape[0]:
-                raise ValueError(
-                    f"sample_weight.shape[0]={sample_weight.shape[0]} should be "
-                    f"equal to X.shape[0]={X.shape[0]}"
-                )
-
-        lr = self.learning_rate
-        no_decay = lr == 1.0
-
-        for group, arr, weights in groupby_array(X[:, 0], y, sample_weight, by=X[:, 0]):
-            key = group[0].item()
-
-            weighted_counts = arr * weights
-            weighted_data = np.column_stack((weighted_counts, weights))
-
-            if no_decay:
-                self.coef_[key] = self.coef_[key] + weighted_data.sum(axis=0)
-            else:
-                n_obs = len(arr)
-                decay_factor = lr**n_obs
-                data_weights = lr ** np.arange(n_obs - 1, -1, -1)
-                data_contribution = data_weights @ weighted_data
-                reinjection = (1 - decay_factor) * self.prior_
-                self.coef_[key] = (
-                    decay_factor * self.coef_[key] + data_contribution + reinjection
-                )
 
     def fit(
         self,

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -1367,13 +1367,9 @@ class _BayesianLinearModel(MemoryUsageMixin, BaseEstimator):
             X_w: Any = csc_array(X).multiply(w_sqrt.reshape(-1, 1)).tocsc()
         else:
             X_w = np.asarray(X) * w_sqrt[:, np.newaxis]
-        current = self.cov_inv_
-        if not issparse(current):
-            # The dense paths keep only the upper triangle current; a
-            # directional rule reads the whole matrix.
-            upper = np.triu(np.asarray(current))
-            current = upper + np.triu(upper, 1).T
-        result = rule.update(current, X_w, y * w_sqrt, alpha=self._prior_floor())
+        # The dense paths keep only the upper triangle current, and the
+        # rules read and write on that convention (dsymm/dsyrk).
+        result = rule.update(self.cov_inv_, X_w, y * w_sqrt, alpha=self._prior_floor())
         prior = self.cov_inv_ if result is None else result[0]
         return prior, 1.0, weights, 0.0
 

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -50,9 +50,14 @@ from ._blas_helpers import (
 )
 from ._forgetting import (
     ExponentialForgetting,
+    StabilizedForgetting,
     TickRule,
+    UniformRule,
+    UpdateRule,
+    check_update_rule,
     resolve_tick,
     tick_groups,
+    uniform_batch,
 )
 from ._gaussian import (
     LaplaceApproximator,
@@ -76,6 +81,20 @@ ReturnType = TypeVar("ReturnType")
 SelfType = TypeVar("SelfType", bound="NormalRegressor | BayesianGLM")
 
 
+def _grouped_batch(
+    rule: Any, prior: NDArray[np.float64], estimator: str
+) -> tuple[float, Any]:
+    """``(rate, floor)`` for a grouped conjugate model's batch: each row of
+    a group is one step of the rule, so the group's prior is scaled by
+    ``rate ** n`` and ``(1 - rate ** n) * floor`` added back."""
+    check_update_rule(rule, estimator=estimator, uniform_only=True)
+    if rule is None:
+        return 1.0, 0.0
+    if isinstance(rule, StabilizedForgetting):
+        return rule.rate, prior if rule.alpha is None else rule.alpha
+    return rule.rate, 0.0
+
+
 class DirichletClassifier(MemoryUsageMixin, BaseEstimator, ClassifierMixin):
     """
     Intercept-only Dirichlet-Multinomial classifier.
@@ -92,12 +111,11 @@ class DirichletClassifier(MemoryUsageMixin, BaseEstimator, ClassifierMixin):
         the set of classes; values are the initial Dirichlet
         :math:`\\alpha_k`. A uniform prior (e.g. ``{0: 1, 1: 1}``)
         encodes no prior preference.
-    learning_rate : float, default=1.0
-        Decay rate for the concentration parameters. Values less
-        than 1 geometrically shrink the posterior on each call to
-        ``decay``, increasing uncertainty over time. This converts
-        the model into a forgetting estimator suitable for restless
-        bandit problems.
+    forgetting : ExponentialForgetting or StabilizedForgetting, optional
+        Forgetting applied on every ``partial_fit`` before the batch is
+        absorbed, one step per row, for change that happens because you
+        observed. ``None`` (default) forgets nothing. Forgetting with
+        time is ``decay``.
     random_state : int, np.random.Generator, or None, default=None
         Controls the random number generator for ``sample``. Pass an
         int for reproducible results across calls.
@@ -141,9 +159,8 @@ class DirichletClassifier(MemoryUsageMixin, BaseEstimator, ClassifierMixin):
 
         \\mathbb{E}[\\theta_k] = \\frac{\\alpha_k}{\\sum_j \\alpha_j}
 
-    When ``learning_rate < 1``, calling ``decay`` scales all
-    concentration parameters by the decay rate, uniformly increasing
-    posterior uncertainty.
+    Calling ``decay`` scales all concentration parameters by the
+    rule's rate, uniformly increasing posterior uncertainty.
 
     References
     ----------
@@ -177,11 +194,11 @@ class DirichletClassifier(MemoryUsageMixin, BaseEstimator, ClassifierMixin):
         self,
         alphas: Dict[Union[int, str], float],
         *,
-        learning_rate: float = 1.0,
+        forgetting: Optional[UniformRule] = None,
         random_state: Union[int, np.random.Generator, None] = None,
     ) -> None:
         self.alphas = alphas
-        self.learning_rate = learning_rate
+        self.forgetting = forgetting
         self.random_state = random_state
 
     def fit(
@@ -308,6 +325,7 @@ class DirichletClassifier(MemoryUsageMixin, BaseEstimator, ClassifierMixin):
                 )
 
         # Group X values, y, and sample weights together
+        rate, floor = _grouped_batch(self.forgetting, self.prior_, type(self).__name__)
         for group, arr, weights in groupby_array(X[:, 0], y, sample_weight, by=X[:, 0]):
             key = group[0].item()
 
@@ -317,10 +335,11 @@ class DirichletClassifier(MemoryUsageMixin, BaseEstimator, ClassifierMixin):
             # Stack with prior
             vals = np.vstack((self.known_alphas_[key], weighted_arr))
 
-            # Apply learning rate decay
             decay_idx = np.flip(np.arange(len(vals)))
-            posterior = vals * (self.learning_rate**decay_idx)[:, np.newaxis]
-            self.known_alphas_[key] = posterior.sum(axis=0)
+            posterior = vals * (rate**decay_idx)[:, np.newaxis]
+            self.known_alphas_[key] = (
+                posterior.sum(axis=0) + (1 - rate ** len(arr)) * floor
+            )
 
     def predict_proba(self, X: NDArray[Any]) -> Any:
         """
@@ -422,6 +441,13 @@ class DirichletClassifier(MemoryUsageMixin, BaseEstimator, ClassifierMixin):
 
     _default_tick_rule: type = ExponentialForgetting
 
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        # Models pickled before ``forgetting=`` carried ``learning_rate``.
+        rate = state.pop("learning_rate", None)
+        if rate is not None and "forgetting" not in state:
+            state["forgetting"] = None if rate == 1.0 else self._default_tick_rule(rate)
+        super().__setstate__(state)
+
     def decay(
         self,
         forgetting: Any = None,
@@ -461,7 +487,6 @@ class DirichletClassifier(MemoryUsageMixin, BaseEstimator, ClassifierMixin):
             forgetting,
             steps=steps,
             decay_rate=decay_rate,
-            learning_rate=self.learning_rate,
             prior=self.prior_,
             default=self._default_tick_rule,
         )
@@ -490,12 +515,11 @@ class GammaRegressor(MemoryUsageMixin, BaseEstimator, RegressorMixin):
         ``alpha``, determines the prior mean
         :math:`\\mathbb{E}[\\lambda] = \\alpha / \\beta` and prior
         variance :math:`\\text{Var}[\\lambda] = \\alpha / \\beta^2`.
-    learning_rate : float, default=1.0
-        Decay rate for the posterior parameters. Values less than 1
-        geometrically shrink both :math:`\\alpha` and :math:`\\beta`
-        on each call to ``decay``, increasing posterior variance
-        while preserving the mean. This converts the model into a
-        forgetting estimator suitable for restless bandit problems.
+    forgetting : ExponentialForgetting or StabilizedForgetting, optional
+        Forgetting applied on every ``partial_fit`` before the batch is
+        absorbed, one step per row, for change that happens because you
+        observed. ``None`` (default) forgets nothing. Forgetting with
+        time is ``decay``.
     random_state : int, np.random.Generator, or None, default=None
         Controls the random number generator for ``sample``. Pass an
         int for reproducible results across calls.
@@ -535,9 +559,9 @@ class GammaRegressor(MemoryUsageMixin, BaseEstimator, RegressorMixin):
     posterior variance is
     :math:`\\text{Var}[\\lambda] = \\alpha / \\beta^2`.
 
-    When ``learning_rate < 1``, calling ``decay`` scales both
-    :math:`\\alpha` and :math:`\\beta` equally, so the posterior
-    mean is preserved but the variance increases.
+    Calling ``decay`` scales both :math:`\\alpha` and :math:`\\beta`
+    equally, so the posterior mean is preserved but the variance
+    increases.
 
     References
     ----------
@@ -572,12 +596,12 @@ class GammaRegressor(MemoryUsageMixin, BaseEstimator, RegressorMixin):
         alpha: float,
         beta: float,
         *,
-        learning_rate: float = 1.0,
+        forgetting: Optional[UniformRule] = None,
         random_state: Union[int, np.random.Generator, None] = None,
     ) -> None:
         self.alpha = alpha
         self.beta = beta
-        self.learning_rate = learning_rate
+        self.forgetting = forgetting
         self.random_state = random_state
 
     def fit(
@@ -656,6 +680,7 @@ class GammaRegressor(MemoryUsageMixin, BaseEstimator, RegressorMixin):
                 )
 
         # Group X values, y, and sample weights together
+        rate, floor = _grouped_batch(self.forgetting, self.prior_, type(self).__name__)
         for group, arr, weights in groupby_array(X[:, 0], y, sample_weight, by=X[:, 0]):
             key = group[0].item()
 
@@ -666,12 +691,9 @@ class GammaRegressor(MemoryUsageMixin, BaseEstimator, RegressorMixin):
 
             vals = np.vstack((self.coef_[key], weighted_data))
 
-            # Calculate the decay index for nonstationary models
             decay_idx = np.flip(np.arange(len(vals)))
-            # Calculate the posterior
-            posterior = vals * (self.learning_rate**decay_idx)[:, np.newaxis]
-            # Calculate the coefficient
-            self.coef_[key] = posterior.sum(axis=0)
+            posterior = vals * (rate**decay_idx)[:, np.newaxis]
+            self.coef_[key] = posterior.sum(axis=0) + (1 - rate ** len(arr)) * floor
 
     def partial_fit(
         self,
@@ -793,6 +815,13 @@ class GammaRegressor(MemoryUsageMixin, BaseEstimator, RegressorMixin):
 
     _default_tick_rule: type = ExponentialForgetting
 
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        # Models pickled before ``forgetting=`` carried ``learning_rate``.
+        rate = state.pop("learning_rate", None)
+        if rate is not None and "forgetting" not in state:
+            state["forgetting"] = None if rate == 1.0 else self._default_tick_rule(rate)
+        super().__setstate__(state)
+
     def decay(
         self,
         forgetting: Any = None,
@@ -834,7 +863,6 @@ class GammaRegressor(MemoryUsageMixin, BaseEstimator, RegressorMixin):
             forgetting,
             steps=steps,
             decay_rate=decay_rate,
-            learning_rate=self.learning_rate,
             prior=self.prior_,
             default=self._default_tick_rule,
         )
@@ -1273,7 +1301,7 @@ class _BayesianLinearModel(MemoryUsageMixin, BaseEstimator):
         # Read here, owned elsewhere: the concrete ``__init__`` sets the
         # hyperparameters and ``_initialize_prior`` the generator.
         alpha: float
-        learning_rate: float
+        forgetting: Optional[UpdateRule]
         sparse: bool
         random_state: Union[int, np.random.Generator, None]
         random_state_: np.random.Generator
@@ -1296,6 +1324,82 @@ class _BayesianLinearModel(MemoryUsageMixin, BaseEstimator):
         return eta
 
     _default_tick_rule: type = ExponentialForgetting
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        # Models pickled before ``forgetting=`` carried ``learning_rate``.
+        rate = state.pop("learning_rate", None)
+        if rate is not None and "forgetting" not in state:
+            state["forgetting"] = None if rate == 1.0 else self._default_tick_rule(rate)
+        super().__setstate__(state)
+
+    def _forget_batch(
+        self,
+        X: Union[NDArray[Any], csc_array],
+        y: NDArray[Any],
+        sample_weight: Optional[NDArray[Any]],
+    ) -> tuple[Any, float, NDArray[np.float64], float]:
+        """Forget before absorbing a batch, per ``self.forgetting``.
+
+        Returns ``(prior, prior_decay, weights, floor)``: the prior
+        precision to update from, a scalar it is still to be multiplied
+        by, the effective row weights, and the precision a stabilized
+        rule floors at (``(1 - prior_decay) * floor`` goes on the
+        diagonal). A uniform rule counts each row as one step, so
+        ``prior_decay = rate ** n`` and older rows of the batch weigh
+        less; a directional rule returns its own forgotten precision
+        with ``prior_decay = 1``. A fresh prior, from ``fit`` or a first
+        ``sample``, is never floored: nothing has been forgotten yet.
+        """
+        rule = self.forgetting
+        check_update_rule(rule, estimator=type(self).__name__, sparse=self.sparse)
+        assert X.shape is not None
+        n = X.shape[0]
+        if rule is None or isinstance(rule, TickRule):
+            gamma, floor = uniform_batch(rule, n, alpha=self._prior_floor())
+            if getattr(self, "_prior_is_fresh", False):
+                floor = 0.0
+            rate = 1.0 if rule is None else rule.rate
+            weights = compute_effective_weights(n, sample_weight, rate)
+            return self.cov_inv_, gamma, weights, floor
+        weights = compute_effective_weights(n, sample_weight, 1.0)
+        w_sqrt = np.sqrt(weights)
+        if issparse(X):
+            X_w: Any = csc_array(X).multiply(w_sqrt.reshape(-1, 1)).tocsc()
+        else:
+            X_w = np.asarray(X) * w_sqrt[:, np.newaxis]
+        current = self.cov_inv_
+        if not issparse(current):
+            # The dense paths keep only the upper triangle current; a
+            # directional rule reads the whole matrix.
+            upper = np.triu(np.asarray(current))
+            current = upper + np.triu(upper, 1).T
+        result = rule.update(current, X_w, y * w_sqrt, alpha=self._prior_floor())
+        prior = self.cov_inv_ if result is None else result[0]
+        return prior, 1.0, weights, 0.0
+
+    def _shift_diagonal(self, cov_inv: csc_array, shift: float) -> None:
+        """``cov_inv += shift * I`` in place.
+
+        The diagonal is always stored (the prior is ``alpha * I``), so
+        its positions, found once per pattern by running ``diagonal()``
+        over entry numbers and cached against the index array's
+        identity, make this a gather-add; ``setdiag`` relocates it on
+        every call.
+        """
+        if shift == 0.0:
+            return
+        cached = self.__dict__.get("_diag_pos")
+        if cached is None or cached[0] is not cov_inv.indices:
+            values = cov_inv.data
+            cov_inv.data = np.arange(1, values.size + 1, dtype=np.float64)
+            pos = cov_inv.diagonal().astype(np.intp) - 1
+            cov_inv.data = values
+            if np.any(pos < 0):  # missing diagonal entry: let scipy insert it
+                cov_inv.setdiag(cov_inv.diagonal() + shift)
+                return
+            cached = (cov_inv.indices, pos)
+            self._diag_pos = cached
+        cov_inv.data[cached[1]] += shift
 
     def _apply_tick(self, rule: TickRule, steps: float) -> None:
         """Forget ``steps`` ticks of ``rule`` on the precision. Only the
@@ -1333,6 +1437,7 @@ class _BayesianLinearModel(MemoryUsageMixin, BaseEstimator):
         assert X.shape is not None  # for the type checker
         self.n_features_ = X.shape[1]
         self.coef_ = np.zeros(self.n_features_)
+        self._prior_is_fresh = True
         if self.sparse:
             self.cov_inv_ = csc_array(eye(self.n_features_, format="csc")) * self.alpha
         else:
@@ -1462,7 +1567,7 @@ class _BayesianLinearModel(MemoryUsageMixin, BaseEstimator):
         Incrementally update the posterior with new data.
 
         Uses the current posterior as the prior for the new update,
-        decayed by ``learning_rate``. If the model has not been
+        forgotten per ``forgetting``. If the model has not been
         fitted, this is equivalent to calling ``fit``.
 
         Parameters
@@ -1735,7 +1840,6 @@ class _BayesianLinearModel(MemoryUsageMixin, BaseEstimator):
             forgetting,
             steps=steps,
             decay_rate=decay_rate,
-            learning_rate=self.learning_rate,
             default=self._default_tick_rule,
         )
         self._apply_tick(rule, steps)
@@ -1844,12 +1948,14 @@ class NormalRegressor(_BayesianLinearModel, RegressorMixin):
     beta : float
         Known noise precision. The likelihood is
         :math:`y \\mid x, w \\sim \\mathcal{N}(x^T w, \\beta^{-1})`.
-    learning_rate : float, default=1.0
-        Decay rate for the posterior precision on each call to
-        ``decay``. Values less than 1 geometrically shrink the
-        precision matrix, increasing posterior uncertainty over time.
-        This converts the model into a forgetting estimator suitable
-        for restless bandit problems.
+    forgetting : forgetting rule, optional
+        Forgetting applied on every ``partial_fit`` before the batch is
+        absorbed, for change that happens because you observed. A
+        uniform rule (``ExponentialForgetting``, ``StabilizedForgetting``)
+        takes one step per row; a directional rule
+        (``FeatureWiseForgetting``, ``SiftForgetting``) forgets only along
+        what the batch excites. ``None`` (default) forgets nothing.
+        Forgetting with time is ``decay``.
     sparse : bool, default=False
         If True, use sparse matrix operations for the precision
         matrix. Input ``X`` must be a ``scipy.sparse.csc_array``.
@@ -1889,14 +1995,15 @@ scipy.sparse.csc_array
         \\mu_n = \\Lambda_n^{-1}
         (\\gamma^n \\Lambda_0 \\mu_0 + \\beta X^T W y)
 
-    where :math:`\\gamma` is the learning rate (1.0 for standard
-    Bayesian update) and :math:`W` is a diagonal matrix of effective
-    sample weights incorporating both user-supplied weights and
-    learning-rate decay.
+    where :math:`\\gamma` is the rate of a uniform ``forgetting`` rule
+    (1.0 with none) and :math:`W` is a diagonal matrix of effective
+    sample weights incorporating both user-supplied weights and the
+    within-batch forgetting. A directional rule replaces
+    :math:`\\gamma^n \\Lambda_0` with its own forgotten precision.
 
-    When ``learning_rate < 1``, calling ``decay`` scales the precision
-    matrix by :math:`\\gamma^n`, uniformly increasing posterior
-    uncertainty while preserving the mean.
+    Calling ``decay`` scales the precision matrix by the rule's rate,
+    uniformly increasing posterior uncertainty while preserving the
+    mean.
 
     References
     ----------
@@ -1939,13 +2046,13 @@ scipy.sparse.csc_array
         alpha: float,
         beta: float,
         *,
-        learning_rate: float = 1.0,
+        forgetting: Optional[UpdateRule] = None,
         sparse: bool = False,
         random_state: Union[int, np.random.Generator, None] = None,
     ) -> None:
         self.alpha = alpha
         self.beta = beta
-        self.learning_rate = learning_rate
+        self.forgetting = forgetting
         self.sparse = sparse
         self.random_state = random_state
 
@@ -1955,31 +2062,21 @@ scipy.sparse.csc_array
         X: Union[NDArray[Any], csc_array],
         y: NDArray[Any],
         sample_weight: Optional[NDArray[Any]] = None,
+        *,
+        pending_eta: Optional[NDArray[np.float64]] = None,
     ):
+        """One recursive update from the forgotten prior. ``pending_eta``,
+        when given, is the prior information vector ``Λ·coef_`` already in
+        hand (an empirical-Bayes correction leaves it instead of solving),
+        so the matvec is skipped."""
         if self.sparse:
             X = csc_array(X)
-
         assert X.shape is not None  # for the type checker
 
-        # Handle sample weights
-        if sample_weight is None:
-            sample_weight = np.ones(X.shape[0], dtype=np.float64)
-        else:
-            sample_weight = np.asarray(sample_weight, dtype=np.float64)
-            if sample_weight.shape[0] != X.shape[0]:
-                raise ValueError(
-                    f"sample_weight.shape[0]={sample_weight.shape[0]} should be "
-                    f"equal to X.shape[0]={X.shape[0]}"
-                )
-
-        # Apply the learning rate decay to get effective weights
-        effective_weights = compute_effective_weights(
-            X.shape[0], sample_weight, self.learning_rate
+        prior, prior_decay, effective_weights, floor = self._forget_batch(
+            X, y, sample_weight
         )
-
-        assert X.shape is not None  # for the type checker
-        prior_decay = self.learning_rate ** X.shape[0]
-
+        reinjection = (1.0 - prior_decay) * floor
         y_weighted = y * effective_weights
 
         if self.sparse:
@@ -1988,31 +2085,52 @@ scipy.sparse.csc_array
             assert isinstance(X, csc_array)
             w_sqrt = np.sqrt(self.beta * effective_weights)
             X_weighted = X.multiply(w_sqrt.reshape(-1, 1)).tocsc()
-            cov_inv = cast(
-                csc_array,
-                prior_decay * self.cov_inv_ + X_weighted.T @ X_weighted,
+            prior_csc = cast(csc_array, prior)
+            if prior_decay != 1.0:
+                # New data array, not in-place: leaves cov_inv_ untouched if the solve below fails.
+                prior_csc = csc_array(
+                    (prior_csc.data * prior_decay, prior_csc.indices, prior_csc.indptr),
+                    shape=prior_csc.shape,
+                )
+            prior_eta = (
+                prior_csc @ self.coef_
+                if pending_eta is None
+                else prior_decay * pending_eta
             )
-            # Scale vectors instead of sparse matrices to avoid copies
-            eta = cast(
-                NDArray[np.float64],
-                self.cov_inv_ @ (prior_decay * self.coef_)
-                + X.T @ (self.beta * y_weighted),
-            )
+            cov_inv = cast(csc_array, prior_csc + X_weighted.T @ X_weighted)
+            self._shift_diagonal(cov_inv, reinjection)
+            eta = cast(NDArray[np.float64], prior_eta + X.T @ (self.beta * y_weighted))
             factor: PrecisionFactor = self._sparse_factor(cov_inv)
             coef = factor.solve(eta)
             self._precision_factor = factor
         else:
             assert isinstance(X, np.ndarray)
+            prior_dense = np.asarray(prior)
             w_sqrt = np.sqrt(effective_weights)
             X_weighted = X * w_sqrt[:, np.newaxis]
-            eta = compute_eta_dense(
-                prior_decay, self.cov_inv_, self.coef_, self.beta, X, y_weighted
-            )
+            if pending_eta is None:
+                eta = compute_eta_dense(
+                    prior_decay, prior_dense, self.coef_, self.beta, X, y_weighted
+                )
+            else:
+                # As compute_eta_dense, but dgemv accumulates onto the already-done dsymv term.
+                XF, xt = fortran_view(X)
+                eta = dgemv(
+                    self.beta,
+                    XF,
+                    y_weighted,
+                    trans=1 - xt,
+                    beta=1.0,
+                    y=prior_decay * pending_eta,
+                    overwrite_y=True,
+                )
             # Copy, not a view: dsyrk below writes this buffer, so aliasing cov_inv_
             # would corrupt it before cho_factor gets a chance to reject the update.
-            prior_scaled = np.array(self.cov_inv_, order="F", copy=True)
+            prior_scaled = np.array(prior_dense, order="F", copy=True)
             if prior_decay != 1.0:
                 prior_scaled *= prior_decay
+            if reinjection != 0.0:
+                prior_scaled[np.diag_indices_from(prior_scaled)] += reinjection
             # Fused X^T W X + prior via dsyrk (upper triangle only)
             cov_inv = update_precision_dense(self.beta, X_weighted, prior_scaled)
             # Cache the Cholesky factor for reuse in cov_/sample
@@ -2022,6 +2140,7 @@ scipy.sparse.csc_array
 
         self.cov_inv_ = cov_inv
         self.coef_ = coef
+        self._prior_is_fresh = False
 
 
 class NormalInverseGammaRegressor(NormalRegressor):
@@ -2053,11 +2172,14 @@ array-like of shape (n_features, n_features), default=1.0
         Prior rate parameter of the Inverse-Gamma distribution.
         The prior mean of the noise variance is :math:`b / (a - 1)`
         for :math:`a > 1`.
-    learning_rate : float, default=1.0
-        Decay rate for sequential updates. Values less than 1
-        geometrically shrink the precision and Inverse-Gamma
-        parameters on each call to ``decay``, enabling adaptation
-        to non-stationary environments.
+    forgetting : forgetting rule, optional
+        Forgetting applied on every ``partial_fit`` before the batch is
+        absorbed, for change that happens because you observed. A
+        uniform rule (``ExponentialForgetting``, ``StabilizedForgetting``)
+        takes one step per row; a directional rule
+        (``FeatureWiseForgetting``, ``SiftForgetting``) forgets only along
+        what the batch excites. ``None`` (default) forgets nothing.
+        Forgetting with time is ``decay``.
     sparse : bool, default=False
         If True, use sparse matrix operations for the precision
         matrix. Input ``X`` must be a ``scipy.sparse.csc_array``.
@@ -2165,7 +2287,7 @@ scipy.sparse.csc_array
         lam: Union[ArrayLike, csc_array] = 1.0,
         a: float = 0.1,
         b: float = 0.1,
-        learning_rate: float = 1.0,
+        forgetting: Optional[UpdateRule] = None,
         sparse: bool = False,
         random_state: Union[int, np.random.Generator, None] = None,
     ):
@@ -2173,7 +2295,7 @@ scipy.sparse.csc_array
         self.lam = lam
         self.a = a
         self.b = b
-        self.learning_rate = learning_rate
+        self.forgetting = forgetting
         self.sparse = sparse
         self.random_state = random_state
 
@@ -2191,6 +2313,7 @@ scipy.sparse.csc_array
 
         assert X.shape is not None  # for the type checker
         self.n_features_ = X.shape[1]
+        self._prior_is_fresh = True
         if np.isscalar(self.mu):
             self.coef_ = np.full(self.n_features_, self.mu, dtype=np.float64)
         elif cast(NDArray[np.float64], self.mu).ndim == 1:
@@ -2233,7 +2356,10 @@ scipy.sparse.csc_array
         X: Union[NDArray[Any], csc_array],
         y: NDArray[Any],
         sample_weight: Optional[NDArray[Any]] = None,
+        *,
+        pending_eta: Optional[NDArray[np.float64]] = None,
     ):
+        assert pending_eta is None  # only the EB Normal regressor leaves one
         if self.sparse:
             X = csc_array(X)
 
@@ -2250,13 +2376,10 @@ scipy.sparse.csc_array
                     f"equal to X.shape[0]={X.shape[0]}"
                 )
 
-        # Apply the learning rate decay to get effective weights
-        effective_weights = compute_effective_weights(
-            X.shape[0], sample_weight, self.learning_rate
+        prior, prior_decay, effective_weights, floor = self._forget_batch(
+            X, y, sample_weight
         )
-
-        assert X.shape is not None  # for the type checker
-        prior_decay = self.learning_rate ** X.shape[0]
+        reinjection = (1.0 - prior_decay) * floor
 
         # Update the inverse covariance matrix with weights
         if self.sparse:
@@ -2264,13 +2387,19 @@ scipy.sparse.csc_array
             assert isinstance(X, csc_array)
             w_sqrt = np.sqrt(effective_weights)
             X_weighted = X.multiply(w_sqrt.reshape(-1, 1)).tocsc()
-            V_n = prior_decay * self.cov_inv_ + X_weighted.T @ X_weighted
+            V_n: Any = cast(csc_array, prior_decay * prior + X_weighted.T @ X_weighted)
+            self._shift_diagonal(V_n, reinjection)
         else:
             assert isinstance(X, np.ndarray)
             w_sqrt = np.sqrt(effective_weights)
             X_weighted = X * w_sqrt[:, np.newaxis]
+            # Copy, not a view: dsyrk writes this buffer.
+            prior_scaled = np.array(prior, order="F", copy=True)
+            if prior_decay != 1.0:
+                prior_scaled *= prior_decay
+            if reinjection != 0.0:
+                prior_scaled[np.diag_indices_from(prior_scaled)] += reinjection
             # Fused X^T W X + prior via dsyrk (upper triangle only)
-            prior_scaled = np.asfortranarray(prior_decay * self.cov_inv_)
             V_n = update_precision_dense(1.0, X_weighted, prior_scaled)
 
         # Apply weights to y for the linear term
@@ -2280,7 +2409,7 @@ scipy.sparse.csc_array
         if self.sparse:
             # Compute prior term and extract prior_quad before adding
             # the data term, mirroring the dense path optimisation.
-            prior_cov_coef = self.cov_inv_ @ (prior_decay * self.coef_)
+            prior_cov_coef = prior @ (prior_decay * self.coef_)
             prior_quad = float(self.coef_.dot(prior_cov_coef))
             eta = prior_cov_coef + X.T @ y_weighted
             eta = cast(NDArray[np.float64], eta)
@@ -2291,7 +2420,7 @@ scipy.sparse.csc_array
         else:
             # Inline compute_eta_dense to reuse the intermediate dsymv
             # result for prior_quad, saving one O(p²) matvec.
-            prior_cov_coef = dsymv(prior_decay, self.cov_inv_, self.coef_)
+            prior_cov_coef = dsymv(prior_decay, prior, self.coef_)
             prior_quad = self.coef_.dot(prior_cov_coef)
             # eta = prior_decay * cov_inv @ coef + X^T @ y_weighted
             assert isinstance(X, np.ndarray)
@@ -2328,6 +2457,7 @@ scipy.sparse.csc_array
         self.coef_ = m_n
         self.a_ = a_n
         self.b_ = b_n
+        self._prior_is_fresh = False
 
     @cached_property
     def shape_(self) -> PrecisionFactor:
@@ -2527,12 +2657,14 @@ class BayesianGLM(_BayesianLinearModel, RegressorMixin):
           (Bernoulli likelihood).
         - ``'log'``: Exponential. Use for count outcomes (Poisson
           likelihood).
-    learning_rate : float, default=1.0
-        Decay rate for the posterior precision on each call to ``decay``.
-        Values less than 1 geometrically shrink the precision matrix,
-        increasing posterior uncertainty over time. This converts the
-        model into a forgetting (non-stationary) estimator suitable for
-        restless bandit problems.
+    forgetting : forgetting rule, optional
+        Forgetting applied on every ``partial_fit`` before the batch is
+        absorbed, for change that happens because you observed. A
+        uniform rule (``ExponentialForgetting``, ``StabilizedForgetting``)
+        takes one step per row; a directional rule
+        (``FeatureWiseForgetting``, ``SiftForgetting``) forgets only along
+        what the batch excites. ``None`` (default) forgets nothing.
+        Forgetting with time is ``decay``.
     approximator : PosteriorApproximator, default=LaplaceApproximator()
         Strategy object for approximating the posterior. The default
         ``LaplaceApproximator`` performs 5 IRLS iterations per update.
@@ -2598,11 +2730,9 @@ scipy.sparse.csc_array
     and :math:`W` is the diagonal matrix of IRLS weights. See Chapter 8
     of [1]_ for details.
 
-    When ``learning_rate < 1``, calling ``decay`` scales the precision
-    matrix by :math:`\\gamma^n` where :math:`\\gamma` is the learning rate
-    and :math:`n` is the number of samples. This uniformly increases
-    posterior uncertainty, allowing the model to adapt to non-stationary
-    environments.
+    Calling ``decay`` scales the precision matrix by the rule's rate,
+    uniformly increasing posterior uncertainty so the model can follow
+    a non-stationary environment.
 
     References
     ----------
@@ -2670,14 +2800,14 @@ scipy.sparse.csc_array
         alpha: float = 1.0,
         *,
         link: LinkFunction = "logit",
-        learning_rate: float = 1.0,
+        forgetting: Optional[UpdateRule] = None,
         approximator: Optional[PosteriorApproximator] = None,
         sparse: bool = False,
         random_state: Union[int, np.random.Generator, None] = None,
     ) -> None:
         self.alpha = alpha
         self.link: LinkFunction = link
-        self.learning_rate = learning_rate
+        self.forgetting = forgetting
         self.approximator = approximator
         self.sparse = sparse
         self.random_state = random_state
@@ -2713,28 +2843,33 @@ scipy.sparse.csc_array
             prior_factor = self._pop_factor_hint()
             self.__dict__.pop("_precision_factor", None)
 
-        # Only the EB subclass sets these; left out otherwise so a custom
-        # approximator written without them keeps working on BayesianGLM.
+        prior, prior_decay, weights, floor = self._forget_batch(X, y, sample_weight)
+        if prior is not self.cov_inv_:
+            # A directional rule changed the prior; the cached factor is of
+            # the old one.
+            prior_factor = None
+        # Left out when unused so a custom approximator written without
+        # them keeps working on BayesianGLM.
         extra: dict[str, Any] = {}
-        prior_floor = getattr(self, "_pending_floor", 0.0)
-        if prior_floor != 0.0:
-            extra["prior_floor"] = prior_floor
+        if floor != 0.0:
+            extra["prior_floor"] = floor
         if coef_init is not None:
             extra["coef_init"] = coef_init
         posterior = self.approximator_.update_posterior(
             X,
             y,
             self.coef_,
-            self.cov_inv_,  # type: ignore
+            prior,  # type: ignore
             link=self.link,
-            sample_weight=sample_weight,
-            learning_rate=self.learning_rate,
+            sample_weight=weights,
+            prior_decay=prior_decay,
             sparse=self.sparse,
             prior_factor=prior_factor,
             **extra,
         )
         self.coef_ = posterior.mean
         self.cov_inv_ = posterior.precision
+        self._prior_is_fresh = False
         self._laplace_converged = posterior.converged
         if not posterior.converged:
             warnings.warn(

--- a/src/bayesianbandits/_estimators.py
+++ b/src/bayesianbandits/_estimators.py
@@ -49,12 +49,12 @@ from ._blas_helpers import (
     update_precision_dense,
 )
 from ._forgetting import (
+    UNIFORM_RULES,
     ExponentialForgetting,
-    StabilizedForgetting,
-    TickRule,
+    ForgettingRule,
     UniformRule,
-    UpdateRule,
     check_update_rule,
+    convert_legacy_state,
     resolve_tick,
     tick_groups,
     uniform_batch,
@@ -79,20 +79,6 @@ from ._sparse_bayesian_linear_regression import (
 Params = ParamSpec("Params")
 ReturnType = TypeVar("ReturnType")
 SelfType = TypeVar("SelfType", bound="NormalRegressor | BayesianGLM")
-
-
-def _grouped_batch(
-    rule: Any, prior: NDArray[np.float64], estimator: str
-) -> tuple[float, Any]:
-    """``(rate, floor)`` for a grouped conjugate model's batch: each row of
-    a group is one step of the rule, so the group's prior is scaled by
-    ``rate ** n`` and ``(1 - rate ** n) * floor`` added back."""
-    check_update_rule(rule, estimator=estimator, uniform_only=True)
-    if rule is None:
-        return 1.0, 0.0
-    if isinstance(rule, StabilizedForgetting):
-        return rule.rate, prior if rule.alpha is None else rule.alpha
-    return rule.rate, 0.0
 
 
 class DirichletClassifier(MemoryUsageMixin, BaseEstimator, ClassifierMixin):
@@ -325,7 +311,10 @@ class DirichletClassifier(MemoryUsageMixin, BaseEstimator, ClassifierMixin):
                 )
 
         # Group X values, y, and sample weights together
-        rate, floor = _grouped_batch(self.forgetting, self.prior_, type(self).__name__)
+        check_update_rule(
+            self.forgetting, estimator=type(self).__name__, uniform_only=True
+        )
+        rate, floor = uniform_batch(self.forgetting, 1, alpha=self.prior_)
         for group, arr, weights in groupby_array(X[:, 0], y, sample_weight, by=X[:, 0]):
             key = group[0].item()
 
@@ -442,10 +431,7 @@ class DirichletClassifier(MemoryUsageMixin, BaseEstimator, ClassifierMixin):
     _default_tick_rule: type = ExponentialForgetting
 
     def __setstate__(self, state: Dict[str, Any]) -> None:
-        # Models pickled before ``forgetting=`` carried ``learning_rate``.
-        rate = state.pop("learning_rate", None)
-        if rate is not None and "forgetting" not in state:
-            state["forgetting"] = None if rate == 1.0 else self._default_tick_rule(rate)
+        convert_legacy_state(state, self._default_tick_rule)
         super().__setstate__(state)
 
     def decay(
@@ -482,14 +468,10 @@ class DirichletClassifier(MemoryUsageMixin, BaseEstimator, ClassifierMixin):
         """
         if not hasattr(self, "known_alphas_"):
             self._initialize_prior()
-        tick_groups(
-            self.known_alphas_,
-            forgetting,
-            steps=steps,
-            decay_rate=decay_rate,
-            prior=self.prior_,
-            default=self._default_tick_rule,
+        rule = resolve_tick(
+            forgetting, decay_rate=decay_rate, default=self._default_tick_rule
         )
+        tick_groups(self.known_alphas_, rule, steps=steps, prior=self.prior_)
 
 
 class GammaRegressor(MemoryUsageMixin, BaseEstimator, RegressorMixin):
@@ -680,7 +662,10 @@ class GammaRegressor(MemoryUsageMixin, BaseEstimator, RegressorMixin):
                 )
 
         # Group X values, y, and sample weights together
-        rate, floor = _grouped_batch(self.forgetting, self.prior_, type(self).__name__)
+        check_update_rule(
+            self.forgetting, estimator=type(self).__name__, uniform_only=True
+        )
+        rate, floor = uniform_batch(self.forgetting, 1, alpha=self.prior_)
         for group, arr, weights in groupby_array(X[:, 0], y, sample_weight, by=X[:, 0]):
             key = group[0].item()
 
@@ -816,10 +801,7 @@ class GammaRegressor(MemoryUsageMixin, BaseEstimator, RegressorMixin):
     _default_tick_rule: type = ExponentialForgetting
 
     def __setstate__(self, state: Dict[str, Any]) -> None:
-        # Models pickled before ``forgetting=`` carried ``learning_rate``.
-        rate = state.pop("learning_rate", None)
-        if rate is not None and "forgetting" not in state:
-            state["forgetting"] = None if rate == 1.0 else self._default_tick_rule(rate)
+        convert_legacy_state(state, self._default_tick_rule)
         super().__setstate__(state)
 
     def decay(
@@ -858,14 +840,10 @@ class GammaRegressor(MemoryUsageMixin, BaseEstimator, RegressorMixin):
         """
         if not hasattr(self, "coef_"):
             self._initialize_prior()
-        tick_groups(
-            self.coef_,
-            forgetting,
-            steps=steps,
-            decay_rate=decay_rate,
-            prior=self.prior_,
-            default=self._default_tick_rule,
+        rule = resolve_tick(
+            forgetting, decay_rate=decay_rate, default=self._default_tick_rule
         )
+        tick_groups(self.coef_, rule, steps=steps, prior=self.prior_)
 
 
 def _scaled_identity_f(n: int, scale: float) -> NDArray[np.float64]:
@@ -1301,7 +1279,7 @@ class _BayesianLinearModel(MemoryUsageMixin, BaseEstimator):
         # Read here, owned elsewhere: the concrete ``__init__`` sets the
         # hyperparameters and ``_initialize_prior`` the generator.
         alpha: float
-        forgetting: Optional[UpdateRule]
+        forgetting: Optional[ForgettingRule]
         sparse: bool
         random_state: Union[int, np.random.Generator, None]
         random_state_: np.random.Generator
@@ -1326,10 +1304,7 @@ class _BayesianLinearModel(MemoryUsageMixin, BaseEstimator):
     _default_tick_rule: type = ExponentialForgetting
 
     def __setstate__(self, state: Dict[str, Any]) -> None:
-        # Models pickled before ``forgetting=`` carried ``learning_rate``.
-        rate = state.pop("learning_rate", None)
-        if rate is not None and "forgetting" not in state:
-            state["forgetting"] = None if rate == 1.0 else self._default_tick_rule(rate)
+        convert_legacy_state(state, self._default_tick_rule)
         super().__setstate__(state)
 
     def _forget_batch(
@@ -1354,7 +1329,7 @@ class _BayesianLinearModel(MemoryUsageMixin, BaseEstimator):
         check_update_rule(rule, estimator=type(self).__name__, sparse=self.sparse)
         assert X.shape is not None
         n = X.shape[0]
-        if rule is None or isinstance(rule, TickRule):
+        if rule is None or isinstance(rule, UNIFORM_RULES):
             gamma, floor = uniform_batch(rule, n, alpha=self._prior_floor())
             if getattr(self, "_prior_is_fresh", False):
                 floor = 0.0
@@ -1397,7 +1372,7 @@ class _BayesianLinearModel(MemoryUsageMixin, BaseEstimator):
             self._diag_pos = cached
         cov_inv.data[cached[1]] += shift
 
-    def _apply_tick(self, rule: TickRule, steps: float) -> None:
+    def _apply_tick(self, rule: UniformRule, steps: float) -> None:
         """Forget ``steps`` ticks of ``rule`` on the precision. Only the
         variance grows, so the posterior mean is untouched; the cached
         factor follows a scalar rule and is dropped for any other."""
@@ -1832,11 +1807,8 @@ class _BayesianLinearModel(MemoryUsageMixin, BaseEstimator):
         # If the model has not been fit, there is no prior to decay
         if not hasattr(self, "coef_"):
             return
-        rule, steps, _ = resolve_tick(
-            forgetting,
-            steps=steps,
-            decay_rate=decay_rate,
-            default=self._default_tick_rule,
+        rule = resolve_tick(
+            forgetting, decay_rate=decay_rate, default=self._default_tick_rule
         )
         self._apply_tick(rule, steps)
 
@@ -2042,7 +2014,7 @@ scipy.sparse.csc_array
         alpha: float,
         beta: float,
         *,
-        forgetting: Optional[UpdateRule] = None,
+        forgetting: Optional[ForgettingRule] = None,
         sparse: bool = False,
         random_state: Union[int, np.random.Generator, None] = None,
     ) -> None:
@@ -2283,7 +2255,7 @@ scipy.sparse.csc_array
         lam: Union[ArrayLike, csc_array] = 1.0,
         a: float = 0.1,
         b: float = 0.1,
-        forgetting: Optional[UpdateRule] = None,
+        forgetting: Optional[ForgettingRule] = None,
         sparse: bool = False,
         random_state: Union[int, np.random.Generator, None] = None,
     ):
@@ -2618,7 +2590,7 @@ scipy.sparse.csc_array
     def _prior_floor(self) -> Optional[float]:
         return float(cast(Any, self.lam)) if np.isscalar(self.lam) else None
 
-    def _apply_tick(self, rule: TickRule, steps: float) -> None:
+    def _apply_tick(self, rule: UniformRule, steps: float) -> None:
         """Forget the Inverse-Gamma parameters alongside the precision, so
         the marginal t widens on both counts: fewer degrees of freedom and
         a higher scale."""
@@ -2796,7 +2768,7 @@ scipy.sparse.csc_array
         alpha: float = 1.0,
         *,
         link: LinkFunction = "logit",
-        forgetting: Optional[UpdateRule] = None,
+        forgetting: Optional[ForgettingRule] = None,
         approximator: Optional[PosteriorApproximator] = None,
         sparse: bool = False,
         random_state: Union[int, np.random.Generator, None] = None,

--- a/src/bayesianbandits/_forgetting.py
+++ b/src/bayesianbandits/_forgetting.py
@@ -404,12 +404,16 @@ class StabilizedForgetting:
         return alpha
 
     def _apply(self, precision: ArrayType, lam: float, alpha: float) -> ArrayType:
-        n = precision.shape[0]
+        shift = (1 - lam) * alpha
         if sparse.issparse(precision):
-            floor = (1 - lam) * alpha * sparse.eye(n, format="csc")
-        else:
-            floor = (1 - lam) * alpha * np.eye(n)
-        return precision * lam + floor
+            n = precision.shape[0]
+            return precision * lam + shift * sparse.eye(n, format="csc")
+        # Scale into a new array of the same layout and shift its diagonal
+        # in place: no identity matrix, and a Fortran input stays Fortran,
+        # which the dense fit paths rely on to read the right triangle.
+        R = np.asarray(precision) * lam
+        R[np.diag_indices_from(R)] += shift
+        return R
 
     def tick(
         self, precision: ArrayType, *, alpha: Optional[float], steps: float = 1

--- a/src/bayesianbandits/_forgetting.py
+++ b/src/bayesianbandits/_forgetting.py
@@ -49,7 +49,8 @@ from scipy import sparse
 from scipy.linalg import cholesky, eigh, lapack, solve_triangular
 from scipy.sparse import csc_array
 
-from bayesianbandits._blas_helpers import dsyrk
+from bayesianbandits import _blas_helpers as blas
+from bayesianbandits._blas_helpers import dsyrk, fortran_view
 
 ArrayType = Union[NDArray[Any], csc_array]
 
@@ -263,8 +264,14 @@ def _sift_downdate_dense(
     Using Cholesky + triangular solve instead of ``solve(H, w.T)``
     ensures the correction ``V^T V`` is exactly symmetric, preventing
     floating-point asymmetry drift over many forgetting steps.
+
+    Only the upper triangle of ``precision`` is read (``dsymm``) and only
+    the upper triangle of the result is written (``dsyrk``), the same
+    convention as the dense fit paths, so no symmetrizing copy is needed.
     """
-    w = np.asarray(precision @ X_bar.T, dtype=np.float64)  # (n, q)
+    RF, transposed = fortran_view(np.asarray(precision, dtype=np.float64))
+    # RF's lower triangle is precision's upper when RF is the transpose.
+    w = blas.dsymm(1.0, RF, np.asfortranarray(X_bar.T), lower=transposed)  # (n, q)
     H = X_bar @ w  # (q, q)
     L = cholesky(H, lower=True)  # H = L L^T
     V = solve_triangular(L, w.T, lower=True)  # (q, n);  V^T V = w H^{-1} w^T

--- a/src/bayesianbandits/_forgetting.py
+++ b/src/bayesianbandits/_forgetting.py
@@ -60,7 +60,8 @@ ForgettingResult = tuple[ArrayType, NDArray[Any], NDArray[Any]]
 class TickRule(Protocol):
     """A forgetting rule that can be applied without a batch: the clock ticked."""
 
-    rate: float
+    @property
+    def rate(self) -> float: ...
 
     def tick(
         self, precision: ArrayType, *, alpha: Optional[float], steps: float = 1
@@ -71,10 +72,16 @@ class TickRule(Protocol):
 class UpdateRule(Protocol):
     """A forgetting rule applied to a batch before it is absorbed."""
 
-    rate: float
+    @property
+    def rate(self) -> float: ...
 
     def update(
-        self, precision: ArrayType, X: ArrayType, y: NDArray[Any], *, alpha: float
+        self,
+        precision: ArrayType,
+        X: ArrayType,
+        y: NDArray[Any],
+        *,
+        alpha: Optional[float],
     ) -> ForgettingResult | None: ...
 
 
@@ -343,7 +350,7 @@ class ExponentialForgetting:
         X: ArrayType,
         y: NDArray[Any],
         *,
-        alpha: float,
+        alpha: Optional[float],
     ) -> ForgettingResult:
         return self.rate * precision, np.asarray(X), y
 
@@ -408,7 +415,7 @@ class StabilizedForgetting:
         X: ArrayType,
         y: NDArray[Any],
         *,
-        alpha: float,
+        alpha: Optional[float],
     ) -> ForgettingResult:
         return self._apply(precision, self.rate, self.floor(alpha)), np.asarray(X), y
 
@@ -460,7 +467,7 @@ class SiftForgetting:
         X: ArrayType,
         y: NDArray[Any],
         *,
-        alpha: float,
+        alpha: Optional[float],
     ) -> ForgettingResult | None:
         lam = self.rate
         if sparse.issparse(X):
@@ -562,7 +569,7 @@ class FeatureWiseForgetting:
         X: ArrayType,
         y: NDArray[Any],
         *,
-        alpha: float,
+        alpha: Optional[float],
     ) -> ForgettingResult:
         d = self.rate ** (_active_counts(X) / 2.0)
         if sparse.issparse(precision):
@@ -582,23 +589,27 @@ class FeatureWiseForgetting:
         return R_bar, X_eff, y
 
 
+UniformRule = Union[ExponentialForgetting, StabilizedForgetting]
+"""The rules that forget every direction alike: the only ones the grouped
+conjugate models and the empirical Bayes estimators accept."""
+
+
 def resolve_tick(
     forgetting: Any,
     *,
     steps: float,
     decay_rate: Optional[float],
-    learning_rate: float,
     default: type = ExponentialForgetting,
     stacklevel: int = 3,
 ) -> tuple[TickRule, float, Any]:
     """Sort out the arguments of an estimator's ``decay``.
 
     Returns ``(rule, steps, legacy_X)``. ``rule`` is the tick rule to
-    apply: ``forgetting`` itself, or ``default`` built from ``decay_rate``
-    (or, deprecated, from ``learning_rate``). A context array passed where
-    the rule goes is the pre-rule calling convention; it is returned as
-    ``legacy_X`` with ``steps`` set to its row count, so estimators that
-    read the rows (the grouped conjugate models) can keep doing so.
+    apply: ``forgetting`` itself, or ``default`` built from ``decay_rate``.
+    A context array passed where the rule goes is the pre-rule calling
+    convention; it is returned as ``legacy_X`` with ``steps`` set to its
+    row count, so estimators that read the rows (the grouped conjugate
+    models) can keep doing so.
     """
     legacy_X = None
     if isinstance(forgetting, numbers.Real) and not isinstance(forgetting, bool):
@@ -623,14 +634,10 @@ def resolve_tick(
         steps = legacy_X.shape[0] if hasattr(legacy_X, "shape") else len(legacy_X)
     if forgetting is None:
         if decay_rate is None:
-            warnings.warn(
-                "decay() without a forgetting rule or decay_rate falls back "
-                "to learning_rate; this default is deprecated. Pass a rule "
-                "such as StabilizedForgetting(0.95), or decay_rate=.",
-                FutureWarning,
-                stacklevel=stacklevel,
+            raise TypeError(
+                "decay() needs a forgetting rule such as "
+                "StabilizedForgetting(0.95), or decay_rate=."
             )
-            decay_rate = learning_rate
         forgetting = default(decay_rate)
     elif decay_rate is not None:
         raise TypeError(
@@ -646,7 +653,6 @@ def tick_groups(
     *,
     steps: float,
     decay_rate: Optional[float],
-    learning_rate: float,
     prior: NDArray[np.float64],
     default: type = ExponentialForgetting,
 ) -> None:
@@ -659,7 +665,6 @@ def tick_groups(
         forgetting,
         steps=steps,
         decay_rate=decay_rate,
-        learning_rate=learning_rate,
         default=default,
         stacklevel=4,
     )
@@ -677,3 +682,44 @@ def tick_groups(
         return
     for key in list(table):
         table[key] = tick(table[key], steps)
+
+
+def uniform_batch(
+    rule: Optional[Any], n: int, *, alpha: Optional[float]
+) -> tuple[float, float]:
+    """``(gamma, floor)`` for a uniform rule over an ``n``-row batch: each
+    row is one step, so the prior is scaled by ``gamma = rate ** n`` and
+    ``(1 - gamma) * floor`` is added back to its diagonal. ``(1.0, 0.0)``
+    with no rule."""
+    if rule is None:
+        return 1.0, 0.0
+    gamma = rule.rate**n
+    if isinstance(rule, StabilizedForgetting):
+        return gamma, rule.floor(alpha)
+    return gamma, 0.0
+
+
+def check_update_rule(
+    rule: Any, *, estimator: str, uniform_only: bool = False, sparse: bool = False
+) -> None:
+    """Raise unless ``rule`` can be the ``forgetting`` of ``estimator``."""
+    if rule is None:
+        return
+    if uniform_only:
+        if not isinstance(rule, (ExponentialForgetting, StabilizedForgetting)):
+            raise TypeError(
+                f"{estimator} forgets uniformly: forgetting= takes "
+                "ExponentialForgetting or StabilizedForgetting, not "
+                f"{type(rule).__name__}."
+            )
+        return
+    if not isinstance(rule, UpdateRule):
+        raise TypeError(
+            f"forgetting= takes a forgetting rule such as "
+            f"ExponentialForgetting(0.99), not {rule!r}."
+        )
+    if sparse and isinstance(rule, SiftForgetting):
+        raise TypeError(
+            "SiftForgetting fills in a sparse precision matrix; use "
+            "FeatureWiseForgetting on a sparse estimator."
+        )

--- a/src/bayesianbandits/_forgetting.py
+++ b/src/bayesianbandits/_forgetting.py
@@ -38,10 +38,8 @@ The caller then does::
 
 from __future__ import annotations
 
-import numbers
-import warnings
 from dataclasses import dataclass
-from typing import Any, NamedTuple, Optional, Protocol, Union, cast, runtime_checkable
+from typing import Any, NamedTuple, Optional, Union, cast
 
 import numpy as np
 from numpy.typing import NDArray
@@ -55,35 +53,6 @@ from bayesianbandits._blas_helpers import dsyrk, fortran_view
 ArrayType = Union[NDArray[Any], csc_array]
 
 ForgettingResult = tuple[ArrayType, NDArray[Any], NDArray[Any]]
-
-
-@runtime_checkable
-class TickRule(Protocol):
-    """A forgetting rule that can be applied without a batch: the clock ticked."""
-
-    @property
-    def rate(self) -> float: ...
-
-    def tick(
-        self, precision: ArrayType, *, alpha: Optional[float], steps: float = 1
-    ) -> ArrayType: ...
-
-
-@runtime_checkable
-class UpdateRule(Protocol):
-    """A forgetting rule applied to a batch before it is absorbed."""
-
-    @property
-    def rate(self) -> float: ...
-
-    def update(
-        self,
-        precision: ArrayType,
-        X: ArrayType,
-        y: NDArray[Any],
-        *,
-        alpha: Optional[float],
-    ) -> ForgettingResult | None: ...
 
 
 class _SparseFilterResult(NamedTuple):
@@ -390,7 +359,7 @@ class StabilizedForgetting:
     rate: float
     alpha: Optional[float] = None
 
-    def floor(self, alpha: Optional[float]) -> float:
+    def floor(self, alpha: Any) -> Any:
         """The prior precision this rule floors at, given the estimator's;
         ``None`` means the estimator has no scalar prior precision."""
         if self.alpha is not None:
@@ -601,107 +570,75 @@ class FeatureWiseForgetting:
 
 
 UniformRule = Union[ExponentialForgetting, StabilizedForgetting]
-"""The rules that forget every direction alike: the only ones the grouped
-conjugate models and the empirical Bayes estimators accept."""
+"""The rules that forget every direction alike, and so can tick on the
+clock; the only ones the grouped conjugate models and the empirical Bayes
+estimators accept."""
+
+ForgettingRule = Union[
+    ExponentialForgetting, StabilizedForgetting, FeatureWiseForgetting, SiftForgetting
+]
+"""Any rule an estimator's ``forgetting=`` accepts."""
+
+UNIFORM_RULES = (ExponentialForgetting, StabilizedForgetting)
+DIRECTIONAL_RULES = (FeatureWiseForgetting, SiftForgetting)
 
 
 def resolve_tick(
-    forgetting: Any,
-    *,
-    steps: float,
-    decay_rate: Optional[float],
-    default: type = ExponentialForgetting,
-    stacklevel: int = 3,
-) -> tuple[TickRule, float, Any]:
-    """Sort out the arguments of an estimator's ``decay``.
-
-    Returns ``(rule, steps, legacy_X)``. ``rule`` is the tick rule to
-    apply: ``forgetting`` itself, or ``default`` built from ``decay_rate``.
-    A context array passed where the rule goes is the pre-rule calling
-    convention; it is returned as ``legacy_X`` with ``steps`` set to its
-    row count, so estimators that read the rows (the grouped conjugate
-    models) can keep doing so.
-    """
-    legacy_X = None
-    if isinstance(forgetting, numbers.Real) and not isinstance(forgetting, bool):
-        raise TypeError(
-            "decay() takes a forgetting rule, not a bare rate; pass "
-            "decay_rate=... or a rule such as ExponentialForgetting(rate)."
-        )
-    if forgetting is not None and not isinstance(forgetting, TickRule):
-        if isinstance(forgetting, UpdateRule):
-            raise TypeError(
-                f"{type(forgetting).__name__} forgets along a batch, so it "
-                "belongs on the learner's forgetting= argument, not decay()."
-            )
-        warnings.warn(
-            "Passing a context array to decay() is deprecated; pass "
-            "steps=<number of ticks> and a forgetting rule or decay_rate.",
-            FutureWarning,
-            stacklevel=stacklevel,
-        )
-        legacy_X = forgetting
-        forgetting = None
-        steps = legacy_X.shape[0] if hasattr(legacy_X, "shape") else len(legacy_X)
+    forgetting: Any, *, decay_rate: Optional[float], default: type
+) -> UniformRule:
+    """The rule an estimator's ``decay`` ticks with: ``forgetting`` itself,
+    or ``default`` built from ``decay_rate``."""
     if forgetting is None:
         if decay_rate is None:
             raise TypeError(
                 "decay() needs a forgetting rule such as "
                 "StabilizedForgetting(0.95), or decay_rate=."
             )
-        forgetting = default(decay_rate)
-    elif decay_rate is not None:
+        return default(decay_rate)
+    if decay_rate is not None:
         raise TypeError(
             "Pass either a forgetting rule or decay_rate, not both; the rule "
             "carries its own rate."
         )
-    return forgetting, steps, legacy_X
+    if isinstance(forgetting, DIRECTIONAL_RULES):
+        raise TypeError(
+            f"{type(forgetting).__name__} forgets along a batch, so it "
+            "belongs on the learner's forgetting= argument, not decay()."
+        )
+    if not isinstance(forgetting, UNIFORM_RULES):
+        raise TypeError(
+            "decay() takes a forgetting rule such as ExponentialForgetting(rate) "
+            f"or decay_rate=..., not {forgetting!r}."
+        )
+    return forgetting
 
 
 def tick_groups(
     table: dict[Any, NDArray[np.float64]],
-    forgetting: Any,
+    rule: UniformRule,
     *,
     steps: float,
-    decay_rate: Optional[float],
     prior: NDArray[np.float64],
-    default: type = ExponentialForgetting,
 ) -> None:
     """``decay`` for a grouped conjugate model: one parameter vector per
     group in ``table``, all sharing ``prior``. Scales every group by
     ``rate ** steps``, mixing ``prior`` back in under
-    :class:`StabilizedForgetting`. A legacy context array ticks once per
-    row, on that row's group."""
-    rule, steps, legacy_X = resolve_tick(
-        forgetting,
-        steps=steps,
-        decay_rate=decay_rate,
-        default=default,
-        stacklevel=4,
-    )
-
-    def tick(value: NDArray[np.float64], n: float) -> NDArray[np.float64]:
-        gamma = rule.rate**n
-        if isinstance(rule, StabilizedForgetting):
-            floor = prior if rule.alpha is None else rule.alpha
-            return np.asarray(gamma * value + (1 - gamma) * floor, dtype=np.float64)
-        return np.asarray(gamma * value, dtype=np.float64)
-
-    if legacy_X is not None:
-        for x in legacy_X:
-            table[x.item()] = tick(table[x.item()], 1)
-        return
+    :class:`StabilizedForgetting`."""
+    gamma, floor = uniform_batch(rule, steps, alpha=prior)
     for key in list(table):
-        table[key] = tick(table[key], steps)
+        table[key] = np.asarray(
+            gamma * table[key] + (1 - gamma) * floor, dtype=np.float64
+        )
 
 
 def uniform_batch(
-    rule: Optional[Any], n: int, *, alpha: Optional[float]
-) -> tuple[float, float]:
-    """``(gamma, floor)`` for a uniform rule over an ``n``-row batch: each
-    row is one step, so the prior is scaled by ``gamma = rate ** n`` and
-    ``(1 - gamma) * floor`` is added back to its diagonal. ``(1.0, 0.0)``
-    with no rule."""
+    rule: Optional[UniformRule], n: float, *, alpha: Any
+) -> tuple[float, Any]:
+    """``(gamma, floor)`` for a uniform rule over ``n`` steps: the prior is
+    scaled by ``gamma = rate ** n`` and ``(1 - gamma) * floor`` added back,
+    where ``floor`` is the estimator's prior precision (a scalar, or the
+    grouped models' prior vector) unless the rule carries its own.
+    ``(1.0, 0.0)`` with no rule."""
     if rule is None:
         return 1.0, 0.0
     gamma = rule.rate**n
@@ -717,14 +654,14 @@ def check_update_rule(
     if rule is None:
         return
     if uniform_only:
-        if not isinstance(rule, (ExponentialForgetting, StabilizedForgetting)):
+        if not isinstance(rule, UNIFORM_RULES):
             raise TypeError(
                 f"{estimator} forgets uniformly: forgetting= takes "
                 "ExponentialForgetting or StabilizedForgetting, not "
                 f"{type(rule).__name__}."
             )
         return
-    if not isinstance(rule, UpdateRule):
+    if not isinstance(rule, UNIFORM_RULES + DIRECTIONAL_RULES):
         raise TypeError(
             f"forgetting= takes a forgetting rule such as "
             f"ExponentialForgetting(0.99), not {rule!r}."
@@ -734,3 +671,11 @@ def check_update_rule(
             "SiftForgetting fills in a sparse precision matrix; use "
             "FeatureWiseForgetting on a sparse estimator."
         )
+
+
+def convert_legacy_state(state: dict[str, Any], default: type) -> None:
+    """Models pickled before ``forgetting=`` carried ``learning_rate``:
+    turn it into the rule the class used to apply."""
+    rate = state.pop("learning_rate", None)
+    if rate is not None and "forgetting" not in state:
+        state["forgetting"] = None if rate == 1.0 else default(rate)

--- a/src/bayesianbandits/_gaussian.py
+++ b/src/bayesianbandits/_gaussian.py
@@ -552,7 +552,7 @@ def update_gaussian_posterior_laplace(
     *,
     link: LinkFunction,
     sample_weight: Optional[NDArray[np.float64]] = None,
-    learning_rate: float = 1.0,
+    prior_decay: float = 1.0,
     sparse: bool = False,
     prior_floor: float = 0.0,
     n_iter: int = 3,
@@ -591,9 +591,9 @@ def update_gaussian_posterior_laplace(
     link : {'logit', 'log'}
         Link function
     sample_weight : array-like of shape (n_samples,), optional
-        Sample weights
-    learning_rate : float
-        Decay factor for prior contribution
+        Sample weights, as the rows are to count
+    prior_decay : float
+        Factor the prior precision is scaled by before the update
     sparse : bool
         Whether to use sparse operations
     n_iter : int, default=3
@@ -626,10 +626,7 @@ def update_gaussian_posterior_laplace(
     if n_samples == 0:
         return GaussianPosterior(prior_mean.copy(), prior_precision.copy(), None)
 
-    effective_weights = compute_effective_weights(
-        n_samples, sample_weight, learning_rate
-    )
-    prior_decay = learning_rate**n_samples
+    effective_weights = compute_effective_weights(n_samples, sample_weight, 1.0)
 
     if sparse:
         return _irls_sparse(
@@ -682,11 +679,12 @@ class PosteriorApproximator(Protocol):
     place for the posterior (the caller no longer holds it as the
     prior's factor), or ignore it entirely.
 
+    ``prior_decay`` scales the prior precision before the update, and
     ``prior_floor``, when nonzero, requests stabilized forgetting
-    (Kulhavy & Zarrop 1993): after decaying the prior precision by
-    ``γⁿ``, ``(1 - γⁿ)·prior_floor`` is added back to its diagonal so
-    the prior's contribution converges to ``prior_floor·I`` instead of
-    vanishing.  Only the precision is shifted, never the prior's eta
+    (Kulhavy & Zarrop 1993): ``(1 - prior_decay)·prior_floor`` is added
+    back to the scaled prior's diagonal so the prior's contribution
+    converges to ``prior_floor·I`` instead of vanishing. ``sample_weight``
+    arrives with any within-batch forgetting already applied.  Only the precision is shifted, never the prior's eta
     term, so the re-injected prior is centered at zero.
 
     ``coef_init``, when given, is the starting point for iterative
@@ -702,7 +700,7 @@ class PosteriorApproximator(Protocol):
         prior_precision: ArrayType,
         link: LinkFunction,
         sample_weight: Optional[NDArray[np.float64]],
-        learning_rate: float,
+        prior_decay: float,
         sparse: bool,
         prior_factor: Optional[Any] = None,
         prior_floor: float = 0.0,
@@ -779,7 +777,7 @@ class LaplaceApproximator(MemoryUsageMixin, PosteriorApproximator):
         prior_precision: ArrayType,
         link: LinkFunction,
         sample_weight: Optional[NDArray[np.float64]],
-        learning_rate: float,
+        prior_decay: float,
         sparse: bool,
         prior_factor: Optional[Any] = None,
         prior_floor: float = 0.0,
@@ -792,7 +790,7 @@ class LaplaceApproximator(MemoryUsageMixin, PosteriorApproximator):
             prior_precision,
             link=link,
             sample_weight=sample_weight,
-            learning_rate=learning_rate,
+            prior_decay=prior_decay,
             sparse=sparse,
             prior_floor=prior_floor,
             n_iter=self.n_iter,
@@ -1153,7 +1151,7 @@ def update_gaussian_posterior_rvga(
     *,
     link: LinkFunction,
     sample_weight: Optional[NDArray[np.float64]] = None,
-    learning_rate: float = 1.0,
+    prior_decay: float = 1.0,
     sparse: bool = False,
     prior_floor: float = 0.0,
     n_iter: int = 5,
@@ -1173,9 +1171,10 @@ def update_gaussian_posterior_rvga(
         native recursive mode), threading the posterior factor between
         chunks. Bounds the Gram-matrix allocation at
         ``8 * batch_size**2`` bytes instead of ``8 * n_samples**2``.
-        Decay and sample weights compose exactly across chunks; the
-        variational weights make the result mildly dependent on row
-        order. Ignored when ``sparse=False``.
+        The prior is forgotten once, before the first chunk, and the
+        row weights are as given; the variational weights make the
+        result mildly dependent on row order. Ignored when
+        ``sparse=False``.
 
     References
     ----------
@@ -1204,9 +1203,9 @@ def update_gaussian_posterior_rvga(
                 sample_weight=(
                     sample_weight[start:end] if sample_weight is not None else None
                 ),
-                learning_rate=learning_rate,
+                prior_decay=prior_decay if start == 0 else 1.0,
                 sparse=True,
-                prior_floor=prior_floor,
+                prior_floor=prior_floor if start == 0 else 0.0,
                 n_iter=n_iter,
                 tol=tol,
                 n_gh_nodes=n_gh_nodes,
@@ -1215,10 +1214,7 @@ def update_gaussian_posterior_rvga(
             )
         return posterior
 
-    effective_weights = compute_effective_weights(
-        n_samples, sample_weight, learning_rate
-    )
-    prior_decay = learning_rate**n_samples
+    effective_weights = compute_effective_weights(n_samples, sample_weight, 1.0)
 
     if sparse:
         return _rvga_sparse(
@@ -1313,7 +1309,7 @@ class RVGAApproximator(MemoryUsageMixin, PosteriorApproximator):
         prior_precision: ArrayType,
         link: LinkFunction,
         sample_weight: Optional[NDArray[np.float64]],
-        learning_rate: float,
+        prior_decay: float,
         sparse: bool,
         prior_factor: Optional[Any] = None,
         prior_floor: float = 0.0,
@@ -1326,7 +1322,7 @@ class RVGAApproximator(MemoryUsageMixin, PosteriorApproximator):
             prior_precision,
             link=link,
             sample_weight=sample_weight,
-            learning_rate=learning_rate,
+            prior_decay=prior_decay,
             sparse=sparse,
             prior_floor=prior_floor,
             n_iter=self.n_iter,

--- a/src/bayesianbandits/api.py
+++ b/src/bayesianbandits/api.py
@@ -1476,17 +1476,10 @@ class LipschitzContextualAgent(MemoryUsageMixin, Generic[TokenType]):
         Parameters
         ----------
         forgetting : ExponentialForgetting or StabilizedForgetting, optional
-            The rule to tick with, carrying its own rate. A context
-            array here is the deprecated calling convention; it is
-            enriched with one arm's features before it is passed on.
+            The rule to tick with, carrying its own rate.
         steps : float, default=1
             Number of ticks; the rule's rate is raised to this power.
         decay_rate : float, optional
             Shorthand for the learner's default rule at this rate.
         """
-        if forgetting is not None and not hasattr(forgetting, "tick"):
-            single_token = [self.arms[0].action_token]
-            forgetting = self.arm_featurizer.transform(
-                forgetting, action_tokens=single_token
-            )
         self.learner.decay(forgetting, decay_rate=decay_rate, steps=steps)

--- a/src/bayesianbandits/pipelines/_agent.py
+++ b/src/bayesianbandits/pipelines/_agent.py
@@ -185,16 +185,12 @@ class AgentPipeline(MemoryUsageMixin, Generic[ContextType, TokenType]):
         Parameters
         ----------
         forgetting : ExponentialForgetting or StabilizedForgetting, optional
-            The rule to tick with, carrying its own rate. A context
-            array here is the deprecated calling convention and is
-            transformed through the pipeline steps before it is passed on.
+            The rule to tick with, carrying its own rate.
         steps : float, default=1
             Number of ticks; the rule's rate is raised to this power.
         decay_rate : float, optional
             Shorthand for each learner's default rule at this rate.
         """
-        if forgetting is not None and not hasattr(forgetting, "tick"):
-            forgetting = self.transform(forgetting)
         self._agent.decay(forgetting, decay_rate=decay_rate, steps=steps)
 
     # Delegation methods

--- a/src/bayesianbandits/pipelines/_learner.py
+++ b/src/bayesianbandits/pipelines/_learner.py
@@ -377,16 +377,12 @@ class LearnerPipeline(MemoryUsageMixin, Generic[X_contra]):
         Parameters
         ----------
         forgetting : ExponentialForgetting or StabilizedForgetting, optional
-            The rule to tick with, carrying its own rate. A context
-            array here is the deprecated calling convention and is
-            transformed through the pipeline steps before it is passed on.
+            The rule to tick with, carrying its own rate.
         steps : float, default=1
             Number of ticks; the rule's rate is raised to this power.
         decay_rate : float, optional
             Shorthand for the learner's default rule at this rate.
         """
-        if forgetting is not None and not hasattr(forgetting, "tick"):
-            forgetting = self._apply_transformers(forgetting)
         self._learner.decay(forgetting, decay_rate=decay_rate, steps=steps)
 
     def predict(self, X: X_contra) -> NDArray[np.float64]:

--- a/tests/test_bayesian_glm.py
+++ b/tests/test_bayesian_glm.py
@@ -6,7 +6,12 @@ import scipy.sparse as sp
 from numpy.testing import assert_allclose, assert_array_less
 from sklearn.datasets import make_classification, make_regression
 
-from bayesianbandits import BayesianGLM, LaplaceApproximator, RVGAApproximator
+from bayesianbandits import (
+    BayesianGLM,
+    ExponentialForgetting,
+    LaplaceApproximator,
+    RVGAApproximator,
+)
 
 
 # Fixtures and parametrization
@@ -48,7 +53,11 @@ def test_bayesian_glm_init(sparse: bool, link: str, rng) -> None:
     """Test BayesianGLM initialization."""
     # Default approximator
     clf = BayesianGLM(
-        alpha=1.0, link=link, learning_rate=0.9, sparse=sparse, random_state=0
+        alpha=1.0,
+        link=link,
+        forgetting=ExponentialForgetting(0.9),
+        sparse=sparse,
+        random_state=0,
     )
     assert clf.alpha == 1.0
     assert clf.link == link
@@ -340,7 +349,7 @@ def test_bayesian_glm_decay(binary_data, sparse: bool) -> None:
     clf = BayesianGLM(
         alpha=1.0,
         link="logit",
-        learning_rate=0.9,
+        forgetting=ExponentialForgetting(0.9),
         approximator=LaplaceApproximator(n_iter=10),
         sparse=sparse,
     )
@@ -354,7 +363,7 @@ def test_bayesian_glm_decay(binary_data, sparse: bool) -> None:
         precision_before = np.diag(clf.cov_inv_)
 
     # Apply decay
-    clf.decay(decay_rate=clf.learning_rate, steps=X.shape[0])
+    clf.decay(decay_rate=0.9, steps=X.shape[0])
 
     # Predictions should stay the same
     preds_after = clf.predict(X_fit)

--- a/tests/test_decay_api.py
+++ b/tests/test_decay_api.py
@@ -11,6 +11,7 @@ from sklearn.preprocessing import FunctionTransformer
 from bayesianbandits import (
     Agent,
     Arm,
+    BayesianGLM,
     ContextualAgent,
     DirichletClassifier,
     EmpiricalBayesDirichletClassifier,
@@ -79,6 +80,17 @@ class TestTickRules:
         est.decay(StabilizedForgetting(0.9), steps=2)
         g = 0.9**2
         assert_allclose(_dense(est.cov_inv_), g * before + (1 - g) * 2.0 * np.eye(4))
+
+    def test_stabilized_tick_keeps_the_precision_fortran_ordered(self):
+        """The dense update reads one triangle through a Fortran view, so
+        a tick must not hand it back a C-ordered matrix."""
+        est, X = _fit_normal(False)
+        assert np.asarray(est.cov_inv_).flags.f_contiguous
+        est.decay(StabilizedForgetting(0.9))
+        assert np.asarray(est.cov_inv_).flags.f_contiguous
+        glm = BayesianGLM(alpha=1.0).fit(X, (X[:, 0] > 0).astype(float))
+        glm.decay(StabilizedForgetting(0.9))
+        assert np.asarray(glm.cov_inv_).flags.f_contiguous
 
     def test_stabilized_with_its_own_alpha(self):
         est, _ = _fit_normal(False)

--- a/tests/test_decay_api.py
+++ b/tests/test_decay_api.py
@@ -137,21 +137,6 @@ class TestTickRules:
         assert not hasattr(est, "coef_")
 
 
-class TestDeprecatedCallingConvention:
-    def test_context_array_means_steps_from_its_rows(self):
-        est, X = _fit_normal(False)
-        twin, _ = _fit_normal(False)
-        with pytest.warns(FutureWarning, match="steps="):
-            est.decay(X[:4], decay_rate=0.9)
-        twin.decay(decay_rate=0.9, steps=4)
-        assert_allclose(_dense(est.cov_inv_), _dense(twin.cov_inv_))
-
-    def test_neither_rule_nor_rate_is_an_error(self):
-        est, _ = _fit_normal(False, forgetting=ExponentialForgetting(0.7))
-        with pytest.raises(TypeError, match="decay_rate="):
-            est.decay(steps=2)
-
-
 class TestNormalInverseGamma:
     def test_stabilized_needs_a_scalar_prior_precision(self):
         rng = np.random.default_rng(0)
@@ -234,15 +219,6 @@ class TestGroupedModels:
             model.decay(StabilizedForgetting(0.8))
         assert_allclose(model.coef_[1], [2.0, 3.0], atol=1e-6)
 
-    def test_legacy_array_ticks_only_the_listed_groups(self):
-        clf = DirichletClassifier({0: 1.0, 1: 1.0}, random_state=0)
-        clf.fit(np.array([[1], [2]]), np.array([0, 1]))
-        a1, a2 = clf.known_alphas_[1].copy(), clf.known_alphas_[2].copy()
-        with pytest.warns(FutureWarning):
-            clf.decay(np.array([[1], [1]]), decay_rate=0.5)
-        assert_allclose(clf.known_alphas_[1], 0.25 * a1)
-        assert_allclose(clf.known_alphas_[2], a2)
-
     @pytest.mark.parametrize(
         "cls, kwargs",
         [
@@ -281,7 +257,7 @@ class TestPassThrough:
         agent.decay(decay_rate=0.5, steps=2)
         assert_allclose(_learner(agent.arm(0)).coef_[1], 0.25 * before)
 
-    def test_pipelines_pass_through_and_transform_a_legacy_array(self):
+    def test_pipelines_pass_the_rule_through(self):
         arms = [Arm(0, learner=NormalRegressor(alpha=1.0, beta=1.0))]
         agent = ContextualAgent(arms, ThompsonSampling(), random_seed=0)
         pipeline = AgentPipeline([("id", FunctionTransformer())], agent)
@@ -290,9 +266,6 @@ class TestPassThrough:
         before = _dense(_learner(arms[0]).cov_inv_)
         pipeline.decay(ExponentialForgetting(0.5))
         assert_allclose(_dense(_learner(arms[0]).cov_inv_), 0.5 * before)
-        with pytest.warns(FutureWarning):
-            pipeline.decay(np.vstack([X, X]), decay_rate=0.5)
-        assert_allclose(_dense(_learner(arms[0]).cov_inv_), 0.125 * before)
 
         learner = LearnerPipeline(
             [("id", FunctionTransformer())], NormalRegressor(alpha=1.0, beta=1.0)
@@ -302,12 +275,6 @@ class TestPassThrough:
         learner.decay(StabilizedForgetting(0.5))
         assert_allclose(
             _dense(cast(Any, learner.learner).cov_inv_), 0.5 * before + 0.5 * np.eye(2)
-        )
-        with pytest.warns(FutureWarning):
-            learner.decay(np.vstack([X, X]), decay_rate=0.5)
-        assert_allclose(
-            _dense(cast(Any, learner.learner).cov_inv_),
-            0.25 * (0.5 * before + 0.5 * np.eye(2)),
         )
 
     def test_lipschitz_agent_ticks_the_shared_learner_once(self):
@@ -325,10 +292,6 @@ class TestPassThrough:
         before = _dense(shared.cov_inv_)
         agent.decay(ExponentialForgetting(0.5), steps=2)
         assert_allclose(_dense(shared.cov_inv_), 0.25 * before)
-        # The deprecated array form: one tick per context row, not per arm.
-        with pytest.warns(FutureWarning):
-            agent.decay(np.vstack([X, X]), decay_rate=0.5)
-        assert_allclose(_dense(shared.cov_inv_), 0.0625 * before)
 
 
 class TestBreakingChanges:
@@ -336,6 +299,11 @@ class TestBreakingChanges:
         est, X = _fit_normal(False)
         with pytest.raises(TypeError):
             est.decay(X, 0.9)  # type: ignore[misc]
+
+    def test_a_context_array_is_refused(self):
+        est, X = _fit_normal(False)
+        with pytest.raises(TypeError, match="decay_rate="):
+            est.decay(X)
 
     def test_a_bare_rate_is_refused_with_a_pointer(self):
         agent = Agent(

--- a/tests/test_decay_api.py
+++ b/tests/test_decay_api.py
@@ -47,13 +47,11 @@ def _one_hot_arm(X, action_tokens, n_arms=3):
     return out
 
 
-def _fit_normal(sparse, learning_rate=1.0, **kwargs):
+def _fit_normal(sparse, **kwargs):
     rng = np.random.default_rng(0)
     X = rng.standard_normal((30, 4))
     y = X @ np.array([1.0, -1.0, 0.5, 0.0]) + rng.normal(0, 0.1, 30)
-    est = NormalRegressor(
-        alpha=2.0, beta=1.0, sparse=sparse, learning_rate=learning_rate, **kwargs
-    )
+    est = NormalRegressor(alpha=2.0, beta=1.0, sparse=sparse, **kwargs)
     est.fit(sp.csc_array(X) if sparse else X, y)
     return est, X
 
@@ -136,12 +134,10 @@ class TestDeprecatedCallingConvention:
         twin.decay(decay_rate=0.9, steps=4)
         assert_allclose(_dense(est.cov_inv_), _dense(twin.cov_inv_))
 
-    def test_falling_back_to_learning_rate_warns(self):
-        est, _ = _fit_normal(False, learning_rate=0.7)
-        before = _dense(est.cov_inv_)
-        with pytest.warns(FutureWarning, match="learning_rate"):
+    def test_neither_rule_nor_rate_is_an_error(self):
+        est, _ = _fit_normal(False, forgetting=ExponentialForgetting(0.7))
+        with pytest.raises(TypeError, match="decay_rate="):
             est.decay(steps=2)
-        assert_allclose(_dense(est.cov_inv_), 0.7**2 * before)
 
 
 class TestNormalInverseGamma:

--- a/tests/test_eb_estimators.py
+++ b/tests/test_eb_estimators.py
@@ -13,6 +13,8 @@ from bayesianbandits import (
     EmpiricalBayesDirichletClassifier,
     EmpiricalBayesGammaRegressor,
     EmpiricalBayesNormalRegressor,
+    ExponentialForgetting,
+    StabilizedForgetting,
 )
 from bayesianbandits._estimators import NormalRegressor
 
@@ -278,7 +280,7 @@ class TestEBNormalRegressor:
         model = EmpiricalBayesNormalRegressor(
             alpha=1.0,
             beta=1.0,
-            learning_rate=0.99,
+            forgetting=StabilizedForgetting(0.99),
             sparse=sparse,
         )
         model.fit(X, y)
@@ -303,7 +305,7 @@ class TestEBNormalRegressor:
         """decay() with decay_rate=1.0 is a no-op (zero reinjection)."""
         X, y = regression_data
         model = EmpiricalBayesNormalRegressor(
-            alpha=1.0, beta=1.0, learning_rate=0.99, sparse=sparse
+            alpha=1.0, beta=1.0, forgetting=StabilizedForgetting(0.99), sparse=sparse
         )
         model.fit(X, y)
 
@@ -322,7 +324,7 @@ class TestEBNormalRegressor:
         model = EmpiricalBayesNormalRegressor(
             alpha=1.0,
             beta=1.0,
-            learning_rate=0.99,
+            forgetting=StabilizedForgetting(0.99),
             sparse=sparse,
         )
         model.fit(X[:50], y[:50])
@@ -357,7 +359,7 @@ class TestEBNormalRegressor:
         model = EmpiricalBayesNormalRegressor(
             alpha=1.0,
             beta=1.0,
-            learning_rate=0.99,
+            forgetting=StabilizedForgetting(0.99),
             sparse=sparse,
         )
         model.fit(X, y)
@@ -390,7 +392,7 @@ class TestEBNormalRegressor:
         model = EmpiricalBayesNormalRegressor(
             alpha=1.0,
             beta=1.0,
-            learning_rate=0.99,
+            forgetting=StabilizedForgetting(0.99),
             sparse=sparse,
         )
         # Should not raise
@@ -493,7 +495,7 @@ class TestEBNormalRegressor:
     def test_partial_fit_tracks_full_fit(self, sparse):
         """Chunked partial_fit from far-off α, β must land on the full fit.
 
-        With ``learning_rate=1`` the online learner sees the same
+        With ``forgetting=ExponentialForgetting(1`` the online learner sees the same)
         sufficient statistics as ``fit``, so its MacKay fixed point is
         the same one. Before ``_correct_precision`` re-solved ``coef_``
         it drifted (α off by 1.8x, β off by 0.5x, coef off by 0.3).
@@ -729,7 +731,7 @@ class TestSampleWeight:
         weights[:5] = 2.0  # upweight first half
 
         model = EmpiricalBayesNormalRegressor(
-            alpha=1.0, beta=1.0, sparse=sparse, learning_rate=0.99
+            alpha=1.0, beta=1.0, sparse=sparse, forgetting=StabilizedForgetting(0.99)
         )
         model.fit(X[:50], y[:50])
 
@@ -745,14 +747,14 @@ class TestSampleWeight:
         X, y = regression_data
 
         model_uniform = EmpiricalBayesNormalRegressor(
-            alpha=1.0, beta=1.0, sparse=sparse, learning_rate=0.99
+            alpha=1.0, beta=1.0, sparse=sparse, forgetting=StabilizedForgetting(0.99)
         )
         model_uniform.fit(X[:50], y[:50])
         model_uniform.partial_fit(X[50:60], y[50:60])
         coef_uniform = model_uniform.coef_.copy()
 
         model_weighted = EmpiricalBayesNormalRegressor(
-            alpha=1.0, beta=1.0, sparse=sparse, learning_rate=0.99
+            alpha=1.0, beta=1.0, sparse=sparse, forgetting=StabilizedForgetting(0.99)
         )
         model_weighted.fit(X[:50], y[:50])
         weights = np.ones(10)
@@ -786,7 +788,7 @@ class TestPriorScalar:
     """``_prior_scalar`` is the prior's real contribution to Λ's diagonal.
 
     Under forgetting ``_fit_helper`` scales the prior by
-    ``learning_rate ** n_samples``, so ``alpha`` itself overstates it.
+    ``rate ** n_samples``, so ``alpha`` itself overstates it.
     MacKay's ``gamma = p - prior_scalar * tr(Λ⁻¹)`` is sensitive to
     that: every unobserved feature contributes exactly
     ``1 / prior_scalar`` to the trace, so overstating the scalar pushes
@@ -800,15 +802,13 @@ class TestPriorScalar:
         y = X @ rng.standard_normal(8) + 0.1 * rng.standard_normal(200)
 
         model = EmpiricalBayesNormalRegressor(
-            alpha=1.0, beta=1.0, learning_rate=0.99, sparse=sparse
+            alpha=1.0, beta=1.0, forgetting=StabilizedForgetting(0.99), sparse=sparse
         )
         model.fit(X, y)
 
         diagonal = model.cov_inv_.diagonal() if sparse else np.diag(model.cov_inv_)
         assert model._prior_scalar <= np.min(diagonal) * (1 + 1e-9)
-        assert model._prior_scalar == pytest.approx(
-            model.learning_rate ** X.shape[0] * model.alpha
-        )
+        assert model._prior_scalar == pytest.approx(0.99 ** X.shape[0] * model.alpha)
 
     def test_gamma_stays_in_range_when_features_are_unobserved(self, sparse):
         """Wide data with all-zero columns keeps gamma in (0, min(n, p)].
@@ -826,7 +826,7 @@ class TestPriorScalar:
         y = X[:, :20] @ rng.standard_normal(20) + 0.1 * rng.standard_normal(n_samples)
 
         model = EmpiricalBayesNormalRegressor(
-            alpha=1.0, beta=1.0, learning_rate=0.99999, sparse=sparse
+            alpha=1.0, beta=1.0, forgetting=StabilizedForgetting(0.99999), sparse=sparse
         )
         model.fit(X, y)
 
@@ -841,7 +841,7 @@ class TestPriorScalar:
         y = X[:, :20] @ rng.standard_normal(20) + 0.1 * rng.standard_normal(30)
 
         model = EmpiricalBayesNormalRegressor(
-            alpha=1.0, beta=1.0, learning_rate=0.99999, sparse=sparse
+            alpha=1.0, beta=1.0, forgetting=StabilizedForgetting(0.99999), sparse=sparse
         )
         model.fit(X, y)
 
@@ -856,7 +856,7 @@ class TestPriorScalar:
         y = X[:, :20] @ rng.standard_normal(20) + 0.1 * rng.standard_normal(30)
 
         model = EmpiricalBayesNormalRegressor(
-            alpha=1.0, beta=1.0, learning_rate=0.99999, sparse=sparse
+            alpha=1.0, beta=1.0, forgetting=StabilizedForgetting(0.99999), sparse=sparse
         )
         model.fit(X[:20], y[:20])
         before = (model.alpha, model.beta)
@@ -1102,14 +1102,14 @@ class TestEBDirichletClassifier:
         y = np.concatenate(y_parts)
 
         model = EmpiricalBayesDirichletClassifier(
-            {0: 1.0, 1: 1.0}, learning_rate=0.9, random_state=42
+            {0: 1.0, 1: 1.0}, forgetting=StabilizedForgetting(0.9), random_state=42
         )
         model.fit(X, y)
         prior_after_fit = model.prior_.copy()
 
         # Decay all groups
         for _ in range(200):
-            model.decay(decay_rate=model.learning_rate)
+            model.decay(decay_rate=0.9)
 
         # Alphas should converge to prior, not zero
         for key in list(model.known_alphas_.keys()):
@@ -1137,10 +1137,10 @@ class TestEBDirichletClassifier:
         lr = 0.9
 
         batch_model = EmpiricalBayesDirichletClassifier(
-            {0: 1.0, 1: 1.0}, learning_rate=lr, random_state=42
+            {0: 1.0, 1: 1.0}, forgetting=StabilizedForgetting(lr), random_state=42
         )
         seq_model = EmpiricalBayesDirichletClassifier(
-            {0: 1.0, 1: 1.0}, learning_rate=lr, random_state=42
+            {0: 1.0, 1: 1.0}, forgetting=StabilizedForgetting(lr), random_state=42
         )
 
         # Phase 1: diverge
@@ -1192,7 +1192,9 @@ class TestEBDirichletClassifier:
         """Stabilized forgetting prevents negative counts with lr < 1."""
         rng = np.random.default_rng(42)
         model = EmpiricalBayesDirichletClassifier(
-            {0: 1.0, 1: 1.0, 2: 1.0}, learning_rate=0.8, random_state=0
+            {0: 1.0, 1: 1.0, 2: 1.0},
+            forgetting=StabilizedForgetting(0.8),
+            random_state=0,
         )
 
         for i in range(200):
@@ -1201,7 +1203,7 @@ class TestEBDirichletClassifier:
             model.partial_fit(np.array([[g]]), np.array([cls]))
 
             if i % 3 == 0:
-                model.decay(decay_rate=model.learning_rate)
+                model.decay(decay_rate=0.8)
 
             for key, val in model.known_alphas_.items():
                 if hasattr(val, "__len__"):
@@ -1288,7 +1290,7 @@ class TestEBDirichletClassifier:
         """Decay on unfitted model: stabilized forgetting gives lr*α + (1-lr)*α = α."""
         lr = 0.9
         model = EmpiricalBayesDirichletClassifier(
-            {0: 2.0, 1: 3.0}, learning_rate=lr, random_state=42
+            {0: 2.0, 1: 3.0}, forgetting=StabilizedForgetting(lr), random_state=42
         )
         model.decay(decay_rate=lr)
 
@@ -1440,13 +1442,13 @@ class TestEBGammaRegressor:
         y = np.concatenate(y_parts)
 
         model = EmpiricalBayesGammaRegressor(
-            alpha=1.0, beta=1.0, learning_rate=0.9, random_state=42
+            alpha=1.0, beta=1.0, forgetting=StabilizedForgetting(0.9), random_state=42
         )
         model.fit(X, y)
         prior_after_fit = model.prior_.copy()
 
         for _ in range(200):
-            model.decay(decay_rate=model.learning_rate)
+            model.decay(decay_rate=0.9)
 
         for key in list(model.coef_.keys()):
             np.testing.assert_allclose(
@@ -1463,7 +1465,7 @@ class TestEBGammaRegressor:
         """Decay on unfitted model: stabilized forgetting gives lr*p + (1-lr)*p = p."""
         lr = 0.9
         model = EmpiricalBayesGammaRegressor(
-            alpha=2.0, beta=3.0, learning_rate=lr, random_state=42
+            alpha=2.0, beta=3.0, forgetting=StabilizedForgetting(lr), random_state=42
         )
         model.decay(decay_rate=lr)
 
@@ -1538,7 +1540,7 @@ class TestEBGammaRegressor:
         """Stabilized forgetting prevents negative counts with lr < 1."""
         rng = np.random.default_rng(42)
         model = EmpiricalBayesGammaRegressor(
-            alpha=1.0, beta=1.0, learning_rate=0.8, random_state=0
+            alpha=1.0, beta=1.0, forgetting=StabilizedForgetting(0.8), random_state=0
         )
 
         for i in range(200):
@@ -1547,7 +1549,7 @@ class TestEBGammaRegressor:
             model.partial_fit(np.array([[g]]), np.array([count]))
 
             if i % 3 == 0:
-                model.decay(decay_rate=model.learning_rate)
+                model.decay(decay_rate=0.8)
 
             for key, val in model.coef_.items():
                 counts = val - model.prior_
@@ -1680,7 +1682,9 @@ class TestFailedUpdateLeavesEstimatorIntact:
         y = rng.standard_normal(30)
         X_fit = sp.csc_array(X) if sparse else X
 
-        est = cls(alpha=1.0, beta=1.0, learning_rate=0.9, sparse=sparse)
+        est = cls(
+            alpha=1.0, beta=1.0, forgetting=ExponentialForgetting(0.9), sparse=sparse
+        )
         est.partial_fit(X_fit[:15], y[:15])
 
         def _dense(matrix):
@@ -1700,13 +1704,10 @@ class TestFailedUpdateLeavesEstimatorIntact:
                 side_effect=np.linalg.LinAlgError("boom"),
             )
         else:
-            module = (
-                "bayesianbandits._eb_estimators"
-                if cls is EmpiricalBayesNormalRegressor
-                else "bayesianbandits._estimators"
-            )
+            # The EB estimator delegates its update to the base class.
             failure = mock.patch(
-                f"{module}.cho_factor_f", side_effect=np.linalg.LinAlgError("boom")
+                "bayesianbandits._estimators.cho_factor_f",
+                side_effect=np.linalg.LinAlgError("boom"),
             )
 
         with failure, pytest.raises(np.linalg.LinAlgError):
@@ -1722,7 +1723,7 @@ class TestFailedUpdateLeavesEstimatorIntact:
         rng = np.random.default_rng(0)
         X = rng.standard_normal((10, 4))
         y = rng.standard_normal(10)
-        est = EmpiricalBayesNormalRegressor(learning_rate=0.9)
+        est = EmpiricalBayesNormalRegressor(forgetting=StabilizedForgetting(0.9))
 
         with mock.patch.object(
             EmpiricalBayesNormalRegressor,
@@ -1761,7 +1762,10 @@ class TestSufficientStatsCarryTheRowWeights:
         X, y = regression_data
         X, y = X[:12], y[:12]
         model = EmpiricalBayesNormalRegressor(
-            alpha=1.0, beta=1.0, sparse=sparse, learning_rate=learning_rate
+            alpha=1.0,
+            beta=1.0,
+            sparse=sparse,
+            forgetting=StabilizedForgetting(learning_rate),
         )
         model.fit(sp.csc_array(X) if sparse else X, y)
 
@@ -1779,7 +1783,10 @@ class TestSufficientStatsCarryTheRowWeights:
         X, y = regression_data
         Xf = sp.csc_array(X) if sparse else X
         model = EmpiricalBayesNormalRegressor(
-            alpha=1.0, beta=1.0, sparse=sparse, learning_rate=learning_rate
+            alpha=1.0,
+            beta=1.0,
+            sparse=sparse,
+            forgetting=StabilizedForgetting(learning_rate),
         )
         model.fit(Xf[:10], y[:10])
         for i in range(10, 40, 5):
@@ -1788,7 +1795,10 @@ class TestSufficientStatsCarryTheRowWeights:
         assert model.beta != 1.0
 
         one_at_a_time = EmpiricalBayesNormalRegressor(
-            alpha=1.0, beta=1.0, sparse=sparse, learning_rate=learning_rate
+            alpha=1.0,
+            beta=1.0,
+            sparse=sparse,
+            forgetting=StabilizedForgetting(learning_rate),
         )
         one_at_a_time.fit(Xf[:10], y[:10])
         for i in range(10, 40):
@@ -1802,16 +1812,14 @@ class TestSufficientStatsCarryTheRowWeights:
         self, regression_data, sparse
     ):
         """The sklearn invariant, and the sharpest form of the bug: at
-        ``learning_rate=1`` there is no decay, so any discrepancy is
+        ``forgetting=ExponentialForgetting(1`` there is no decay), so any discrepancy is
         ``sample_weight`` alone."""
         X, y = regression_data
         X, y = X[:12], y[:12]
         Xd, yd = np.repeat(X, 2, axis=0), np.repeat(y, 2)
 
         def run(X_, y_, step, **kw):
-            model = EmpiricalBayesNormalRegressor(
-                alpha=1.0, beta=1.0, sparse=sparse, learning_rate=1.0
-            )
+            model = EmpiricalBayesNormalRegressor(alpha=1.0, beta=1.0, sparse=sparse)
             Xf = sp.csc_array(X_) if sparse else X_
             sw = kw.get("sample_weight")
             model.fit(

--- a/tests/test_eb_glm.py
+++ b/tests/test_eb_glm.py
@@ -15,6 +15,7 @@ from bayesianbandits import (
     EmpiricalBayesGLM,
     LaplaceApproximator,
     RVGAApproximator,
+    StabilizedForgetting,
 )
 from bayesianbandits._empirical_bayes import glm_log_likelihood
 
@@ -306,7 +307,9 @@ class TestEBGLM:
 
     def test_decay_reinjects_prior(self, link, sparse):
         X, y = _simulate(link)
-        model = EmpiricalBayesGLM(link=link, learning_rate=0.9, sparse=sparse)
+        model = EmpiricalBayesGLM(
+            link=link, forgetting=StabilizedForgetting(0.9), sparse=sparse
+        )
         model.fit(_X(X, sparse), y)
         diag_before = _diag(model)
         s_before = model._prior_scalar
@@ -325,7 +328,9 @@ class TestEBGLM:
         """With learning_rate < 1 the prior component after partial_fit is
         γⁿ·s_old + (1 - γⁿ)·alpha_old, then rescaled by the MacKay step."""
         X, y = _simulate(link)
-        model = EmpiricalBayesGLM(link=link, learning_rate=0.95, sparse=sparse)
+        model = EmpiricalBayesGLM(
+            link=link, forgetting=StabilizedForgetting(0.95), sparse=sparse
+        )
         model.fit(_X(X[:100], sparse), y[:100])
         s_old, alpha_old = model._prior_scalar, model.alpha
         g = 0.95**20
@@ -389,7 +394,9 @@ class TestEBGLM:
 
     def test_pickle_after_online_update(self, link, sparse):
         X, y = _simulate(link)
-        model = EmpiricalBayesGLM(link=link, sparse=sparse, learning_rate=0.99)
+        model = EmpiricalBayesGLM(
+            link=link, sparse=sparse, forgetting=StabilizedForgetting(0.99)
+        )
         model.fit(_X(X, sparse), y)
         model.partial_fit(_X(X[:50], sparse), y[:50])
         model.decay(decay_rate=0.99, steps=5)
@@ -464,7 +471,9 @@ class TestFailedPartialFitLeavesEBStateIntact:
     @staticmethod
     def _fitted(sparse):
         X, y = _simulate("log", n=40, p=4)
-        model = EmpiricalBayesGLM(link="log", learning_rate=0.9, sparse=sparse)
+        model = EmpiricalBayesGLM(
+            link="log", forgetting=StabilizedForgetting(0.9), sparse=sparse
+        )
         return model.fit(_X(X, sparse), y), X, y
 
     @pytest.mark.parametrize("sparse", [False, True])
@@ -493,7 +502,9 @@ class TestEffectiveN:
     def test_counts_the_effective_row_weights(self):
         X, y = _simulate("log", n=4, p=3)
         w = np.array([2.0, 3.0, 1.0, 4.0])
-        model = EmpiricalBayesGLM(link="log", learning_rate=0.9).fit(X, y, w)
+        model = EmpiricalBayesGLM(link="log", forgetting=StabilizedForgetting(0.9)).fit(
+            X, y, w
+        )
         assert model._effective_n == pytest.approx(
             np.sum(w * 0.9 ** np.arange(3, -1, -1))
         )

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -5,6 +5,7 @@ from numpy.typing import NDArray
 
 from bayesianbandits import (
     DirichletClassifier,
+    ExponentialForgetting,
     GammaRegressor,
 )
 
@@ -204,13 +205,13 @@ def test_dirichletclassifier_decay(
     """Test GammaRegressor decay only increases variance."""
 
     clf = DirichletClassifier(
-        alphas={1: 1, 2: 1, 3: 1}, learning_rate=0.9, random_state=0
+        alphas={1: 1, 2: 1, 3: 1}, forgetting=ExponentialForgetting(0.9), random_state=0
     )
     clf.fit(X, y)
 
     pre_decay = clf.predict(X)
 
-    clf.decay(decay_rate=clf.learning_rate, steps=len(X))
+    clf.decay(decay_rate=0.9, steps=len(X))
 
     assert_almost_equal(clf.predict(X), pre_decay)
 
@@ -221,9 +222,7 @@ def test_dirichletclassifier_manual_decay(
 ) -> None:
     """Test GammaRegressor decay only increases variance."""
 
-    clf = DirichletClassifier(
-        alphas={1: 1, 2: 1, 3: 1}, learning_rate=1.0, random_state=0
-    )
+    clf = DirichletClassifier(alphas={1: 1, 2: 1, 3: 1}, random_state=0)
     clf.fit(X, y)
 
     pre_decay = clf.predict(X)
@@ -347,10 +346,10 @@ def test_dirichletclassifier_partial_fit_with_weights(
     assert_almost_equal(clf1.known_alphas_[2], clf2.known_alphas_[2])
     assert_almost_equal(clf1.known_alphas_[3], clf2.known_alphas_[3])
 
-    # Test sequential partial_fit with learning_rate=1 (no decay)
+    # Test sequential partial_fit with forgetting=ExponentialForgetting(1 (no decay))
     clf3 = DirichletClassifier(
         alphas={1: 1, 2: 1, 3: 1},
-        learning_rate=1.0,  # No decay
+        # No decay
         random_state=0,
     )
     # First batch
@@ -365,10 +364,8 @@ def test_dirichletclassifier_partial_fit_with_weights(
     w2 = weights[5:]
     clf3.partial_fit(X2, y2, sample_weight=w2)
 
-    # With learning_rate=1, sequential partial_fit should equal single fit
-    clf4 = DirichletClassifier(
-        alphas={1: 1, 2: 1, 3: 1}, learning_rate=1.0, random_state=0
-    )
+    # With sequential partial_fit should equal single fit
+    clf4 = DirichletClassifier(alphas={1: 1, 2: 1, 3: 1}, random_state=0)
     clf4.fit(X, y, sample_weight=weights)
 
     assert_almost_equal(clf3.known_alphas_[1], clf4.known_alphas_[1])
@@ -384,7 +381,7 @@ def test_dirichletclassifier_weights_learning_rate_interaction() -> None:
 
     # Test with learning_rate < 1
     clf1 = DirichletClassifier(
-        alphas={1: 1, 2: 1, 3: 1}, learning_rate=0.5, random_state=0
+        alphas={1: 1, 2: 1, 3: 1}, forgetting=ExponentialForgetting(0.5), random_state=0
     )
     weights = np.array([2.0, 1.0, 0.5])
     clf1.fit(X, y, sample_weight=weights)
@@ -402,7 +399,7 @@ def test_dirichletclassifier_weights_learning_rate_interaction() -> None:
     # Also verify that weights and decay compose properly
     # If we double all weights, the posterior should scale accordingly
     clf2 = DirichletClassifier(
-        alphas={1: 1, 2: 1, 3: 1}, learning_rate=0.5, random_state=0
+        alphas={1: 1, 2: 1, 3: 1}, forgetting=ExponentialForgetting(0.5), random_state=0
     )
     weights_double = weights * 2
     clf2.fit(X, y, sample_weight=weights_double)
@@ -622,12 +619,14 @@ def test_gamma_regressor_decay(
 ) -> None:
     """Test GammaRegressor decay only increases variance."""
 
-    clf = GammaRegressor(alpha=1, beta=1, learning_rate=0.9, random_state=0)
+    clf = GammaRegressor(
+        alpha=1, beta=1, forgetting=ExponentialForgetting(0.9), random_state=0
+    )
     clf.fit(X, y)
 
     pre_decay = clf.predict(X)
 
-    clf.decay(decay_rate=clf.learning_rate, steps=len(X))
+    clf.decay(decay_rate=0.9, steps=len(X))
 
     assert_almost_equal(clf.predict(X), pre_decay)
 
@@ -638,7 +637,7 @@ def test_gamma_regressor_manual_decay(
 ) -> None:
     """Test GammaRegressor decay only increases variance."""
 
-    clf = GammaRegressor(alpha=1, beta=1, learning_rate=1.0, random_state=0)
+    clf = GammaRegressor(alpha=1, beta=1, random_state=0)
     clf.fit(X, y)
 
     pre_decay = clf.predict(X)
@@ -765,11 +764,11 @@ def test_gamma_regressor_partial_fit_with_weights(
     assert_almost_equal(clf1.coef_[2], clf2.coef_[2])
     assert_almost_equal(clf1.coef_[3], clf2.coef_[3])
 
-    # Test sequential partial_fit with learning_rate=1 (no decay)
+    # Test sequential partial_fit with forgetting=ExponentialForgetting(1 (no decay))
     clf3 = GammaRegressor(
         alpha=1,
         beta=1,
-        learning_rate=1.0,  # No decay
+        # No decay
         random_state=0,
     )
     # First batch
@@ -784,8 +783,8 @@ def test_gamma_regressor_partial_fit_with_weights(
     w2 = weights[5:]
     clf3.partial_fit(X2, y2, sample_weight=w2)
 
-    # With learning_rate=1, sequential partial_fit should equal single fit
-    clf4 = GammaRegressor(alpha=1, beta=1, learning_rate=1.0, random_state=0)
+    # With sequential partial_fit should equal single fit
+    clf4 = GammaRegressor(alpha=1, beta=1, random_state=0)
     clf4.fit(X, y, sample_weight=weights)
 
     assert_almost_equal(clf3.coef_[1], clf4.coef_[1])
@@ -800,7 +799,9 @@ def test_gamma_regressor_weights_learning_rate_interaction() -> None:
     y = np.array([2, 4, 6])
 
     # Test with learning_rate < 1
-    clf1 = GammaRegressor(alpha=1, beta=1, learning_rate=0.5, random_state=0)
+    clf1 = GammaRegressor(
+        alpha=1, beta=1, forgetting=ExponentialForgetting(0.5), random_state=0
+    )
     weights = np.array([2.0, 1.0, 0.5])
     clf1.fit(X, y, sample_weight=weights)
 
@@ -942,10 +943,12 @@ def test_gamma_regressor_decay_with_weights() -> None:
     y = np.array([10])
     weights = np.array([2.0])
 
-    clf = GammaRegressor(alpha=1, beta=1, learning_rate=0.9, random_state=0)
+    clf = GammaRegressor(
+        alpha=1, beta=1, forgetting=ExponentialForgetting(0.9), random_state=0
+    )
     clf.fit(X, y, sample_weight=weights)
 
-    # With learning_rate=0.9:
+    # With forgetting=ExponentialForgetting(0.9:)
     # Stack: [[1, 1], [20, 2]]
     # Decay: [0.9^1, 0.9^0] = [0.9, 1.0]
     # Result: [1, 1]*0.9 + [20, 2]*1.0 = [0.9, 0.9] + [20, 2] = [20.9, 2.9]

--- a/tests/test_exp3a.py
+++ b/tests/test_exp3a.py
@@ -13,6 +13,7 @@ from bayesianbandits import (
     EXP3A,
     Arm,
     ContextualAgent,
+    ExponentialForgetting,
     NormalInverseGammaRegressor,
     NormalRegressor,
 )
@@ -397,8 +398,18 @@ class TestEXP3ANonStationarity:
         """Test that EXP3A adapts when rewards change."""
         # Create two arms
         arms = [
-            Arm(0, learner=NormalInverseGammaRegressor(learning_rate=0.9)),
-            Arm(1, learner=NormalInverseGammaRegressor(learning_rate=0.9)),
+            Arm(
+                0,
+                learner=NormalInverseGammaRegressor(
+                    forgetting=ExponentialForgetting(0.9)
+                ),
+            ),
+            Arm(
+                1,
+                learner=NormalInverseGammaRegressor(
+                    forgetting=ExponentialForgetting(0.9)
+                ),
+            ),
         ]
 
         policy = EXP3A(gamma=0.1, eta=2.0, samples=20)

--- a/tests/test_forgetting.py
+++ b/tests/test_forgetting.py
@@ -790,16 +790,7 @@ class TestTick:
         assert C_bar.flags.c_contiguous
 
     def test_directional_rules_have_no_tick(self):
-        from bayesianbandits._forgetting import TickRule, UpdateRule
-
-        assert isinstance(ExponentialForgetting(0.9), TickRule)
-        assert isinstance(StabilizedForgetting(0.9), TickRule)
-        assert not isinstance(FeatureWiseForgetting(0.9), TickRule)
-        assert not isinstance(SiftForgetting(0.9), TickRule)
-        for rule in (
-            ExponentialForgetting(0.9),
-            StabilizedForgetting(0.9),
-            FeatureWiseForgetting(0.9),
-            SiftForgetting(0.9),
-        ):
-            assert isinstance(rule, UpdateRule)
+        for rule in (ExponentialForgetting(0.9), StabilizedForgetting(0.9)):
+            assert hasattr(rule, "tick") and hasattr(rule, "update")
+        for rule in (FeatureWiseForgetting(0.9), SiftForgetting(0.9)):
+            assert not hasattr(rule, "tick") and hasattr(rule, "update")

--- a/tests/test_forgetting.py
+++ b/tests/test_forgetting.py
@@ -139,6 +139,19 @@ class TestFilterBatch:
         surviving = eigvals_orig[eigvals_orig >= 1e-12]
         assert_allclose(eigvals_bar, surviving, rtol=1e-10)
 
+    def test_dense_reads_only_the_upper_triangle(self):
+        """The dense fit paths keep only the upper triangle current, in
+        either memory layout; the downdate must not read the other one."""
+        rng = np.random.default_rng(7)
+        R = _random_pd(6, rng)
+        X_bar = rng.standard_normal((2, 6))
+        clean = np.triu(_sift_downdate_dense(np.asfortranarray(R), X_bar, 0.8))
+        for order in ("C", "F"):
+            junk = np.array(R, order=order)
+            junk[np.tril_indices(6, -1)] = 1e9
+            out = _sift_downdate_dense(junk, X_bar, 0.8)
+            assert_allclose(np.triu(out), clean, rtol=1e-12)
+
     @pytest.mark.parametrize("use_sparse", [False, True], ids=["dense", "sparse"])
     def test_q_zero_returns_none(self, use_sparse):
         """When no eigenvalues survive thresholding, return None."""
@@ -764,6 +777,17 @@ class TestTick:
         assert_allclose(
             sparse.csc_array(R_bar).toarray(), 0.9 * R.toarray() + 0.1 * np.eye(4)
         )
+
+    def test_stabilized_tick_keeps_the_dense_layout(self):
+        rng = np.random.default_rng(0)
+        R = np.asfortranarray(_random_pd(4, rng))
+        R_bar = np.asarray(StabilizedForgetting(0.9).tick(R, alpha=2.0))
+        assert R_bar.flags.f_contiguous
+        assert_allclose(R_bar, 0.9 * R + 0.1 * 2.0 * np.eye(4), atol=1e-12)
+        C_bar = np.asarray(
+            StabilizedForgetting(0.9).tick(np.ascontiguousarray(R), alpha=2.0)
+        )
+        assert C_bar.flags.c_contiguous
 
     def test_directional_rules_have_no_tick(self):
         from bayesianbandits._forgetting import TickRule, UpdateRule

--- a/tests/test_forgetting_update.py
+++ b/tests/test_forgetting_update.py
@@ -1,0 +1,389 @@
+"""``forgetting=``: the per-update forgetting API on the estimators."""
+
+import pickle
+from typing import Any
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+from scipy import sparse as sp
+
+from bayesianbandits import (
+    BayesianGLM,
+    DirichletClassifier,
+    EmpiricalBayesGammaRegressor,
+    EmpiricalBayesGLM,
+    EmpiricalBayesNormalRegressor,
+    ExponentialForgetting,
+    FeatureWiseForgetting,
+    GammaRegressor,
+    NormalInverseGammaRegressor,
+    NormalRegressor,
+    SiftForgetting,
+    StabilizedForgetting,
+)
+from bayesianbandits._gaussian import RVGAApproximator
+
+
+def _dense(P):
+    return P.toarray() if sp.issparse(P) else np.asarray(P)
+
+
+def _sym(P):
+    """The dense fit paths keep only the upper triangle current."""
+    P = _dense(P)
+    return np.triu(P) + np.triu(P, 1).T
+
+
+def _data(n=30, p=4, seed=0):
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n, p))
+    y = X @ np.linspace(1, -1, p) + rng.normal(0, 0.1, n)
+    return X, y
+
+
+class TestUniformRulesOnUpdate:
+    @pytest.mark.parametrize("sparse", [False, True])
+    def test_exponential_is_one_step_per_row(self, sparse):
+        """A batch of n rows scales the prior by rate**n and weighs its
+        older rows less: the same posterior as n single-row updates."""
+        X, y = _data()
+        one = NormalRegressor(
+            alpha=1.0, beta=2.0, sparse=sparse, forgetting=ExponentialForgetting(0.9)
+        )
+        many = NormalRegressor(
+            alpha=1.0, beta=2.0, sparse=sparse, forgetting=ExponentialForgetting(0.9)
+        )
+        wrap = (lambda A: sp.csc_array(A)) if sparse else (lambda A: A)
+        one.fit(wrap(X[:10]), y[:10])
+        many.fit(wrap(X[:10]), y[:10])
+        one.partial_fit(wrap(X[10:]), y[10:])
+        for i in range(10, 30):
+            many.partial_fit(wrap(X[i : i + 1]), y[i : i + 1])
+        assert_allclose(one.coef_, many.coef_, rtol=1e-10)
+        assert_allclose(_sym(one.cov_inv_), _sym(many.cov_inv_), rtol=1e-10)
+
+    @pytest.mark.parametrize("sparse", [False, True])
+    def test_stabilized_floors_after_the_first_fit_only(self, sparse):
+        X, y = _data()
+        wrap = (lambda A: sp.csc_array(A)) if sparse else (lambda A: A)
+        est = NormalRegressor(
+            alpha=2.0, beta=1.0, sparse=sparse, forgetting=StabilizedForgetting(0.8)
+        )
+        plain = NormalRegressor(
+            alpha=2.0, beta=1.0, sparse=sparse, forgetting=ExponentialForgetting(0.8)
+        )
+        est.fit(wrap(X[:10]), y[:10])
+        plain.fit(wrap(X[:10]), y[:10])
+        # fit: nothing to forget yet, so no floor is added.
+        assert_allclose(_sym(est.cov_inv_), _sym(plain.cov_inv_))
+        est.partial_fit(wrap(X[10:15]), y[10:15])
+        plain.partial_fit(wrap(X[10:15]), y[10:15])
+        g = 0.8**5
+        assert_allclose(
+            _sym(est.cov_inv_), _sym(plain.cov_inv_) + (1 - g) * 2.0 * np.eye(4)
+        )
+
+    def test_stabilized_after_sample_before_fit_is_not_floored(self):
+        X, y = _data()
+        est = NormalRegressor(alpha=2.0, beta=1.0, forgetting=StabilizedForgetting(0.8))
+        plain = NormalRegressor(
+            alpha=2.0, beta=1.0, forgetting=ExponentialForgetting(0.8)
+        )
+        est.sample(X[:2])  # initializes the prior without fitting
+        plain.sample(X[:2])
+        est.partial_fit(X[:10], y[:10])
+        plain.partial_fit(X[:10], y[:10])
+        assert_allclose(_sym(est.cov_inv_), _sym(plain.cov_inv_))
+
+    def test_no_rule_is_no_forgetting(self):
+        X, y = _data()
+        est = NormalRegressor(alpha=1.0, beta=1.0).fit(X[:10], y[:10])
+        before = _sym(est.cov_inv_)
+        est.partial_fit(X[10:], y[10:])
+        gain = _sym(est.cov_inv_) - before
+        assert np.all(np.linalg.eigvalsh(gain) >= -1e-10)
+
+    def test_nig_dense_stabilized_floors_at_lam(self):
+        X, y = _data()
+        est = NormalInverseGammaRegressor(lam=2.0, forgetting=StabilizedForgetting(0.8))
+        plain = NormalInverseGammaRegressor(
+            lam=2.0, forgetting=ExponentialForgetting(0.8)
+        )
+        est.fit(X[:10], y[:10])
+        plain.fit(X[:10], y[:10])
+        est.partial_fit(X[10:15], y[10:15])
+        plain.partial_fit(X[10:15], y[10:15])
+        g = 0.8**5
+        assert_allclose(
+            _sym(est.cov_inv_), _sym(plain.cov_inv_) + (1 - g) * 2.0 * np.eye(4)
+        )
+
+    def test_nig_forgets_the_inverse_gamma_under_a_uniform_rule_only(self):
+        X, y = _data()
+        uni = NormalInverseGammaRegressor(forgetting=ExponentialForgetting(0.9))
+        uni.fit(X[:10], y[:10])
+        a, b = uni.a_, uni.b_
+        uni.partial_fit(X[10:15], y[10:15])
+        # Older rows of the batch weigh less: the effective count is a
+        # geometric sum, not 5.
+        assert uni.a_ == pytest.approx(0.9**5 * a + 0.5 * np.sum(0.9 ** np.arange(5)))
+        assert uni.b_ < 0.9**5 * b + 0.5 * np.sum(y[10:15] ** 2) + 1e-9
+        dire = NormalInverseGammaRegressor(forgetting=FeatureWiseForgetting(0.9))
+        dire.fit(X[:10], y[:10])
+        a = dire.a_
+        dire.partial_fit(X[10:15], y[10:15])
+        assert dire.a_ == pytest.approx(a + 2.5)
+
+
+class TestDirectionalRulesOnUpdate:
+    def test_feature_wise_scales_only_the_observed_features(self):
+        X, y = _data(p=4)
+        est = NormalRegressor(
+            alpha=1.0, beta=1.0, forgetting=FeatureWiseForgetting(0.5)
+        )
+        est.fit(X[:10], y[:10])
+        R = _sym(est.cov_inv_)
+        # One row touching features 0 and 1 only.
+        x = np.array([[1.0, 2.0, 0.0, 0.0]])
+        est.partial_fit(x, np.array([0.3]))
+        d = np.array([np.sqrt(0.5), np.sqrt(0.5), 1.0, 1.0])
+        expected = (d[:, None] * R) * d[None, :] + x.T @ x
+        assert_allclose(_sym(est.cov_inv_), expected, rtol=1e-10)
+
+    def test_feature_wise_keeps_the_sparsity_pattern(self):
+        rng = np.random.default_rng(0)
+        p = 40
+        rows = []
+        for _ in range(60):
+            r = np.zeros(p)
+            r[0] = 1.0  # shared column
+            r[1 + rng.integers(p - 1)] = 1.0
+            rows.append(r)
+        X = sp.csc_array(np.array(rows))
+        y = rng.standard_normal(60)
+        est = NormalRegressor(
+            alpha=1.0, beta=1.0, sparse=True, forgetting=FeatureWiseForgetting(0.9)
+        )
+        est.fit(X[:30], y[:30])
+        pattern = set(zip(*est.cov_inv_.nonzero()))
+        est.partial_fit(X[30:], y[30:])
+        data_pattern = set(zip(*((X.T @ X).nonzero())))
+        assert set(zip(*est.cov_inv_.nonzero())) <= pattern | data_pattern
+
+    def test_sift_downdates_along_the_batch(self):
+        X, y = _data(p=3)
+        est = NormalRegressor(alpha=1.0, beta=1.0, forgetting=SiftForgetting(0.5))
+        est.fit(X[:10], y[:10])
+        R = _sym(est.cov_inv_)
+        x = np.array([[1.0, 0.0, 0.0]])
+        est.partial_fit(x, np.array([0.0]))
+        w = R @ x[0]
+        expected = R - 0.5 * np.outer(w, w) / (x[0] @ w) + x.T @ x
+        assert_allclose(_sym(est.cov_inv_), expected, rtol=1e-10)
+
+    def test_directional_rules_leave_the_mean_where_the_data_puts_it(self):
+        """Forgetting alone moves no coefficient: with a batch that adds
+        nothing (zero rows) the mean is unchanged."""
+        X, y = _data(p=3)
+        for rule in (FeatureWiseForgetting(0.5), SiftForgetting(0.5)):
+            est = NormalRegressor(alpha=1.0, beta=1.0, forgetting=rule)
+            est.fit(X[:10], y[:10])
+            coef = est.coef_.copy()
+            est.partial_fit(np.zeros((2, 3)), np.zeros(2))
+            assert_allclose(est.coef_, coef, atol=1e-12)
+
+    def test_glm_accepts_a_directional_rule(self):
+        X, y = _data(p=3)
+        y = (y > 0).astype(float)
+        est = BayesianGLM(alpha=1.0, forgetting=FeatureWiseForgetting(0.5))
+        est.fit(X[:10], y[:10])
+        R = _sym(est.cov_inv_)
+        x = np.array([[1.0, 0.0, 0.0]])
+        est.partial_fit(x, np.array([1.0]))
+        d = np.array([np.sqrt(0.5), 1.0, 1.0])
+        forgotten = (d[:, None] * R) * d[None, :]
+        # The Laplace update adds a rank-one Fisher term to the forgotten prior.
+        gain = _sym(est.cov_inv_) - forgotten
+        assert np.all(np.linalg.eigvalsh(gain) >= -1e-10)
+        assert np.linalg.matrix_rank(gain, tol=1e-8) == 1
+
+    def test_sift_is_refused_on_a_sparse_estimator(self):
+        X, y = _data()
+        est = NormalRegressor(
+            alpha=1.0, beta=1.0, sparse=True, forgetting=SiftForgetting(0.9)
+        )
+        with pytest.raises(TypeError, match="FeatureWiseForgetting"):
+            est.fit(sp.csc_array(X), y)
+
+    def test_a_non_rule_is_refused(self):
+        X, y = _data()
+        est = NormalRegressor(alpha=1.0, beta=1.0, forgetting=0.9)  # type: ignore[arg-type]
+        with pytest.raises(TypeError, match="ExponentialForgetting"):
+            est.fit(X, y)
+
+
+class TestUniformOnlyEstimators:
+    @pytest.mark.parametrize(
+        "make",
+        [
+            lambda rule: EmpiricalBayesNormalRegressor(forgetting=rule),
+            lambda rule: EmpiricalBayesGLM(forgetting=rule),
+            lambda rule: DirichletClassifier({0: 1.0, 1: 1.0}, forgetting=rule),
+            lambda rule: GammaRegressor(alpha=1.0, beta=1.0, forgetting=rule),
+        ],
+    )
+    def test_directional_rules_are_refused(self, make):
+        est = make(FeatureWiseForgetting(0.9))
+        if isinstance(est, (DirichletClassifier, GammaRegressor)):
+            X, y = np.array([[1], [1]]), np.array([0, 1])
+        else:
+            X, y = np.eye(3), np.array([1.0, 0.0, 1.0])
+        with pytest.raises(TypeError, match="forgets uniformly"):
+            est.fit(X, y)
+
+    def test_eb_glm_sparse_rvga_forgets_through_the_cached_factor(self):
+        X, y = _data(n=40, p=3, seed=1)
+        y = (y > 0).astype(float)
+        est = EmpiricalBayesGLM(
+            sparse=True,
+            approximator=RVGAApproximator(),
+            forgetting=StabilizedForgetting(0.9),
+        )
+        est.fit(sp.csc_array(X[:30]), y[:30])
+        est.sample(sp.csc_array(X[:2]))  # caches the factor
+        s, alpha_old = est._prior_scalar, est.alpha
+        est.partial_fit(sp.csc_array(X[30:]), y[30:])
+        g = 0.9**10
+        assert est._prior_scalar == pytest.approx(
+            (g * s + (1 - g) * alpha_old) * est.alpha / alpha_old
+        )
+        assert np.all(np.isfinite(est.coef_))
+
+    def test_eb_stabilized_matches_the_old_learning_rate_bookkeeping(self):
+        X, y = _data()
+        est = EmpiricalBayesNormalRegressor(
+            alpha=1.0, beta=1.0, forgetting=StabilizedForgetting(0.99)
+        )
+        est.fit(X[:20], y[:20])
+        s, alpha_old = est._prior_scalar, est.alpha
+        est.partial_fit(X[20:25], y[20:25])
+        g = 0.99**5
+        # The online MacKay step then rescales the prior part to the new alpha.
+        assert est._prior_scalar == pytest.approx(
+            (g * s + (1 - g) * alpha_old) * est.alpha / alpha_old
+        )
+
+    def test_eb_exponential_lets_the_prior_scalar_decay(self):
+        X, y = _data()
+        est = EmpiricalBayesNormalRegressor(
+            alpha=1.0, beta=1.0, forgetting=ExponentialForgetting(0.9)
+        )
+        est.fit(X[:20], y[:20])
+        s, alpha_old = est._prior_scalar, est.alpha
+        est.partial_fit(X[20:25], y[20:25])
+        assert est._prior_scalar == pytest.approx(0.9**5 * s * est.alpha / alpha_old)
+
+    def test_grouped_stabilized_mixes_the_prior_back_per_row(self):
+        clf = DirichletClassifier(
+            {0: 1.0, 1: 3.0}, forgetting=StabilizedForgetting(0.5)
+        )
+        clf.fit(np.array([[1]]), np.array([0]))
+        prior = np.array([1.0, 3.0])
+        # fit: prior scaled by 0.5, one row added, prior mixed back at 0.5.
+        after_fit = 0.5 * prior + np.array([1.0, 0.0]) + 0.5 * prior
+        assert_allclose(clf.known_alphas_[1], after_fit)
+        clf.partial_fit(np.array([[1], [1]]), np.array([1, 1]))
+        # Two rows: 0.25 on the old value, the first row at 0.5, the second
+        # at 1, and 0.75 of the prior back.
+        expected = 0.25 * after_fit + 1.5 * np.array([0.0, 1.0]) + 0.75 * prior
+        assert_allclose(clf.known_alphas_[1], expected)
+
+    def test_eb_gamma_stabilized_returns_to_the_prior(self):
+        model = EmpiricalBayesGammaRegressor(
+            alpha=2.0, beta=3.0, forgetting=StabilizedForgetting(0.5), random_state=0
+        )
+        model.fit(np.array([[1], [1], [1]]), np.array([2, 3, 4]))
+        for _ in range(60):
+            model.partial_fit(np.array([[2]]), np.array([1]))  # another group
+        # Group 1 is only ticked by decay; group 2's rows do not touch it.
+        assert model.coef_[1][0] > model.prior_[0]
+
+
+class TestLegacyPickles:
+    def _relabel(self, est, learning_rate):
+        state = est.__getstate__()
+        state.pop("forgetting")
+        state["learning_rate"] = learning_rate
+        fresh: Any = object.__new__(type(est))
+        fresh.__setstate__(state)
+        return fresh
+
+    def test_plain_rate_becomes_exponential(self):
+        X, y = _data()
+        est = NormalRegressor(alpha=1.0, beta=1.0).fit(X, y)
+        loaded = self._relabel(est, 0.95)
+        assert loaded.forgetting == ExponentialForgetting(0.95)
+        assert not hasattr(loaded, "learning_rate")
+        assert_allclose(loaded.coef_, est.coef_)
+
+    def test_rate_one_becomes_no_rule(self):
+        X, y = _data()
+        est = NormalRegressor(alpha=1.0, beta=1.0).fit(X, y)
+        assert self._relabel(est, 1.0).forgetting is None
+
+    def test_eb_rate_becomes_stabilized(self):
+        X, y = _data()
+        est = EmpiricalBayesNormalRegressor().fit(X, y)
+        assert self._relabel(est, 0.9).forgetting == StabilizedForgetting(0.9)
+
+    def test_grouped_rate_converts_too(self):
+        clf = DirichletClassifier({0: 1.0, 1: 1.0}).fit(np.array([[1]]), np.array([0]))
+        assert self._relabel(clf, 0.8).forgetting == ExponentialForgetting(0.8)
+        model = GammaRegressor(alpha=1.0, beta=1.0).fit(np.array([[1]]), np.array([2]))
+        assert self._relabel(model, 0.8).forgetting == ExponentialForgetting(0.8)
+
+    def test_current_pickles_round_trip(self):
+        X, y = _data()
+        est = NormalRegressor(
+            alpha=1.0, beta=1.0, forgetting=FeatureWiseForgetting(0.9)
+        ).fit(X, y)
+        loaded: Any = pickle.loads(pickle.dumps(est))
+        assert loaded.forgetting == FeatureWiseForgetting(0.9)
+        loaded.partial_fit(X[:3], y[:3])
+        est.partial_fit(X[:3], y[:3])
+        assert_allclose(loaded.coef_, est.coef_)
+
+
+class TestCoverageUnderFeatureWise:
+    def test_intercept_plus_arm_predictions_stay_calibrated(self):
+        """Intercept plus one-hot arms, 90/5/5 pulls, stationary rewards:
+        the cell-mean intervals under feature-wise forgetting must cover
+        the truth about as often as they claim."""
+        rng = np.random.default_rng(3)
+        means = np.array([1.0, 0.5, 0.0])
+        est = NormalRegressor(
+            alpha=1.0, beta=4.0, forgetting=FeatureWiseForgetting(0.98)
+        )
+
+        def row(a):
+            x = np.zeros(4)
+            x[0] = 1.0
+            x[1 + a] = 1.0
+            return x
+
+        hits = 0
+        total = 0
+        for t in range(1500):
+            a = rng.choice(3, p=[0.9, 0.05, 0.05])
+            x = row(a)[None, :]
+            est.partial_fit(x, np.array([means[a] + rng.normal(0, 0.5)]))
+            if t >= 500:
+                S = np.linalg.inv(_sym(est.cov_inv_))
+                for arm in range(3):
+                    r = row(arm)
+                    sd = np.sqrt(r @ S @ r)
+                    hits += abs(r @ est.coef_ - means[arm]) < 1.96 * sd
+                    total += 1
+        assert hits / total > 0.9
+        assert np.linalg.eigvalsh(_sym(est.cov_inv_))[0] >= 1.0 - 1e-9

--- a/tests/test_gaussian_posterior_laplace.py
+++ b/tests/test_gaussian_posterior_laplace.py
@@ -140,12 +140,18 @@ class TestLaplaceApproximation:
 
         # With no decay, prior dominates
         posterior_no_decay = update_gaussian_posterior_laplace(
-            X, y, prior_mean, prior_precision, link="logit", learning_rate=1.0
+            X, y, prior_mean, prior_precision, link="logit"
         )
 
         # With decay, data has more influence
         posterior_decay = update_gaussian_posterior_laplace(
-            X, y, prior_mean, prior_precision, link="logit", learning_rate=0.5
+            X,
+            y,
+            prior_mean,
+            prior_precision,
+            link="logit",
+            prior_decay=0.5**10,
+            sample_weight=compute_effective_weights(10, None, 0.5),
         )
 
         # Decayed version should move further from prior
@@ -396,8 +402,8 @@ def _fit_overshoot(X, y, sample_weight, n_iter, sparse=False):
         np.zeros(p),
         csc_array(P) if sparse else P,
         link="log",
-        sample_weight=sample_weight,
-        learning_rate=0.98,
+        sample_weight=compute_effective_weights(X.shape[0], sample_weight, 0.98),
+        prior_decay=0.98 ** X.shape[0],
         sparse=sparse,
         n_iter=n_iter,
         tol=1e-6,

--- a/tests/test_howto_decay.py
+++ b/tests/test_howto_decay.py
@@ -6,6 +6,7 @@ from bayesianbandits import (
     Arm,
     ContextualAgent,
     EmpiricalBayesNormalRegressor,
+    ExponentialForgetting,
     NormalRegressor,
     ThompsonSampling,
 )
@@ -49,7 +50,7 @@ def test_effective_window_size():
 
 
 def test_no_decay_by_default():
-    """learning_rate=1.0 means no decay on partial_fit."""
+    """No forgetting rule means no forgetting on partial_fit."""
     learner = NormalRegressor(alpha=1.0, beta=1.0)
     X = np.array([[1.0]])
     y = np.array([1.0])
@@ -57,7 +58,7 @@ def test_no_decay_by_default():
 
     precision_after_fit = learner.cov_inv_.copy()
 
-    # partial_fit with learning_rate=1.0 should only add information
+    # partial_fit with forgetting=ExponentialForgetting(1.0 should only add information)
     learner.partial_fit(X, y)
     precision_after_update = learner.cov_inv_
 
@@ -70,8 +71,12 @@ def test_coupled_decay_depends_on_batch_size():
     # Two learners with same learning_rate but different batch sizes
     lr = 0.99
 
-    learner_one = NormalRegressor(alpha=1.0, beta=1.0, learning_rate=lr)
-    learner_ten = NormalRegressor(alpha=1.0, beta=1.0, learning_rate=lr)
+    learner_one = NormalRegressor(
+        alpha=1.0, beta=1.0, forgetting=ExponentialForgetting(lr)
+    )
+    learner_ten = NormalRegressor(
+        alpha=1.0, beta=1.0, forgetting=ExponentialForgetting(lr)
+    )
 
     # Fit both on same initial data
     X_init = np.array([[1.0]])
@@ -98,7 +103,6 @@ def test_eb_stabilized_forgetting():
     learner = EmpiricalBayesNormalRegressor(
         alpha=1.0,
         beta=1.0,
-        learning_rate=1.0,
     )
 
     X = np.array([[1.0, 2.0]])

--- a/tests/test_normal_estimators.py
+++ b/tests/test_normal_estimators.py
@@ -8,6 +8,7 @@ from numpy.typing import NDArray
 from sklearn.datasets import make_regression
 
 from bayesianbandits import (
+    ExponentialForgetting,
     NormalInverseGammaRegressor,
     NormalRegressor,
 )
@@ -288,13 +289,17 @@ def test_normal_regressor_decay(
         X_fit = X
 
     clf = NormalRegressor(
-        alpha=1, beta=1, learning_rate=0.9, sparse=sparse, random_state=0
+        alpha=1,
+        beta=1,
+        forgetting=ExponentialForgetting(0.9),
+        sparse=sparse,
+        random_state=0,
     )
     clf.fit(X_fit, y)
 
     pre_decay = clf.predict(X_fit)
 
-    clf.decay(decay_rate=clf.learning_rate, steps=X.shape[0])
+    clf.decay(decay_rate=0.9, steps=X.shape[0])
 
     assert_almost_equal(clf.predict(X_fit), pre_decay)
 
@@ -311,9 +316,7 @@ def test_normal_regressor_manual_decay(
     else:
         X_fit = X
 
-    clf = NormalRegressor(
-        alpha=1, beta=1, learning_rate=1.0, sparse=sparse, random_state=0
-    )
+    clf = NormalRegressor(alpha=1, beta=1, sparse=sparse, random_state=0)
     clf.fit(X_fit, y)
 
     pre_decay = clf.predict(X_fit)
@@ -339,9 +342,7 @@ def test_normal_regressor_serialization(
     else:
         X_fit = X
 
-    clf = NormalRegressor(
-        alpha=1, beta=1, learning_rate=1.0, sparse=sparse, random_state=0
-    )
+    clf = NormalRegressor(alpha=1, beta=1, sparse=sparse, random_state=0)
     clf.fit(X_fit, y)
 
     pre_dump_cov_inv = clf.cov_inv_
@@ -547,20 +548,16 @@ def test_normal_regressor_partial_fit_with_weights(sparse: bool) -> None:
     X, y = make_regression(n_samples=10, n_features=2, noise=0.1, random_state=42)  # type: ignore
     weights = np.random.rand(10) * 2  # Random weights between 0 and 2
 
-    # Single fit with learning_rate=1 (no decay)
-    reg1 = NormalRegressor(
-        alpha=0.1, beta=1.0, learning_rate=1.0, sparse=sparse, random_state=0
-    )
+    # Single fit with forgetting=ExponentialForgetting(1 (no decay))
+    reg1 = NormalRegressor(alpha=0.1, beta=1.0, sparse=sparse, random_state=0)
     if sparse:
         X_fit = sp.csc_array(X)
     else:
         X_fit = X
     reg1.fit(X_fit, y, sample_weight=weights)
 
-    # Sequential partial_fit with learning_rate=1 (no decay)
-    reg2 = NormalRegressor(
-        alpha=0.1, beta=1.0, learning_rate=1.0, sparse=sparse, random_state=0
-    )
+    # Sequential partial_fit with forgetting=ExponentialForgetting(1 (no decay))
+    reg2 = NormalRegressor(alpha=0.1, beta=1.0, sparse=sparse, random_state=0)
     if sparse:
         X1_fit = sp.csc_array(X[:5])
         X2_fit = sp.csc_array(X[5:])
@@ -623,7 +620,11 @@ def test_normal_regressor_weights_learning_rate_interaction(sparse: bool) -> Non
 
     # With learning rate < 1
     reg = NormalRegressor(
-        alpha=8.0, beta=1.0, learning_rate=0.5, sparse=sparse, random_state=0
+        alpha=8.0,
+        beta=1.0,
+        forgetting=ExponentialForgetting(0.5),
+        sparse=sparse,
+        random_state=0,
     )
     if sparse:
         X_fit = sp.csc_array(X)
@@ -636,9 +637,7 @@ def test_normal_regressor_weights_learning_rate_interaction(sparse: bool) -> Non
     # effective_weights = weights * decay_factors = [2.0*0.25, 1.0*0.5, 0.5*1.0] = [0.5, 0.5, 0.5]
 
     # Fit same data with uniform weights AND SAME learning rate
-    reg_uniform = NormalRegressor(
-        alpha=1.0, beta=1.0, learning_rate=1.0, sparse=sparse, random_state=0
-    )
+    reg_uniform = NormalRegressor(alpha=1.0, beta=1.0, sparse=sparse, random_state=0)
     reg_uniform.fit(X_fit, y, sample_weight=np.array([0.5, 0.5, 0.5]))
 
     # Should be very close (exact up to numerical precision)
@@ -651,7 +650,11 @@ def test_normal_regressor_weights_learning_rate_interaction(sparse: bool) -> Non
     # Also test that weights scale linearly
     # If we double all weights, the precision matrix should scale
     reg_double = NormalRegressor(
-        alpha=1.0, beta=1.0, learning_rate=0.5, sparse=sparse, random_state=0
+        alpha=1.0,
+        beta=1.0,
+        forgetting=ExponentialForgetting(0.5),
+        sparse=sparse,
+        random_state=0,
     )
     reg_double.fit(X_fit, y, sample_weight=weights * 2)
 
@@ -997,7 +1000,9 @@ def test_normal_inverse_gamma_regressor_decay(
 ) -> None:
     """Test NormalRegressor decay only increases variance."""
 
-    clf = NormalInverseGammaRegressor(random_state=0, learning_rate=0.9, sparse=sparse)
+    clf = NormalInverseGammaRegressor(
+        random_state=0, forgetting=ExponentialForgetting(0.9), sparse=sparse
+    )
     if sparse:
         X_fit = sp.csc_array(X)
     else:
@@ -1007,7 +1012,7 @@ def test_normal_inverse_gamma_regressor_decay(
 
     pre_decay = clf.predict(X_fit)
 
-    clf.decay(decay_rate=clf.learning_rate, steps=X.shape[0])
+    clf.decay(decay_rate=0.9, steps=X.shape[0])
 
     assert_almost_equal(clf.predict(X_fit), pre_decay)
 
@@ -1037,7 +1042,7 @@ def test_normal_inverse_gamma_regressor_manual_decay(
 ) -> None:
     """Test NormalRegressor decay only increases variance."""
 
-    clf = NormalInverseGammaRegressor(random_state=0, learning_rate=1.0, sparse=sparse)
+    clf = NormalInverseGammaRegressor(random_state=0, sparse=sparse)
     if sparse:
         X_fit = sp.csc_array(X)
     else:
@@ -1067,7 +1072,7 @@ def test_normal_inverse_gamma_regressor_serialization(
     else:
         X_fit = X
 
-    clf = NormalInverseGammaRegressor(random_state=0, learning_rate=1.0, sparse=sparse)
+    clf = NormalInverseGammaRegressor(random_state=0, sparse=sparse)
     clf.fit(X_fit, y)
 
     pre_dump_cov_inv = clf.cov_inv_
@@ -1339,16 +1344,16 @@ def test_normal_inverse_gamma_regressor_partial_fit_with_weights(sparse: bool) -
     X, y = make_regression(n_samples=10, n_features=2, noise=0.1, random_state=42)  # type: ignore
     weights = np.random.rand(10) * 2  # Random weights between 0 and 2
 
-    # Single fit with learning_rate=1 (no decay)
-    reg1 = NormalInverseGammaRegressor(learning_rate=1.0, sparse=sparse, random_state=0)
+    # Single fit with forgetting=ExponentialForgetting(1 (no decay))
+    reg1 = NormalInverseGammaRegressor(sparse=sparse, random_state=0)
     if sparse:
         X_fit = sp.csc_array(X)
     else:
         X_fit = X
     reg1.fit(X_fit, y, sample_weight=weights)
 
-    # Sequential partial_fit with learning_rate=1 (no decay)
-    reg2 = NormalInverseGammaRegressor(learning_rate=1.0, sparse=sparse, random_state=0)
+    # Sequential partial_fit with forgetting=ExponentialForgetting(1 (no decay))
+    reg2 = NormalInverseGammaRegressor(sparse=sparse, random_state=0)
     if sparse:
         X1_fit = sp.csc_array(X[:5])
         X2_fit = sp.csc_array(X[5:])
@@ -1429,7 +1434,13 @@ def test_normal_inverse_gamma_regressor_weights_learning_rate_interaction(
     # With learning rate < 1
     # Prior parameters need to compensate for decay
     reg = NormalInverseGammaRegressor(
-        mu=0.0, lam=8.0, a=8.0, b=8.0, learning_rate=0.5, sparse=sparse, random_state=0
+        mu=0.0,
+        lam=8.0,
+        a=8.0,
+        b=8.0,
+        forgetting=ExponentialForgetting(0.5),
+        sparse=sparse,
+        random_state=0,
     )
     if sparse:
         X_fit = sp.csc_array(X)
@@ -1439,7 +1450,7 @@ def test_normal_inverse_gamma_regressor_weights_learning_rate_interaction(
 
     # Fit same effective model with no decay
     reg_uniform = NormalInverseGammaRegressor(
-        mu=0.0, lam=1.0, a=1.0, b=1.0, learning_rate=1.0, sparse=sparse, random_state=0
+        mu=0.0, lam=1.0, a=1.0, b=1.0, sparse=sparse, random_state=0
     )
     reg_uniform.fit(X_fit, y, sample_weight=np.array([0.5, 0.5, 0.5]))
 
@@ -1587,7 +1598,7 @@ def test_normal_inverse_gamma_decay_then_sample(sparse: bool) -> None:
     X, y = make_regression(n_samples=50, n_features=3, noise=1.0, random_state=0)
 
     reg = NormalInverseGammaRegressor(
-        sparse=sparse, random_state=42, learning_rate=0.95
+        sparse=sparse, random_state=42, forgetting=ExponentialForgetting(0.95)
     )
     if sparse:
         X_fit = sp.csc_array(X)
@@ -1616,7 +1627,7 @@ def test_normal_inverse_gamma_scale_factor_identity(sparse: bool) -> None:
     """Test scale_factor early return when scale == 1.0."""
     X, y = make_regression(n_samples=50, n_features=3, noise=1.0, random_state=0)
 
-    reg = NormalInverseGammaRegressor(sparse=sparse, random_state=42, learning_rate=1.0)
+    reg = NormalInverseGammaRegressor(sparse=sparse, random_state=42)
     reg.fit(sp.csc_array(X) if sparse else X, y)
 
     original_factor = reg._precision_factor

--- a/tests/test_prior_floor.py
+++ b/tests/test_prior_floor.py
@@ -12,9 +12,19 @@ from scipy.sparse import csc_array
 from scipy.special import expit
 
 from bayesianbandits._gaussian import (
+    compute_effective_weights,
     update_gaussian_posterior_laplace,
     update_gaussian_posterior_rvga,
 )
+
+
+def _forget(rate: float, n: int) -> dict[str, Any]:
+    """What an estimator hands the approximator for a uniform rule over
+    ``n`` rows: the prior decay and the within-batch row weights."""
+    return {
+        "prior_decay": rate**n,
+        "sample_weight": compute_effective_weights(n, None, rate),
+    }
 
 
 def _data(seed: int = 0, n: int = 30, p: int = 4):
@@ -60,8 +70,17 @@ def _call(method: str, sparse: bool, X, y, prior_mean, prior_precision, **kw):
 class TestPriorFloor:
     def test_zero_floor_is_a_no_op(self, method: str, sparse: bool) -> None:
         X, y, m, P = _data()
-        a = _call(method, sparse, X, y, m, P, learning_rate=0.9)
-        b = _call(method, sparse, X, y, m, P, learning_rate=0.9, prior_floor=0.0)
+        a = _call(method, sparse, X, y, m, P, **_forget(0.9, X.shape[0]))
+        b = _call(
+            method,
+            sparse,
+            X,
+            y,
+            m,
+            P,
+            **_forget(0.9, X.shape[0]),
+            prior_floor=0.0,
+        )
         np.testing.assert_allclose(a[0], b[0])
         np.testing.assert_allclose(a[1], b[1])
 
@@ -81,16 +100,21 @@ class TestPriorFloor:
         g = lr**n
         s = (1.0 - g) * floor
 
-        got = _call(method, sparse, X, y, m, P, learning_rate=lr, prior_floor=floor)
+        got = _call(
+            method,
+            sparse,
+            X,
+            y,
+            m,
+            P,
+            **_forget(lr, n),
+            prior_floor=floor,
+        )
 
         # Equivalent prior: precision γⁿP + sI, mean solving (γⁿP + sI) m' = γⁿP m.
         P_eq = g * P + s * np.eye(P.shape[0])
         m_eq = np.linalg.solve(P_eq, g * P @ m)
-        # Run with learning_rate=1 but the same per-row weights: the
-        # effective weights depend on learning_rate, so replicate them
-        # via sample_weight.
-        from bayesianbandits._estimators import compute_effective_weights
-
+        # Run without prior decay but the same per-row weights.
         w = compute_effective_weights(n, None, lr)
         want = _call(method, sparse, X, y, m_eq, P_eq, sample_weight=w)
 
@@ -101,7 +125,16 @@ class TestPriorFloor:
         X, y, m, P = _data()
         P_F = np.asfortranarray(P)
         P_copy = P_F.copy()
-        _call(method, False, X, y, m, P_F, learning_rate=0.9, prior_floor=3.0)
+        _call(
+            method,
+            False,
+            X,
+            y,
+            m,
+            P_F,
+            **_forget(0.9, X.shape[0]),
+            prior_floor=3.0,
+        )
         np.testing.assert_array_equal(P_F, P_copy)
 
 
@@ -123,7 +156,7 @@ def test_rvga_sparse_chunked_floor_composes() -> None:
             csc_array(P),
             link="logit",
             sparse=True,
-            learning_rate=lr,
+            **_forget(lr, n),
             prior_floor=floor,
             n_iter=3,
             batch_size=bs,

--- a/tests/test_reward_space_sampling.py
+++ b/tests/test_reward_space_sampling.py
@@ -6,6 +6,8 @@ is what the identity does not cover: the per-estimator scaling on top
 of the factor (NIG's chi-square mixing, the GLM link) and the guards.
 """
 
+from typing import Any
+
 import numpy as np
 import pytest
 import scipy.sparse as sp
@@ -222,9 +224,10 @@ def _fit_cold(cls=NormalRegressor, p=300, m=20, rows=60, seed=0, **kwargs):
             ]
         )
     )
+    params: dict[str, Any] = dict(kwargs)
     if cls is NormalRegressor:
-        kwargs = dict(alpha=0.7, beta=1.0, **kwargs)
-    est = cls(sparse=True, random_state=seed, **kwargs)
+        params.update(alpha=0.7, beta=1.0)
+    est = cls(sparse=True, random_state=seed, **params)
     est.fit(X_train, rng.standard_normal(rows))
     assert est._precision_factor.n_factored == m
     return est, rng

--- a/tests/test_rvga_approximator.py
+++ b/tests/test_rvga_approximator.py
@@ -9,11 +9,12 @@ import scipy.sparse as sp
 from numpy.testing import assert_allclose
 from scipy.special import expit
 
-from bayesianbandits import BayesianGLM
+from bayesianbandits import BayesianGLM, ExponentialForgetting
 from bayesianbandits._gaussian import (
     GaussianPosterior,
     LaplaceApproximator,
     RVGAApproximator,
+    compute_effective_weights,
     gh_expected_weights,
     log_expected_weights,
     probit_expected_weights,
@@ -792,7 +793,7 @@ class TestRVGAIntegration:
         glm = BayesianGLM(
             link="logit",
             approximator=RVGAApproximator(),
-            learning_rate=0.9,
+            forgetting=ExponentialForgetting(0.9),
             random_state=0,
         )
         glm.fit(X, y)
@@ -950,16 +951,18 @@ class TestSequentialMinibatching:
         sw = np.random.default_rng(1).uniform(0.5, 2.0, 100)
         prior_mean = np.zeros(30)
         prior_prec = sp.csc_array(sp.eye(30, format="csc"))
-        kwargs: dict[str, Any] = dict(
-            link="logit", learning_rate=0.99, sparse=True, n_iter=3, tol=0.0
-        )
+        kwargs: dict[str, Any] = dict(link="logit", sparse=True, n_iter=3, tol=0.0)
+        # What an estimator hands over for ExponentialForgetting(0.99) on
+        # 100 rows: the prior decay once, and the within-batch row weights.
+        w = compute_effective_weights(100, sw, 0.99)
 
         auto = update_gaussian_posterior_rvga(
             X,
             y,
             prior_mean,
             prior_prec,
-            sample_weight=sw,
+            sample_weight=w,
+            prior_decay=0.99**100,
             batch_size=30,
             **kwargs,
         )
@@ -971,7 +974,8 @@ class TestSequentialMinibatching:
                 y[s : s + 30],
                 manual.mean,
                 manual.precision,
-                sample_weight=sw[s : s + 30],
+                sample_weight=w[s : s + 30],
+                prior_decay=0.99**100 if s == 0 else 1.0,
                 prior_factor=manual.factor,
                 **kwargs,
             )


### PR DESCRIPTION
## Summary

Second half of the forgetting API from issue #236: the observation event. `forgetting=` on every estimator takes a rule object that carries its rate, applied in `partial_fit` before the batch is absorbed. `learning_rate` is removed.

- **Uniform rules on the update path give the old numbers.** `ExponentialForgetting(g)` takes one step per row: the prior is scaled by `g ** n` and older rows of the batch weigh less, exactly what `learning_rate=g` did. `StabilizedForgetting(g)` adds the floor at the estimator's α, except on a fresh prior from `fit` or a first `sample`, which has nothing to forget. That is the old EB `had_prior_scalar` semantics, now shared by every estimator.
- **Directional rules** (`FeatureWiseForgetting`, `SiftForgetting`) return their own forgotten precision and the original weighted batch is absorbed from it. The dense fit paths keep only the upper triangle current, so the precision is symmetrized before a directional rule reads it (SIFt otherwise read the stale lower triangle and downdated only the diagonal; there is a test).
- **Who accepts what.** The linear estimators take any rule; `SiftForgetting` on a sparse estimator is a `TypeError` pointing at feature-wise. The grouped conjugate models and the EB estimators take the uniform rules only, since their bookkeeping needs a scalar prior on the diagonal.
- **Migration.** `learning_rate=0.99` becomes `forgetting=ExponentialForgetting(0.99)` on the plain estimators and `forgetting=StabilizedForgetting(0.99)` on the EB ones, which always forgot with the floor. `learning_rate=1.0` is dropped. Models pickled with `learning_rate` load unchanged and are converted on load to the rule the class used to apply. `decay()` with neither a rule nor `decay_rate` now raises. The changelog says all of this.
- **Internals.** `_forget_batch` on the linear base returns `(prior, prior_decay, weights, floor)` and every fit helper consumes that, so the fused BLAS paths are untouched. EB's `_pending_reinjection` and `_pending_floor` are gone, `EmpiricalBayesNormalRegressor._fit_helper` just hands the pending information vector to the base, and the EB grouped models' fit-helper overrides are deleted (the base does the stabilized mix-back). The `PosteriorApproximator` protocol takes `prior_decay` instead of `learning_rate`, with `sample_weight` arriving as the final row weights; the RVGA chunk loop decays and floors the first chunk only.

## Test plan

- [x] `uv run pytest tests -W error::FutureWarning`: 3030 passed
- [x] `tests/test_forgetting_update.py`: one-step-per-row equivalence, floor timing, NIG's inverse-gamma under uniform versus directional rules, feature-wise pattern preservation, the SIFt downdate, GLM with a directional rule, the refusals, EB and grouped bookkeeping, legacy pickle conversion for every class, and a 90/5/5 intercept-plus-arms coverage check under feature-wise
- [x] pyright: 281 messages vs 284 on master
- [x] every touched source file at 100% line coverage; the two remaining misses in `_gaussian.py` are pre-existing dead branches
- [x] `make html` clean; the EB notebook's source is migrated, outputs unchanged since the math is
